### PR TITLE
Replace SLNetRaw by SendSLNetMessage

### DIFF
--- a/src/DataMiner/SLNetTypes/AlarmTemplateHelper/AlarmTemplateHelper.cs
+++ b/src/DataMiner/SLNetTypes/AlarmTemplateHelper/AlarmTemplateHelper.cs
@@ -22,7 +22,7 @@ namespace Skyline.DataMiner.Net.AlarmTemplateHelper
 	/// </remarks>
 	/// <example>
 	/// <code>
-	/// AlarmTemplateHelper helper = new AlarmTemplateHelper(Engine.SLNetRaw.HandleMessages);
+	/// AlarmTemplateHelper helper = new AlarmTemplateHelper(engine.SendSLNetMessages);
 	/// 
 	/// var id = new AlarmTemplateID("AlarmTemplate", "Protocol", "1.0.0.0");
 	/// var rowId = new AlarmTemplateRowID(1, "condition", "filter");

--- a/src/DataMiner/SLNetTypes/Apps/Jobs/Jobs/JobExposers.cs
+++ b/src/DataMiner/SLNetTypes/Apps/Jobs/Jobs/JobExposers.cs
@@ -13,7 +13,7 @@ namespace Skyline.DataMiner.Net.Jobs
 	/// </summary>
 	/// <example>
 	/// <code>
-	/// var jmHelper = new JobManagerHelper(msg => Engine.SLNetRaw.HandleMessages(msg));
+	/// var jmHelper = new JobManagerHelper(engine.SendSLNetMessages);
 	/// 
 	/// var templates = jmHelper.JobTemplates.Read(JobTemplateExposers.Name.Equal("MyJobTemplate"));
 	/// </code>


### PR DESCRIPTION
Engine.SLNetRaw can be dangerous as it circumvents a lot of security checks. Update the help to use SendSLNetMessages instead.