### PR TITLE
Small correction from 'always' to 'most likely'

### DIFF
--- a/user-guide/Cloud_Platform/RemoteAccess/Cloud_Remote_Access.md
+++ b/user-guide/Cloud_Platform/RemoteAccess/Cloud_Remote_Access.md
@@ -17,7 +17,7 @@ When a DMS is cloud-connected, you can use the remote access URL (e.g. ``https:/
 ![Remote access URL in the DCP Admin app](~/user-guide/images/CloudRemoteAccessUrl.png)
 
 > [!TIP]
-> The URL will most likely have the format `https://[dms_name]-[company_name].on.dataminer.services`, depending on what has been configured while going cloud-connected.
+> The URL usually has the format `https://[dms_name]-[company_name].on.dataminer.services`, although this depends on what was configured when the DMS was connected to the cloud.
 
 ## Accessing a DMS remotely
 

--- a/user-guide/Cloud_Platform/RemoteAccess/Cloud_Remote_Access.md
+++ b/user-guide/Cloud_Platform/RemoteAccess/Cloud_Remote_Access.md
@@ -17,7 +17,7 @@ When a DMS is cloud-connected, you can use the remote access URL (e.g. ``https:/
 ![Remote access URL in the DCP Admin app](~/user-guide/images/CloudRemoteAccessUrl.png)
 
 > [!TIP]
-> The URL will always have the format `https://[dms_name]-[company_name].on.dataminer.services`.
+> The URL will most likely have the format `https://[dms_name]-[company_name].on.dataminer.services`, depending on what has been configured while going cloud-connected.
 
 ## Accessing a DMS remotely
 


### PR DESCRIPTION
'always have the format' is not 100% correct, when going cloud-connected a user can fill in anything (that has a valid format) for those 2 pieces of the url.