### PR TITLE
Delete unexisting configuration

### DIFF
--- a/user-guide/Basic_Functionality/Visio/SRM/Embedding_a_Resource_Manager_component.md
+++ b/user-guide/Basic_Functionality/Visio/SRM/Embedding_a_Resource_Manager_component.md
@@ -425,18 +425,18 @@ If a **ComponentActions** shape data field has been added to the *Reservations* 
 
   - *\[StopTime\]*: The timestamp of the end of the selected range.
 
-- **Level**: Can be "global", "band", or "reservation". Determines where the action is available:
+- **Level**: Can be "global" or "reservation". Determines where the action is available:
 
   - *global*: On an empty part of the timeline.
 
   - *reservation*: On a booking block.
 
-Example of a JSON string with three custom actions:
+Example of a JSON string with custom actions:
 
 ```txt
 [
     { "Name": "Action1", "Level": "global, "Type": "script","Execute":"script:CreateReservation||START=[StartTime];STOP=[StopTime]|||" },
-    { "Name": "Action3", "Level": "block", "Type": "set","Execute": "set|34/5|1004:7|Off|" }
+    { "Name": "Action2", "Level": "block", "Type": "set","Execute": "set|34/5|1004:7|Off|" }
 ]
 ```
 

--- a/user-guide/Basic_Functionality/Visio/SRM/Embedding_a_Resource_Manager_component.md
+++ b/user-guide/Basic_Functionality/Visio/SRM/Embedding_a_Resource_Manager_component.md
@@ -429,8 +429,6 @@ If a **ComponentActions** shape data field has been added to the *Reservations* 
 
   - *global*: On an empty part of the timeline.
 
-  - *band*: On the name in the Y-axis of a horizontal band.
-
   - *reservation*: On a booking block.
 
 Example of a JSON string with three custom actions:
@@ -438,7 +436,6 @@ Example of a JSON string with three custom actions:
 ```txt
 [
     { "Name": "Action1", "Level": "global, "Type": "script","Execute":"script:CreateReservation||START=[StartTime];STOP=[StopTime]|||" },
-    { "Name": "Action2", "Level": "band", "Type": "script","Execute": "script:RemoveAll||BAND=[BandName]|||" },
     { "Name": "Action3", "Level": "block", "Type": "set","Execute": "set|34/5|1004:7|Off|" }
 ]
 ```


### PR DESCRIPTION
Removed configuration that does not exist.
It was internal use for DRS 9.5 and SRM 9.5.3 release, but it never made to actual release in DataMiner.