### PR TITLE
css update for scrollbar in "in this article" section

### DIFF
--- a/templates/slc_template/styles/docfx.css
+++ b/templates/slc_template/styles/docfx.css
@@ -658,7 +658,9 @@ body .toc{
 }
 .affix {
   position: relative;
-  height: 100%;
+  height: 95%;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 .sideaffix > div.contribution {
   margin-bottom: 20px;


### PR DESCRIPTION
a scrollbar now appears when the content of the "in this article" section is larger than window height