### PR TITLE
Add links to trending attribute page

### DIFF
--- a/develop/codingguidelines/Monitoring/Trending1.md
+++ b/develop/codingguidelines/Monitoring/Trending1.md
@@ -8,4 +8,4 @@ uid: Trending1
 
 - Make sure no redundant trending can be set on parameters.
 
-- For parameters of type string, when trending is supported, the trend type should be set to "last". (cf. [PROTOCOL.PARAMS.PARAM.DISPLAY.TRENDING.TYPE](xref:Protocol.Params.Param.Display.Trending.Type) section in the DataMiner Protocol Development Guide.)
+- For parameters of type string, when trending is supported, the trend type should be set to "last" (see [PROTOCOL.PARAMS.PARAM.DISPLAY.TRENDING.TYPE](xref:Protocol.Params.Param.Display.Trending.Type)).

--- a/develop/codingguidelines/Monitoring/Trending1.md
+++ b/develop/codingguidelines/Monitoring/Trending1.md
@@ -8,4 +8,4 @@ uid: Trending1
 
 - Make sure no redundant trending can be set on parameters.
 
-- For parameters of type string, when trending is supported, the trend type should be set to "last". (cf. PROTOCOL.PARAMS.PARAM.DISPLAY.TRENDING.TYPE section in the DataMiner Protocol Development Guide.)
+- For parameters of type string, when trending is supported, the trend type should be set to "last". (cf. [PROTOCOL.PARAMS.PARAM.DISPLAY.TRENDING.TYPE](xref:Protocol.Params.Param.Display.Trending.Type) section in the DataMiner Protocol Development Guide.)

--- a/develop/schemadoc/Protocol/Protocol.Params.Param-trending.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param-trending.md
@@ -29,6 +29,7 @@ Default: true.
 <Param id="1" trending="true">
 ```
 
-## See Also
+## See also
+
 - [Trending](xref:MonitoringTrending)
 - [Protocol Trending Guidelines](xref:Trending1)

--- a/develop/schemadoc/Protocol/Protocol.Params.Param-trending.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param-trending.md
@@ -28,3 +28,7 @@ Default: true.
 ```xml
 <Param id="1" trending="true">
 ```
+
+## See Also
+- [Trending](xref:MonitoringTrending)
+- [Protocol Trending Guidelines](xref:Trending1)


### PR DESCRIPTION
Link to general trending page in dataminer development guide.
Link to protocol guidelines regarding trending.
Link guidelines to referenced trend type element.