### PR TITLE
Encode searchTerm in query string

### DIFF
--- a/templates/slc_template/styles/search.js
+++ b/templates/slc_template/styles/search.js
@@ -132,7 +132,7 @@ $(function () {
           // results with toc.html files (table of contents) + without title are skipped
           const title = getTitle(result.metadata_title);
           const url = getUrl(result.storage_path);
-          const htmlString = `<div class="result"><a href="${url}?q=${searchTerm}"><div class="url">${url}</div><div class="title">${title}</div></a></div>`;
+          const htmlString = `<div class="result"><a href="${url}?q=${encodeURIComponent(searchTerm)}"><div class="url">${url}</div><div class="title">${title}</div></a></div>`;
           html.push(htmlString)
         }
 


### PR DESCRIPTION
Fixes an issue where html files are unintentionally downloaded (when the link of a search result is clicked) when using a quoted search term containing the word "download".