### PR TITLE
Update User_rights.md

### DIFF
--- a/user-guide/Advanced_Functionality/Security/About_DMS_Security/User_rights.md
+++ b/user-guide/Advanced_Functionality/Security/About_DMS_Security/User_rights.md
@@ -14,7 +14,7 @@ Rights can be granted according to three concepts:
 
 - **Access levels**: Access levels can be assigned both to users and to individual parameters.
 
-    Users will only be able to set parameters of which the access level is equal or lower than the access level they have been granted. Example: A user with access level 3 can update parameters with access level 3, 4, 5, etc.
+    Users will only be able to set parameters of which the access level is equal or higher than the access level they have been granted. Example: A user with access level 3 can update parameters with access level 3, 4, 5, etc.
 
     Access levels range from 1 (the highest level) to 100 (the lowest level).
 


### PR DESCRIPTION
Changed lower to higher as the explanation was incorrect while the example is correct.
Based on experience +
In the training slides the explanation is: "If the user access level exceeds the access level assigned to a parameter, the user will not be able to use that parameter", which translates to the parameter access level having to be higher than (or equal to) the user access level.