### PR TITLE
Remove OK and Online Parameters from Linecards

### DIFF
--- a/user-guide/Standard_Apps/EPM/EPM_I-DOCSIS/I-DOCSIS_parameters/I-DOCSIS_parameters_linecard.md
+++ b/user-guide/Standard_Apps/EPM/EPM_I-DOCSIS/I-DOCSIS_parameters/I-DOCSIS_parameters_linecard.md
@@ -14,21 +14,13 @@ This page contains an overview of the Linecard parameters available in the I-DOC
 
 - **Percentage CM Offline**
 
-- **Number CM Online**
-
-- **Percentage CM Online**
-
 - **Number CM DOCSIS 2.0**
 
 - **Number CM DOCSIS 3.0**
 
 - **Number CM DOCSIS 3.1**
 
-- **Number CM DOCSIS other**
-
-- **Number CM Ping OK**
-
-- **Percentage CM Ping OK**
+- **Number CM DOCSIS Other**
 
 - **Number CM Ping Unreachable**
 


### PR DESCRIPTION
Remove the OK and Online Parameters from this page, they no longer exist.