### PR TITLE
SLCloud.xml can still contain old IP address

### DIFF
--- a/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/General_DMA_configuration/Changing_the_IP_of_a_DMA.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/General_DMA_configuration/Changing_the_IP_of_a_DMA.md
@@ -12,29 +12,35 @@ For a standalone DMA, i.e. a DMA that is not combined with other DMAs in a clust
 
 1. Stop the DataMiner software on the DMA.
 
-1. Change the IP address of the DMA server in Windows.
+2. Change the IP address of the DMA server in Windows.
 
-1. Go to the folder *C:\\Skyline DataMiner* and open the file *DB.xml*.
+3. Go to the folder *C:\\Skyline DataMiner* and open the file *DB.xml*.
 
-1. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
+4. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
 
-1. If the server hosts a Cassandra database:
+5. If the server hosts a Cassandra database:
 
    1. Open the cassandra.yaml file (typically located in the folder *C:\\Program Files\\Cassandra\\conf\\*).
 
-   1. Replace any references to the old IP address with the new IP address, and save the file.
+   2. Replace any references to the old IP address with the new IP address, and save the file.
 
-   1. Restart the cassandra service.
+   3. Restart the cassandra service.
 
-1. If the server hosts an Elasticsearch database:
+6. If the server hosts an Elasticsearch database:
 
    1. Open the elasticsearch.yml file (typically located in the folder *C:\\Program Files\\Elasticsearch\\config\\*).
 
-   1. Replace any references to the old IP address with the new IP address, and save the file.
+   2. Replace any references to the old IP address with the new IP address, and save the file.
 
-   1. Restart the elasticsearch-service-x64 service.
+   3. Restart the elasticsearch-service-x64 service.
 
-1. Restart DataMiner.
+7. If the server has NATS installed:
+
+   1.  Open the SLCloud.xml, located in the folder *C:\\Skyline DataMiner\\*.
+
+   2.  Replace any references to the old IP address with the new IP address, and save the file.
+
+8. Restart DataMiner.
 
 ## Single DMA in a DMS
 
@@ -42,50 +48,56 @@ For a single DMA within a cluster that does not use the Cassandra cluster featur
 
 1. Stop the DataMiner software on the DMA for which you want to change the IP.
 
-1. Change the IP address of the DMA server in Windows.
+2. Change the IP address of the DMA server in Windows.
 
-1. Go to the folder *C:\\Skyline DataMiner* and open the file *DMS.xml*.
+3. Go to the folder *C:\\Skyline DataMiner* and open the file *DMS.xml*.
 
-1. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
+4. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
 
-1. Go to the folder *C:\\Skyline DataMiner* and open the file *DB.xml*.
+5. Go to the folder *C:\\Skyline DataMiner* and open the file *DB.xml*.
 
-1. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
+6. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
 
-1. If the server hosts a Cassandra database:
+7. If the server hosts a Cassandra database:
 
    1. Open the cassandra.yaml file (typically located in the folder *C:\\Program Files\\Cassandra\\conf\\*).
 
-   1. Replace any references to the old IP address with the new IP address, and save the file.
+   2. Replace any references to the old IP address with the new IP address, and save the file.
 
-   1. Restart the cassandra service.
+   3. Restart the cassandra service.
 
-1. If the server hosts an Elasticsearch database:
+8. If the server hosts an Elasticsearch database:
 
    1. Open the elasticsearch.yml file (typically located in the folder *C:\\Program Files\\Elasticsearch\\config\\*).
 
-   1. Replace any references to the old IP address with the new IP address, and save the file.
+   2. Replace any references to the old IP address with the new IP address, and save the file.
 
-   1. Restart the elasticsearch-service-x64 service.
+   3. Restart the elasticsearch-service-x64 service.
 
-1. Restart DataMiner.
+9. If the server has NATS installed:
 
-1. In System Center, go to the Agents page and remove the old IP address from the list of DMAs in the cluster.
+   1.  Open the SLCloud.xml, located in the folder *C:\\Skyline DataMiner\\*.
 
