### PR TITLE
Typo in hyperlinks documentation

### DIFF
--- a/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/Hyperlinks_xml.md
+++ b/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/Hyperlinks_xml.md
@@ -449,7 +449,7 @@ The view levels do not need to be specified in any particular order. For example
 
 Special placeholders allow you to use (parts) of the value of the alarm or information event in the command name that is displayed in the shortcut menu.
 
-The example below shows four legacy hyperlink definitions. In the first definition, the name of the Automation script, indicated by the placeholder “\[1\]” in the*valueParsing* attribute, will appear at the end of the command name displayed in the shortcut menu. As such, if you right-click an alarm or an information event of which the value starts with e.g. “Set by Automation script MyScript to”, the shortcut menu will contain a custom command named “ExecuteScript.exe –n MyScript”.
+The example below shows four legacy hyperlink definitions. In the first definition, the name of the Automation script, indicated by the placeholder “\[1\]” in the *valueParsing* attribute, will appear at the end of the command name displayed in the shortcut menu. As such, if you right-click an alarm or an information event of which the value starts with e.g. “Set by Automation script MyScript to”, the shortcut menu will contain a custom command named “ExecuteScript.exe –n MyScript”.
 
 Example:
 


### PR DESCRIPTION
While reading through the documentation about hyperlinks, I noticed a missing whitespace.