### PR TITLE
Add view to information taken into account by Automatic Incident Tracking

### DIFF
--- a/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features_in_the_Alarm_Console.md
+++ b/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features_in_the_Alarm_Console.md
@@ -80,6 +80,8 @@ Several factors are taken into account for the grouping:
 
 - Parameter information
 
+- View information
+
 - Time
 
 - Alarm focus information


### PR DESCRIPTION
In the section of Automatic Incident Tracking, it seems to have been overlooked that also view information is taken into account when grouping alarms.