### PR TITLE
Accurate DateTime filtering

### DIFF
--- a/user-guide/Basic_Functionality/Visio/miscellaneous/Creating_a_list_view.md
+++ b/user-guide/Basic_Functionality/Visio/miscellaneous/Creating_a_list_view.md
@@ -96,6 +96,10 @@ ReservationInstance.Status[Int32] == 3
 ReservationInstance.Properties.Class[String] == 'Silver'
 ```
 
+```txt
+ReservationInstance.Name[string] notContains 'Decoder' AND (ReservationInstance.Start[DateTime] >02/16/2021 21:23:05)
+```
+
 To filter on a property with one or more spaces in the property name, use double quotation marks around the property name. For example:
 
 ```txt

--- a/user-guide/Basic_Functionality/Visio/miscellaneous/Creating_a_list_view.md
+++ b/user-guide/Basic_Functionality/Visio/miscellaneous/Creating_a_list_view.md
@@ -89,7 +89,7 @@ ReservationInstance.Status[Int32] == 3
 ```
 
 ```txt
-ReservationInstance.End[DateTime] >01/22/2019 11:17:32
+(ReservationInstance.End[DateTime] >01/22/2019 11:17:32)
 ```
 
 ```txt


### PR DESCRIPTION
Filtering with DateTime can be tricky. In order to work it all the time, the condition must be wrapped with parentheses.
This change should reflect on each documentation part where DateTime server side filtering is used.