### PR TITLE
Added examples why the folder can be locked

### DIFF
--- a/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/General_DMA_configuration.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/General_DMA_configuration.md
@@ -758,7 +758,7 @@ When adding a DataMiner configuration to a DMA, you can select
     The current contents of the *C:\\Skyline DataMiner* folder and all its subfolders will now be copied to the specified configurations folder.
 
     > [!NOTE]
-    > DataMiner Taskbar Utility will stop the running DataMiner software to make sure that none of the files in *C:\\Skyline DataMiner* are locked. In certain rare cases, however, files can be locked by third-party processes (e.g. Anti-virus or even NATS). If this is the case, then you will have to kill those processes manually and retry step 7.
+    > DataMiner Taskbar Utility will stop the running DataMiner software to make sure that none of the files in *C:\\Skyline DataMiner* are locked. In certain rare cases, however, files can be locked by third-party processes (e.g. anti-virus or even NATS). If this is the case, you will have to kill those processes manually and retry step 7.
 
 ### Adding DataMiner configurations to a DMA
 

--- a/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/General_DMA_configuration.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/General_DMA_configuration.md
@@ -758,7 +758,7 @@ When adding a DataMiner configuration to a DMA, you can select
     The current contents of the *C:\\Skyline DataMiner* folder and all its subfolders will now be copied to the specified configurations folder.
 
     > [!NOTE]
-    > DataMiner Taskbar Utility will stop the running DataMiner software to make sure that none of the files in *C:\\Skyline DataMiner* are locked. In certain rare cases, however, files can be locked by third-party processes. If this is the case, then you will have to kill those processes manually and retry step 7.
+    > DataMiner Taskbar Utility will stop the running DataMiner software to make sure that none of the files in *C:\\Skyline DataMiner* are locked. In certain rare cases, however, files can be locked by third-party processes (e.g. Anti-virus or even NATS). If this is the case, then you will have to kill those processes manually and retry step 7.
 
 ### Adding DataMiner configurations to a DMA
 


### PR DESCRIPTION
When initially configuring DM Configs, it might be that the Skyline DataMiner folder is locked, in the past this was typically due to an Anti-virus program and was quite rare. However we've recently seen that NATS locks the folder as well, even if DataMiner is stopped. NATS is used by Dataminer since v10.0, so this is likely to become a more common issue.