### PR TITLE
RN 34225 - SelectedPool

### DIFF
--- a/user-guide/Advanced_Modules/SRM/The_Resources_module/Configuring_pools_of_resources.md
+++ b/user-guide/Advanced_Modules/SRM/The_Resources_module/Configuring_pools_of_resources.md
@@ -4,21 +4,9 @@ uid: Configuring_pools_of_resources
 
 # Configuring pools of resources
 
-This section contains the following topics:
-
-- [Adding a pool](#adding-a-pool)
-
-- [Configuring pool properties](#configuring-pool-properties)
-
-- [Adding resource property definitions](#adding-resource-property-definitions)
-
-- [Adding resources to a pool](#adding-resources-to-a-pool)
-
-- [Adding a virtual function as a resource](#adding-a-virtual-function-as-a-resource)
-
 ## Adding a pool
 
-To add a resource pool using DataMiner 10.2.0/10.1.5 or higher:
+### [DataMiner 10.2.0/10.1.5 or higher](#tab/tabid-1)
 
 1. Make sure no existing resource pool is selected.
 
@@ -28,13 +16,15 @@ To add a resource pool using DataMiner 10.2.0/10.1.5 or higher:
 
 1. To further configure the pool, select it in the resource pool pane, then proceed with the procedures outlined below.
 
-To add a resource pool prior to DataMiner 10.1.5:
+### [Prior to DataMiner 10.1.5](#tab/tabid-2)
 
 1. At the bottom of the leftmost column in the *resources* tab, click the *Add* button.
 
 1. Enter the pool name in the dialog box and click *OK*.
 
 1. To further configure the pool, select it in the column on the left, then proceed with the procedures outlined below.
+
+***
 
 ## Configuring pool properties
 
@@ -62,9 +52,9 @@ In order to define properties for all resources in a pool, and optionally limit 
 
 ## Adding resources to a pool
 
-To add a resource to a pool using DataMiner 10.2.0/10.1.5 or higher:
+### [DataMiner 10.2.0/10.1.5 or higher](#tab/tabid-1)
 
-1. While the pool is selected, in the *resources* tab, click the *Add* *resource* button.
+1. While the pool is selected, in the *resources* tab, click the *Add resource* button.
 
 1. In the *general* subtab, configure the following fields as necessary:
 
@@ -103,7 +93,10 @@ To add a resource to a pool using DataMiner 10.2.0/10.1.5 or higher:
 
 1. Click *Save* in the lower right corner.
 
-To add a resource to a pool prior to DataMiner 10.1.5:
+> [!NOTE]
+> You can also add a resource to a pool by moving or copying it from another pool. To move a resource, drag it from one pool to the other. To copy it, keep Ctrl pressed while you drag. Note that this is only supported for existing, valid resources, and you need to have permission to edit resources to do this. It is also not possible to copy a resource to or from the "(uncategorized)" pool, as this pool is reserved for resources that are not in any other pool.
+
+### [Prior to DataMiner 10.1.5](#tab/tabid-2)
 
 1. While the pool is selected, in the *resources* tab, click the *Add* button.
 
@@ -133,6 +126,8 @@ To add a resource to a pool prior to DataMiner 10.1.5:
 
 1. Click *OK*.
 
+***
+
 ## Adding a virtual function as a resource
 
 To make it possible to schedule a virtual function as a resource, prior to DataMiner 10.2.0/10.1.5 you must add it as a resource in the *Resources* module using the procedure below. From DataMiner 10.2.0/10.1.5 onwards, you can do so as detailed in [Adding resources to a pool](#adding-resources-to-a-pool).
@@ -160,3 +155,16 @@ To make it possible to schedule a virtual function as a resource, prior to DataM
    1. In the *Edit Resource* window, fill a new name in the *Name* box.
 
    1. Click *OK* to close the window.
+
+### Removing a resource from a pool
+
+From DataMiner 10.2.10/10.3.0 onwards, you can remove a resource from a pool as follows:
+
+1. Select the resource pool.
+
+1. In the *Resources* tab, right-click the resource you want to remove and select *Remove from pool*.
+
+> [!NOTE]
+>
+> - Removing a resource from a pool does not delete the resource from the system. It only removes it from the selected pool. If the resource is not present in any other resource pool, it will be moved to the "(uncategorized)" pool.
+> - You can only remove valid, unmodified existing resources that are not in the "(uncategorized)" pool. You also need permission to edit resources to be able to do this.

--- a/user-guide/Basic_Functionality/Visio/SRM/Embedding_a_Resource_Manager_component.md
+++ b/user-guide/Basic_Functionality/Visio/SRM/Embedding_a_Resource_Manager_component.md
@@ -416,14 +416,14 @@ To have shapes display information about an object selected on the timeline, the
 
 - **SelectedOccurrence**: Available from DataMiner 9.5.4 onwards. Used in case there are recurring bookings.
 
-- **SelectedPool**: From DataMiner 10.2.1 onwards, when you select a resource band, this variable is filled in with the first pool of the selected resource.
+- **SelectedPool**: From DataMiner 10.2.1/10.3.0 onwards, when you select a resource band, this variable is filled in with the first pool of the selected resource.
 
   > [!NOTE]
   > From DataMiner 10.2.10/10.3.0 onwards, the *SelectedPool* session variable will contain the GUIDs of all pools of the selected resource(s), separated by commas.
 
 - **SelectedReservation**
 
-- **SelectedResource**: From DataMiner 10.2.1 onwards, this variable is filled in when you select a resource band.
+- **SelectedResource**: From DataMiner 10.2.1/10.3.0 onwards, this variable is filled in when you select a resource band.
 
   > [!NOTE]
   > From DataMiner 10.2.7/10.3.0 onwards, users can select multiple bands by keeping the Ctrl key pressed when selecting different bands, or by keeping the Shift key pressed when selecting the first and last of several consecutive bands that need to be selected. In that case, the *SelectedResource* session variable will contain the GUIDs of all selected resources, separated by commas.

--- a/user-guide/Basic_Functionality/Visio/SRM/Embedding_a_Resource_Manager_component.md
+++ b/user-guide/Basic_Functionality/Visio/SRM/Embedding_a_Resource_Manager_component.md
@@ -416,14 +416,17 @@ To have shapes display information about an object selected on the timeline, the
 
 - **SelectedOccurrence**: Available from DataMiner 9.5.4 onwards. Used in case there are recurring bookings.
 
-- **SelectedPool**: From DataMiner 10.2.1/10.3.0 onwards, when you select a resource band, this variable is filled in with the first pool of the selected resource.
+- **SelectedPool**: From DataMiner 10.2.1 onwards, when you select a resource band, this variable is filled in with the first pool of the selected resource.
+
+  > [!NOTE]
+  > From DataMiner 10.2.10/10.3.0 onwards, the *SelectedPool* session variable will contain the GUIDs of all pools of the selected resource(s), separated by commas.
 
 - **SelectedReservation**
 
-- **SelectedResource**: From DataMiner 10.2.1/10.3.0 onwards, this variable is filled in when you select a resource band.
+- **SelectedResource**: From DataMiner 10.2.1 onwards, this variable is filled in when you select a resource band.
 
   > [!NOTE]
-  > From DataMiner 10.2./10.3.0 onwards, users can select multiple bands by keeping the Ctrl key pressed when selecting different bands, or by keeping the Shift key pressed when selecting the first and last of several consecutive bands that need to be selected. In that case, the *SelectedResource* session variable will contain the GUIDs of all selected resources, separated by commas.
+  > From DataMiner 10.2.7/10.3.0 onwards, users can select multiple bands by keeping the Ctrl key pressed when selecting different bands, or by keeping the Shift key pressed when selecting the first and last of several consecutive bands that need to be selected. In that case, the *SelectedResource* session variable will contain the GUIDs of all selected resources, separated by commas.
 
 - **SelectedSession**
 


### PR DESCRIPTION
Updated documentation of SelectedPool, based on RN 34225 changes.
Also tweaked some in the SelectedResource documentation.
It must be made clear that those 2 variables must be handled as a list of GUIDs, separated by a comma.