### PR TITLE
Removed wrong options for group

### DIFF
--- a/develop/schemadoc/Protocol/Protocol.Actions.Action.On.md
+++ b/develop/schemadoc/Protocol/Protocol.Actions.Action.On.md
@@ -31,7 +31,7 @@ The following table gives an overview of the actions that can be used with the d
 |On|Action|
 |--- |--- |
 |command|crc, length, make, read, replace, replace data, stuffing|
-|group|add to execute, execute, execute next, execute one, execute one top, execute one now, force execute, set, set next, stop current group|
+|group|add to execute, execute, execute next, execute one, execute one top, execute one now, force execute, set|
 |pair| set next, timeout|
 |parameter| aggregate, append, append data, change length, clear, clear on display, copy, copy reverse, go, increment, multiply, normalize, pow, read, replace data, reverse, run actions, save, set, set and get with wait, set info, set with wait|
 |protocol|close, lock/unlock, merge, open, priority lock/priority unlock, read file, sleep, stop current group, swap column, wmi|


### PR DESCRIPTION
According to [Actions Overview](https://docs.dataminer.services/develop/devguide/Connector/LogicActionsOverview.html) and the specific pages [set next](https://docs.dataminer.services/develop/devguide/Connector/Actions/ActionSetNext.html) & [stop current group](https://docs.dataminer.services/develop/devguide/Connector/Actions/ActionStopCurrentGroup.html) these are not to be used with the Action/On == 'group'.