### PR TITLE
Update Creating_a_list_view.md

### DIFF
--- a/user-guide/Basic_Functionality/Visio/miscellaneous/Creating_a_list_view.md
+++ b/user-guide/Basic_Functionality/Visio/miscellaneous/Creating_a_list_view.md
@@ -108,6 +108,19 @@ To filter on a property with one or more spaces in the property name, use double
 ReservationInstance.Properties."Expected Service State"[String] contains 'STaRt'
 ```
 
+#### Booking Status values
+You can use the following table to understand which values can be used for ReservationInstance.Status[Int32]:
+|Booking Status|Property value|
+|:------------:|:------------:|
+|Undefined     |0             |
+|Pending       |1             |
+|Confirmed     |2             |
+|Ongoing       |3             |
+|Ended         |4             |
+|Disconnected  |5             |
+|Interrupted   |6             |
+|Cancelled     |7             |
+
 ### Source: Elements or Services
 
 If you set the *Source* shape data field to “Elements” or “Services”, the *Filter* shape data field can contain a view filter to make the list view only show items from one specific view.

--- a/user-guide/Basic_Functionality/Visio/miscellaneous/Creating_a_list_view.md
+++ b/user-guide/Basic_Functionality/Visio/miscellaneous/Creating_a_list_view.md
@@ -90,6 +90,21 @@ ReservationInstance.Name[string] contains 'Enc'
 ReservationInstance.Status[Int32] == 3
 ```
 
+> [!NOTE]
+> The following values can be used for ReservationInstance.Status[Int32]:
+>
+> |Booking Status|Property value|
+> |--------------|--------------|
+> |Undefined     |0             |
+> |Pending       |1             |
+> |Confirmed     |2             |
+> |Ongoing       |3             |
+> |Ended         |4             |
+> |Disconnected  |5             |
+> |Interrupted   |6             |
+> |Cancelled     |7             |
+
+
 ```txt
 (ReservationInstance.End[DateTime] >01/22/2019 11:17:32)
 ```
@@ -107,19 +122,6 @@ To filter on a property with one or more spaces in the property name, use double
 ```txt
 ReservationInstance.Properties."Expected Service State"[String] contains 'STaRt'
 ```
-
-#### Booking Status values
-You can use the following table to understand which values can be used for ReservationInstance.Status[Int32]:
-|Booking Status|Property value|
-|:------------:|:------------:|
-|Undefined     |0             |
-|Pending       |1             |
-|Confirmed     |2             |
-|Ongoing       |3             |
-|Ended         |4             |
-|Disconnected  |5             |
-|Interrupted   |6             |
-|Cancelled     |7             |
 
 ### Source: Elements or Services
 


### PR DESCRIPTION
Adding a detail of the applicable values for ReservationInstance.Status.
If a user is building a new Visio, they need to know which values correspond to which Status.

I based on the following mapping: https://docs.dataminer.services/user-guide/Basic_Functionality/Visio/miscellaneous/Creating_a_list_view.html#list-view-filters:~:text=StateOfSelection%3A%20Available%20from,Canceled%20(7)
Better to double-check with Orchestration domain.