-1. From DataMiner 10.1.1 onwards, the following additional step is required in order to reset NATS:
+   2.  Replace any references to the old IP address with the new IP address, and save the file.
+
+10. Restart DataMiner.
+
+11. In System Center, go to the Agents page and remove the old IP address from the list of DMAs in the cluster.
+
+12. From DataMiner 10.1.1 onwards, the following additional step is required in order to reset NATS:
 
    1. Open the SLNetClientTest tool. See [Opening the SLNetClientTest tool](xref:Opening_the_SLNetClientTest_tool).
 
       > [!WARNING]
       > Always be extremely careful when using this tool, as it can have far-reaching consequences on the functionality of your DataMiner System.
 
-   1. Connect to the DMA with the changed IP address. See [Connecting to a DMA with the SLNetClientTest tool](xref:Connecting_to_a_DMA_with_the_SLNetClientTest_tool).
+   2. Connect to the DMA with the changed IP address. See [Connecting to a DMA with the SLNetClientTest tool](xref:Connecting_to_a_DMA_with_the_SLNetClientTest_tool).
 
-   1. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
+   3. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
 
-   1. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
+   4. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
 
-   1. Close the SLNetClientTest tool.
+   5. Close the SLNetClientTest tool.
 
 ## Failover DMA in a DMS
 
@@ -93,60 +105,60 @@ For a Failover DMA within a cluster that does not use the Cassandra cluster feat
 
 1. Stop the DataMiner software on **both** Failover DMAs.
 
-1. Change the IP address of the DMA server in Windows.
+2. Change the IP address of the DMA server in Windows.
 
-1. On the DMA of which you have changed the IP, go to the folder *C:\\Skyline DataMiner* and open the file *DB.xml*.
+3. On the DMA of which you have changed the IP, go to the folder *C:\\Skyline DataMiner* and open the file *DB.xml*.
 
-1. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
+4. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
 
-1. On the DMA of which you have changed the IP, go to the folder *C:\\Skyline DataMiner* and open the file *DMS.xml*.
+5. On the DMA of which you have changed the IP, go to the folder *C:\\Skyline DataMiner* and open the file *DMS.xml*.
 
-1. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
+6. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
 
-1. On the other DMA of the Failover pair, go to the folder *C:\\Skyline DataMiner* and open the file *DMS.xml*.
+7. On the other DMA of the Failover pair, go to the folder *C:\\Skyline DataMiner* and open the file *DMS.xml*.
 
-1. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
+8. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
 
-1. If the DMAs hosts a Cassandra database, do the following on both DMAs:
+9. If the DMAs hosts a Cassandra database, do the following on both DMAs:
 
    1. Open the cassandra.yaml file (typically located in the folder *C:\\Program Files\\Cassandra\\conf\\*).
 
-   1. Replace any references to the old IP address with the new IP address, and save the file.
+   2. Replace any references to the old IP address with the new IP address, and save the file.
 
-   1. Restart the cassandra service.
+   3. Restart the cassandra service.
 
-1. If the DMAs hosts an Elasticsearch database, do the following on both DMAs:
+10. If the DMAs hosts an Elasticsearch database, do the following on both DMAs:
 
    1. Open the elasticsearch.yml file (typically located in the folder *C:\\Program Files\\Elasticsearch\\config\\*).
 
-   1. Replace any references to the old IP address with the new IP address, and save the file.
+   2. Replace any references to the old IP address with the new IP address, and save the file.
 
-   1. Restart the elasticsearch-service-x64 service.
+   3. Restart the elasticsearch-service-x64 service.
 
-1. Restart DataMiner on the DMA with the changed IP address.
+11. Restart DataMiner on the DMA with the changed IP address.
 
-1. Restart DataMiner on the other Failover DMA. It should start up in offline mode.
+12. Restart DataMiner on the other Failover DMA. It should start up in offline mode.
 
-1. On the online DMA, go to System Center \> Agents, and remove the old IP address from the list of DMAs in the cluster.
+13. On the online DMA, go to System Center \> Agents, and remove the old IP address from the list of DMAs in the cluster.
 
