### PR TITLE
Update Standalone_Elastic_Backup_Tool.md

### DIFF
--- a/user-guide/Reference/DataMiner_Tools/Standalone_Elastic_Backup_Tool.md
+++ b/user-guide/Reference/DataMiner_Tools/Standalone_Elastic_Backup_Tool.md
@@ -51,6 +51,10 @@ The following arguments should be used regardless of the specified action:
 - `-- pw`: The password that has to be used to connect to Elasticsearch.
 
   Only use this argument when credentials are required.
+  
+- `--key` or `-k`: The path to the file containing the encrypted elastic key.
+
+  Only use this argument when credentials are required. Use separate PasswordEncryptionTool to generate the elastic key from plain text password.
 
 ### Arguments when initializing the repository
 


### PR DESCRIPTION
Please reach out to Alex Collantes from Origin squad about changes to the Standalone Elastic Backup Tool. A new, fully backwards compatible, version of the tool that allows the use of an encrypted key instead of a plain text password has been implemented and tested. Also created a separate PasswordEncryptionTool to encrypt a plain text password and output a txt file with the encrypted form (uses DPAPI for user-bound encryption). Need assistance properly documenting these changes and maintaining an updated repository with the latest code.