### PR TITLE
Remove depreciated parameters from DS SG

### DIFF
--- a/user-guide/Standard_Apps/EPM/EPM_I-DOCSIS/I-DOCSIS_parameters/I-DOCSIS_parameters_ds_service_group.md
+++ b/user-guide/Standard_Apps/EPM/EPM_I-DOCSIS/I-DOCSIS_parameters/I-DOCSIS_parameters_ds_service_group.md
@@ -14,46 +14,20 @@ This page contains an overview of the DS Service Group parameters available in t
 
 - **Percentage CM Offline**
 
-- **Number CM Online**
-
-- **Percentage CM Online**
-
-- **Number CM DS SNR OOS**
-
-- **Percentage CM DS SNR OOS**
-
-- **Number CM DS Power OOS**
-
-- **Percentage CM DS Power OOS**
-
-- **Number CM DS Post-FEC OOS**
-
-- **Percentage CM DS Post-FEC OOS**
-
 - **Number CM DOCSIS 2.0**
 
 - **Number CM DOCSIS 3.0**
 
 - **Number CM DOCSIS 3.1**
 
-- **Number CM DOCSIS other**
-
-- **Number CM Ping OK**
-
-- **Percentage CM Ping OK**
+- **Number CM DOCSIS Other**
 
 - **Number CM Ping Unreachable**
 
 - **Percentage CM Ping Unreachable**
 
-- **Average Latency**: Calculated. The average latency for all CMs associated with the given level. Only CMs that present valid values count towards this KPI.
-
-- **Average Jitter**: Calculated. The average jitter for all CMs associated with the given level. Only CMs that present valid values count towards this KPI.
-
-- **Average Packet Loss Rate**: Calculated. The average packet loss rate for all CMs associated with the given level. Only CMs that present valid values count towards this KPI.
-
 ## System parameters
 
 - **Name**
-- **FN Name**
-- **Linecard Name**
+- **SG Name**
+- **System Name**


### PR DESCRIPTION
Remove depreciated parameters from this page such as OOS, OK, and Avg parameters.