-1. Still on the *Agents* page in System Center, make sure the online Failover DMA is selected in the list on the left, and click the *Failover* button in the lower right corner to check the Failover status. For more information, see [Viewing the current Failover DMA status](xref:Viewing_the_current_Failover_DMA_status).
+14. Still on the *Agents* page in System Center, make sure the online Failover DMA is selected in the list on the left, and click the *Failover* button in the lower right corner to check the Failover status. For more information, see [Viewing the current Failover DMA status](xref:Viewing_the_current_Failover_DMA_status).
 
-1. In case the Failover status is not green and there are heartbeat errors, stop DataMiner, and double-check the DMS.xml files of both DMAs to make sure all references to the old IP address have been correctly replaced.
+15. In case the Failover status is not green and there are heartbeat errors, stop DataMiner, and double-check the DMS.xml files of both DMAs to make sure all references to the old IP address have been correctly replaced.
 
-1. From DataMiner 10.1.1 onwards, the following additional step is required in order to reset NATS:
+16. From DataMiner 10.1.1 onwards, the following additional step is required in order to reset NATS:
 
    1. Open the SLNetClientTest tool. See [Opening the SLNetClientTest tool](xref:Opening_the_SLNetClientTest_tool).
 
       > [!WARNING]
       > Always be extremely careful when using this tool, as it can have far-reaching consequences on the functionality of your DataMiner System.
 
-   1. Connect to the DMA with the changed IP address. See [Connecting to a DMA with the SLNetClientTest tool](xref:Connecting_to_a_DMA_with_the_SLNetClientTest_tool).
+   2. Connect to the DMA with the changed IP address. See [Connecting to a DMA with the SLNetClientTest tool](xref:Connecting_to_a_DMA_with_the_SLNetClientTest_tool).
 
-   1. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
+   3. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
 
-   1. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
+   4. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
 
-   1. Close the SLNetClientTest tool.
+   5. Close the SLNetClientTest tool.
 
 ## DMA in a DMS using a Cassandra cluster
 
@@ -154,13 +166,13 @@ If your DataMiner System uses the Cassandra cluster feature for its general data
 
 1. Stop the DMA of which you want to change the IP.
 
-1. Stop the Cassandra and Elasticsearch services on the DMA server.
+2. Stop the Cassandra and Elasticsearch services on the DMA server.
 
-1. Change the IP address of the DMA server in Windows.
+3. Change the IP address of the DMA server in Windows.
 
-1. Locate the file *cassandra.yaml* on the DMA. By default, it is located in the folder *C:\\Program Files\\Cassandra\\conf*.
+4. Locate the file *cassandra.yaml* on the DMA. By default, it is located in the folder *C:\\Program Files\\Cassandra\\conf*.
 
-1. Open *cassandra.yaml* in a text editor (as Administrator) and replace the IP address in the following lines with the IP of the server:
+5. Open *cassandra.yaml* in a text editor (as Administrator) and replace the IP address in the following lines with the IP of the server:
 
    ```txt
    listen_address: new IP
@@ -168,52 +180,52 @@ If your DataMiner System uses the Cassandra cluster feature for its general data
     broadcast_rpc_address: new IP
    ```
 
-1. Restart the Cassandra service.
+6. Restart the Cassandra service.
 
-1. In a command window, execute *nodetool status* (from the directory *C:\\Program Files\\Cassandra\\bin*), in order to check the status of the cluster. this should result in a list with your new IP, your old IP and all other Cassandra nodes on the server. For example:
+7. In a command window, execute *nodetool status* (from the directory *C:\\Program Files\\Cassandra\\bin*), in order to check the status of the cluster. this should result in a list with your new IP, your old IP and all other Cassandra nodes on the server. For example:
 
    ![Example of the nodetool status resuls](~/user-guide/images/nodetoolstatus.png)
 
-1. In the same command window, execute *nodetool removenode \[host ID of the old IP\]*, e.g. *nodetool removenode 35506039-0f03-4a1e-8642-94484d440116*.
+8. In the same command window, execute *nodetool removenode \[host ID of the old IP\]*, e.g. *nodetool removenode 35506039-0f03-4a1e-8642-94484d440116*.
 
-1. Locate the *cassandra.yaml* files on the other DMAs in the DMS, as described above, and replace any occurrences of the old IP address in the seeds list in these files with the new IP address.
+9. Locate the *cassandra.yaml* files on the other DMAs in the DMS, as described above, and replace any occurrences of the old IP address in the seeds list in these files with the new IP address.
 
