### PR TITLE
Update Protocol.Params.Param-level.md

### DIFF
--- a/develop/schemadoc/Protocol/Protocol.Params.Param-level.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param-level.md
@@ -20,7 +20,7 @@ Default range: 0 (highest level, all rights) to 100 (lowest level).
 
 If you do not specify the *level* attribute, the parameter will have level 0xFFFFFFFF, which is the default security level.
 
-All users with a security level equal to or higher than the one specified in this attribute will be able to see the parameter. For example, a user with security level 3 can see level 3, 4, 5, etc.
+All users with a security level equal to or lower than the one specified in this attribute will be able to see the parameter. For example, a user with security level 3 can see level 3, 4, 5, etc.
 
 ## Examples
 


### PR DESCRIPTION
Changed higher to lower as the explanation was incorrect while the example is correct.
Based on experience +
In the training slides the explanation is: "If the user access level exceeds the access level assigned to a parameter, the user will not be able to use that parameter", which translates to the user access level having to be lower than (or equal to) the parameter level.