-1. Locate the file *Elasticsearch.yml* on the DMA of which you have changed the IP. By default, it is located in the folder *C:\\Program Files\\Elasticsearch\\conf*.
+10. Locate the file *Elasticsearch.yml* on the DMA of which you have changed the IP. By default, it is located in the folder *C:\\Program Files\\Elasticsearch\\conf*.
 
-1. Open *Elasticsearch.yml* in a text editor (as Administrator) and replace the IP address in the following lines with the IP of the server:
+11. Open *Elasticsearch.yml* in a text editor (as Administrator) and replace the IP address in the following lines with the IP of the server:
 
    ```txt
    discovery.zen.ping.unicast.hosts: ["new IP (, IP Cassandra node 2, IP Cassandra node 3, ...)"]
    network.publish_host: new IP
    ```
 
-1. Restart the Elasticsearch service.
+12. Restart the Elasticsearch service.
 
-1. Locate the *Elasticsearch.yml* files on the other DMAs in the DMS, as described above, and replace any occurrences of the old IP address in the *discovery.zen.ping.unicast.hosts* field of these files with the new IP address.
+13. Locate the *Elasticsearch.yml* files on the other DMAs in the DMS, as described above, and replace any occurrences of the old IP address in the *discovery.zen.ping.unicast.hosts* field of these files with the new IP address.
 
-1. Open the file *DB.xml* from the Skyline DataMiner folder of the DMA with the new IP, and replace the old IP in the DB tags for the Cassandra and Elasticsearch databases with the new IP address.
+14. Open the file *DB.xml* from the Skyline DataMiner folder of the DMA with the new IP, and replace the old IP in the DB tags for the Cassandra and Elasticsearch databases with the new IP address.
 
    > [!TIP]
    > See also: [DB.xml](xref:DB_xml#dbxml)
 
-1. Open the file DB.xml for all other DMAs in the DMS, and replace the old IP address with the new IP address for both Cassandra and Elasticsearch.
+15. Open the file DB.xml for all other DMAs in the DMS, and replace the old IP address with the new IP address for both Cassandra and Elasticsearch.
 
-1. Restart DataMiner.
+16. Restart DataMiner.
 
-1. Reset NATS:
+17. Reset NATS:
 
    1. Open the SLNetClientTest tool. See [Opening the SLNetClientTest tool](xref:Opening_the_SLNetClientTest_tool).
 
       > [!WARNING]
       > Always be extremely careful when using this tool, as it can have far-reaching consequences on the functionality of your DataMiner System.
 
-   1. Connect to the DMA with the changed IP address. See [Connecting to a DMA with the SLNetClientTest tool](xref:Connecting_to_a_DMA_with_the_SLNetClientTest_tool).
+   2. Connect to the DMA with the changed IP address. See [Connecting to a DMA with the SLNetClientTest tool](xref:Connecting_to_a_DMA_with_the_SLNetClientTest_tool).
 
-   1. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
+   3. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
 
-   1. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
+   4. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
 
-   1. Close the SLNetClientTest tool.
+   5. Close the SLNetClientTest tool.
 
 > [!TIP]
 > See also: [Migrating the general database to a DMS Cassandra cluster](xref:Migrating_the_general_database_to_a_DMS_Cassandra_cluster)

--- a/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/General_DMA_configuration/Changing_the_IP_of_a_DMA.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/General_DMA_configuration/Changing_the_IP_of_a_DMA.md
@@ -12,35 +12,35 @@ For a standalone DMA, i.e. a DMA that is not combined with other DMAs in a clust
 
 1. Stop the DataMiner software on the DMA.
 
-2. Change the IP address of the DMA server in Windows.
+1. Change the IP address of the DMA server in Windows.
 
-3. Go to the folder *C:\\Skyline DataMiner* and open the file *DB.xml*.
+1. Go to the folder *C:\\Skyline DataMiner* and open the file *DB.xml*.
 
-4. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
+1. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
 
-5. If the server hosts a Cassandra database:
+1. If the server hosts a Cassandra database:
 
    1. Open the cassandra.yaml file (typically located in the folder *C:\\Program Files\\Cassandra\\conf\\*).
 
-   2. Replace any references to the old IP address with the new IP address, and save the file.
+   1. Replace any references to the old IP address with the new IP address, and save the file.
 
-   3. Restart the cassandra service.
+   1. Restart the cassandra service.
 
-6. If the server hosts an Elasticsearch database:
+1. If the server hosts an Elasticsearch database:
 
    1. Open the elasticsearch.yml file (typically located in the folder *C:\\Program Files\\Elasticsearch\\config\\*).
 
-   2. Replace any references to the old IP address with the new IP address, and save the file.
+   1. Replace any references to the old IP address with the new IP address, and save the file.
 
-   3. Restart the elasticsearch-service-x64 service.
+   1. Restart the elasticsearch-service-x64 service.
 
-7. If the server has NATS installed:
+1. If the server has NATS installed:
 
    1.  Open the SLCloud.xml, located in the folder *C:\\Skyline DataMiner\\*.
 
-   2.  Replace any references to the old IP address with the new IP address, and save the file.
+   1.  Replace any references to the old IP address with the new IP address, and save the file.
 
-8. Restart DataMiner.
+1. Restart DataMiner.
 
 ## Single DMA in a DMS
 
@@ -48,56 +48,56 @@ For a single DMA within a cluster that does not use the Cassandra cluster featur
 
 1. Stop the DataMiner software on the DMA for which you want to change the IP.
 
-2. Change the IP address of the DMA server in Windows.
+1. Change the IP address of the DMA server in Windows.
 
-3. Go to the folder *C:\\Skyline DataMiner* and open the file *DMS.xml*.
+1. Go to the folder *C:\\Skyline DataMiner* and open the file *DMS.xml*.
 
-4. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
+1. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
 
-5. Go to the folder *C:\\Skyline DataMiner* and open the file *DB.xml*.
+1. Go to the folder *C:\\Skyline DataMiner* and open the file *DB.xml*.
 
-6. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
+1. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
 
-7. If the server hosts a Cassandra database:
+1. If the server hosts a Cassandra database:
 
    1. Open the cassandra.yaml file (typically located in the folder *C:\\Program Files\\Cassandra\\conf\\*).
 
-   2. Replace any references to the old IP address with the new IP address, and save the file.
+   1. Replace any references to the old IP address with the new IP address, and save the file.
 
-   3. Restart the cassandra service.
+   1. Restart the cassandra service.
 
-8. If the server hosts an Elasticsearch database:
+1. If the server hosts an Elasticsearch database:
 
    1. Open the elasticsearch.yml file (typically located in the folder *C:\\Program Files\\Elasticsearch\\config\\*).
 
-   2. Replace any references to the old IP address with the new IP address, and save the file.
+   1. Replace any references to the old IP address with the new IP address, and save the file.
 
-   3. Restart the elasticsearch-service-x64 service.
+   1. Restart the elasticsearch-service-x64 service.
 
-9. If the server has NATS installed:
+1. If the server has NATS installed:
 
    1.  Open the SLCloud.xml, located in the folder *C:\\Skyline DataMiner\\*.
 
-   2.  Replace any references to the old IP address with the new IP address, and save the file.
+   1.  Replace any references to the old IP address with the new IP address, and save the file.
 
-10. Restart DataMiner.
+1. Restart DataMiner.
 
-11. In System Center, go to the Agents page and remove the old IP address from the list of DMAs in the cluster.
+1. In System Center, go to the Agents page and remove the old IP address from the list of DMAs in the cluster.
 
-12. From DataMiner 10.1.1 onwards, the following additional step is required in order to reset NATS:
+1. From DataMiner 10.1.1 onwards, the following additional step is required in order to reset NATS:
 
    1. Open the SLNetClientTest tool. See [Opening the SLNetClientTest tool](xref:Opening_the_SLNetClientTest_tool).
 
       > [!WARNING]
       > Always be extremely careful when using this tool, as it can have far-reaching consequences on the functionality of your DataMiner System.
 
-   2. Connect to the DMA with the changed IP address. See [Connecting to a DMA with the SLNetClientTest tool](xref:Connecting_to_a_DMA_with_the_SLNetClientTest_tool).
+   1. Connect to the DMA with the changed IP address. See [Connecting to a DMA with the SLNetClientTest tool](xref:Connecting_to_a_DMA_with_the_SLNetClientTest_tool).
 
-   3. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
+   1. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
 
-   4. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
+   1. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
 
-   5. Close the SLNetClientTest tool.
+   1. Close the SLNetClientTest tool.
 
 ## Failover DMA in a DMS
 
@@ -105,60 +105,60 @@ For a Failover DMA within a cluster that does not use the Cassandra cluster feat
 
 1. Stop the DataMiner software on **both** Failover DMAs.
 
-2. Change the IP address of the DMA server in Windows.
+1. Change the IP address of the DMA server in Windows.
 
-3. On the DMA of which you have changed the IP, go to the folder *C:\\Skyline DataMiner* and open the file *DB.xml*.
+1. On the DMA of which you have changed the IP, go to the folder *C:\\Skyline DataMiner* and open the file *DB.xml*.
 
-4. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
+1. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
 
-5. On the DMA of which you have changed the IP, go to the folder *C:\\Skyline DataMiner* and open the file *DMS.xml*.
+1. On the DMA of which you have changed the IP, go to the folder *C:\\Skyline DataMiner* and open the file *DMS.xml*.
 
-6. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
+1. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
 
-7. On the other DMA of the Failover pair, go to the folder *C:\\Skyline DataMiner* and open the file *DMS.xml*.
+1. On the other DMA of the Failover pair, go to the folder *C:\\Skyline DataMiner* and open the file *DMS.xml*.
 
-8. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
+1. Locate the old IP address in this file, replace it with the newly configured one wherever necessary, and save the file.
 
-9. If the DMAs hosts a Cassandra database, do the following on both DMAs:
+1. If the DMAs hosts a Cassandra database, do the following on both DMAs:
 
    1. Open the cassandra.yaml file (typically located in the folder *C:\\Program Files\\Cassandra\\conf\\*).
 
-   2. Replace any references to the old IP address with the new IP address, and save the file.
+   1. Replace any references to the old IP address with the new IP address, and save the file.
 
-   3. Restart the cassandra service.
+   1. Restart the cassandra service.
 
-10. If the DMAs hosts an Elasticsearch database, do the following on both DMAs:
+1. If the DMAs hosts an Elasticsearch database, do the following on both DMAs:
 
    1. Open the elasticsearch.yml file (typically located in the folder *C:\\Program Files\\Elasticsearch\\config\\*).
 
-   2. Replace any references to the old IP address with the new IP address, and save the file.
+   1. Replace any references to the old IP address with the new IP address, and save the file.
 
-   3. Restart the elasticsearch-service-x64 service.
+   1. Restart the elasticsearch-service-x64 service.
 
-11. Restart DataMiner on the DMA with the changed IP address.
+1. Restart DataMiner on the DMA with the changed IP address.
 
-12. Restart DataMiner on the other Failover DMA. It should start up in offline mode.
+1. Restart DataMiner on the other Failover DMA. It should start up in offline mode.
 
-13. On the online DMA, go to System Center \> Agents, and remove the old IP address from the list of DMAs in the cluster.
+1. On the online DMA, go to System Center \> Agents, and remove the old IP address from the list of DMAs in the cluster.
 
-14. Still on the *Agents* page in System Center, make sure the online Failover DMA is selected in the list on the left, and click the *Failover* button in the lower right corner to check the Failover status. For more information, see [Viewing the current Failover DMA status](xref:Viewing_the_current_Failover_DMA_status).
+1. Still on the *Agents* page in System Center, make sure the online Failover DMA is selected in the list on the left, and click the *Failover* button in the lower right corner to check the Failover status. For more information, see [Viewing the current Failover DMA status](xref:Viewing_the_current_Failover_DMA_status).
 
-15. In case the Failover status is not green and there are heartbeat errors, stop DataMiner, and double-check the DMS.xml files of both DMAs to make sure all references to the old IP address have been correctly replaced.
+1. In case the Failover status is not green and there are heartbeat errors, stop DataMiner, and double-check the DMS.xml files of both DMAs to make sure all references to the old IP address have been correctly replaced.
 
-16. From DataMiner 10.1.1 onwards, the following additional step is required in order to reset NATS:
+1. From DataMiner 10.1.1 onwards, the following additional step is required in order to reset NATS:
 
    1. Open the SLNetClientTest tool. See [Opening the SLNetClientTest tool](xref:Opening_the_SLNetClientTest_tool).
 
       > [!WARNING]
       > Always be extremely careful when using this tool, as it can have far-reaching consequences on the functionality of your DataMiner System.
 
-   2. Connect to the DMA with the changed IP address. See [Connecting to a DMA with the SLNetClientTest tool](xref:Connecting_to_a_DMA_with_the_SLNetClientTest_tool).
+   1. Connect to the DMA with the changed IP address. See [Connecting to a DMA with the SLNetClientTest tool](xref:Connecting_to_a_DMA_with_the_SLNetClientTest_tool).
 
-   3. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
+   1. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
 
-   4. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
+   1. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
 
-   5. Close the SLNetClientTest tool.
+   1. Close the SLNetClientTest tool.
 
 ## DMA in a DMS using a Cassandra cluster
 
@@ -166,13 +166,13 @@ If your DataMiner System uses the Cassandra cluster feature for its general data
 
 1. Stop the DMA of which you want to change the IP.
 
-2. Stop the Cassandra and Elasticsearch services on the DMA server.
+1. Stop the Cassandra and Elasticsearch services on the DMA server.
 
-3. Change the IP address of the DMA server in Windows.
+1. Change the IP address of the DMA server in Windows.
 
-4. Locate the file *cassandra.yaml* on the DMA. By default, it is located in the folder *C:\\Program Files\\Cassandra\\conf*.
+1. Locate the file *cassandra.yaml* on the DMA. By default, it is located in the folder *C:\\Program Files\\Cassandra\\conf*.
 
-5. Open *cassandra.yaml* in a text editor (as Administrator) and replace the IP address in the following lines with the IP of the server:
+1. Open *cassandra.yaml* in a text editor (as Administrator) and replace the IP address in the following lines with the IP of the server:
 
    ```txt
    listen_address: new IP
@@ -180,52 +180,52 @@ If your DataMiner System uses the Cassandra cluster feature for its general data
     broadcast_rpc_address: new IP
    ```
 
-6. Restart the Cassandra service.
+1. Restart the Cassandra service.
 
-7. In a command window, execute *nodetool status* (from the directory *C:\\Program Files\\Cassandra\\bin*), in order to check the status of the cluster. this should result in a list with your new IP, your old IP and all other Cassandra nodes on the server. For example:
+1. In a command window, execute *nodetool status* (from the directory *C:\\Program Files\\Cassandra\\bin*), in order to check the status of the cluster. this should result in a list with your new IP, your old IP and all other Cassandra nodes on the server. For example:
 
    ![Example of the nodetool status resuls](~/user-guide/images/nodetoolstatus.png)
 
-8. In the same command window, execute *nodetool removenode \[host ID of the old IP\]*, e.g. *nodetool removenode 35506039-0f03-4a1e-8642-94484d440116*.
+1. In the same command window, execute *nodetool removenode \[host ID of the old IP\]*, e.g. *nodetool removenode 35506039-0f03-4a1e-8642-94484d440116*.
 
-9. Locate the *cassandra.yaml* files on the other DMAs in the DMS, as described above, and replace any occurrences of the old IP address in the seeds list in these files with the new IP address.
+1. Locate the *cassandra.yaml* files on the other DMAs in the DMS, as described above, and replace any occurrences of the old IP address in the seeds list in these files with the new IP address.
 
-10. Locate the file *Elasticsearch.yml* on the DMA of which you have changed the IP. By default, it is located in the folder *C:\\Program Files\\Elasticsearch\\conf*.
+1. Locate the file *Elasticsearch.yml* on the DMA of which you have changed the IP. By default, it is located in the folder *C:\\Program Files\\Elasticsearch\\conf*.
 
-11. Open *Elasticsearch.yml* in a text editor (as Administrator) and replace the IP address in the following lines with the IP of the server:
+1. Open *Elasticsearch.yml* in a text editor (as Administrator) and replace the IP address in the following lines with the IP of the server:
 
    ```txt
    discovery.zen.ping.unicast.hosts: ["new IP (, IP Cassandra node 2, IP Cassandra node 3, ...)"]
    network.publish_host: new IP
    ```
 
-12. Restart the Elasticsearch service.
+1. Restart the Elasticsearch service.
 
-13. Locate the *Elasticsearch.yml* files on the other DMAs in the DMS, as described above, and replace any occurrences of the old IP address in the *discovery.zen.ping.unicast.hosts* field of these files with the new IP address.
+1. Locate the *Elasticsearch.yml* files on the other DMAs in the DMS, as described above, and replace any occurrences of the old IP address in the *discovery.zen.ping.unicast.hosts* field of these files with the new IP address.
 
-14. Open the file *DB.xml* from the Skyline DataMiner folder of the DMA with the new IP, and replace the old IP in the DB tags for the Cassandra and Elasticsearch databases with the new IP address.
+1. Open the file *DB.xml* from the Skyline DataMiner folder of the DMA with the new IP, and replace the old IP in the DB tags for the Cassandra and Elasticsearch databases with the new IP address.
 
    > [!TIP]
    > See also: [DB.xml](xref:DB_xml#dbxml)
 
-15. Open the file DB.xml for all other DMAs in the DMS, and replace the old IP address with the new IP address for both Cassandra and Elasticsearch.
+1. Open the file DB.xml for all other DMAs in the DMS, and replace the old IP address with the new IP address for both Cassandra and Elasticsearch.
 
-16. Restart DataMiner.
+1. Restart DataMiner.
 
-17. Reset NATS:
+1. Reset NATS:
 
    1. Open the SLNetClientTest tool. See [Opening the SLNetClientTest tool](xref:Opening_the_SLNetClientTest_tool).
 
       > [!WARNING]
       > Always be extremely careful when using this tool, as it can have far-reaching consequences on the functionality of your DataMiner System.
 
-   2. Connect to the DMA with the changed IP address. See [Connecting to a DMA with the SLNetClientTest tool](xref:Connecting_to_a_DMA_with_the_SLNetClientTest_tool).
+   1. Connect to the DMA with the changed IP address. See [Connecting to a DMA with the SLNetClientTest tool](xref:Connecting_to_a_DMA_with_the_SLNetClientTest_tool).
 
-   3. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
+   1. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
 
-   4. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
+   1. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
 
-   5. Close the SLNetClientTest tool.
+   1. Close the SLNetClientTest tool.
 
 > [!TIP]
 > See also: [Migrating the general database to a DMS Cassandra cluster](xref:Migrating_the_general_database_to_a_DMS_Cassandra_cluster)

--- a/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/General_DMA_configuration/Changing_the_IP_of_a_DMA.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/General_DMA_configuration/Changing_the_IP_of_a_DMA.md
@@ -36,9 +36,9 @@ For a standalone DMA, i.e. a DMA that is not combined with other DMAs in a clust
 
 1. If the server has NATS installed:
 
-   1.  Open the SLCloud.xml, located in the folder *C:\\Skyline DataMiner\\*.
+   1. Open the file *SLCloud.xml*, located in the folder *C:\\Skyline DataMiner\\*.
 
-   1.  Replace any references to the old IP address with the new IP address, and save the file.
+   1. Replace any references to the old IP address with the new IP address, and save the file.
 
 1. Restart DataMiner.
 
@@ -76,9 +76,9 @@ For a single DMA within a cluster that does not use the Cassandra cluster featur
 
 1. If the server has NATS installed:
 
-   1.  Open the SLCloud.xml, located in the folder *C:\\Skyline DataMiner\\*.
+   1. Open the file *SLCloud.xml*, located in the folder *C:\\Skyline DataMiner\\*.
 
-   1.  Replace any references to the old IP address with the new IP address, and save the file.
+   1. Replace any references to the old IP address with the new IP address, and save the file.
 
 1. Restart DataMiner.
 


### PR DESCRIPTION
When the IP changes, SLCloud.xml can still contain the IP address, potentially causing SYN-floods on the network.
Added this file to the list of files you need to manually update when the IP address changes.