### PR TITLE
Update The_Bookings_module.md

### DIFF
--- a/user-guide/Advanced_Modules/SRM/The_Bookings_module.md
+++ b/user-guide/Advanced_Modules/SRM/The_Bookings_module.md
@@ -24,7 +24,7 @@ The list can be customized as follows:
 
 - To apply a custom column configuration, see [Creating a new column configuration](#creating-a-new-column-configuration) and [Loading the default column configuration](#loading-the-default-column-configuration).
 
-- From DataMiner 9.6.13 onwards, the color displayed in the *Color* column of the list can be customized using the *Visual.Background* property of bookings. In DataMiner 10.0.0/10.0.2, this property is renamed to *VisualBackground*. See [Customizing the color of booking blocks](xref:Embedding_a_Resource_Manager_component#customizing-the-color-of-booking-blocks).
+- From DataMiner 9.6.13 onwards, the color displayed in the *Visual.Background* property column of the list using column type *Color* can be customized using the *Visual.Background* property of bookings. In DataMiner 10.0.0/10.0.2, this property is renamed to *VisualBackground*. See [Customizing the color of booking blocks](xref:Embedding_a_Resource_Manager_component#customizing-the-color-of-booking-blocks).
 
 > [!NOTE]
 > When an item is selected in the list, a session variable is populated with the booking ID, which can be of use for Visio drawings.

--- a/user-guide/Advanced_Modules/SRM/The_Bookings_module.md
+++ b/user-guide/Advanced_Modules/SRM/The_Bookings_module.md
@@ -24,7 +24,7 @@ The list can be customized as follows:
 
 - To apply a custom column configuration, see [Creating a new column configuration](#creating-a-new-column-configuration) and [Loading the default column configuration](#loading-the-default-column-configuration).
 
-- From DataMiner 9.6.13 onwards, the color displayed in the *Visual.Background* property column of the list using column type *Color* can be customized using the *Visual.Background* property of bookings. In DataMiner 10.0.0/10.0.2, this property is renamed to *VisualBackground*. See [Customizing the color of booking blocks](xref:Embedding_a_Resource_Manager_component#customizing-the-color-of-booking-blocks).
+- From DataMiner 9.6.13 onwards, it is possible to have a column display the color configured in the *Visual.Background* property of bookings. For this purpose, add the *Visual.Background* property column and set it to the column type *Color*. In DataMiner 10.0.0/10.0.2, this property is renamed to *VisualBackground*. See [Customizing the color of booking blocks](xref:Embedding_a_Resource_Manager_component#customizing-the-color-of-booking-blocks).
 
 > [!NOTE]
 > When an item is selected in the list, a session variable is populated with the booking ID, which can be of use for Visio drawings.

--- a/user-guide/Basic_Functionality/Visio/miscellaneous/Creating_a_list_view.md
+++ b/user-guide/Basic_Functionality/Visio/miscellaneous/Creating_a_list_view.md
@@ -43,7 +43,7 @@ To create a list view, add a shape on the Visio page with the following shape da
 > [!NOTE]
 >
 > - If a *ListView* component with source *Reservations* or *Bookings* is used together with an embedded Resource Manager component, selecting an item in the list will select the corresponding block on the Resource Manager timeline and vice versa. See [Embedding a Resource Manager component](xref:Embedding_a_Resource_Manager_component).
-> - If colors are defined using the *Visual.Background* property of bookings, from DataMiner 9.6.13 onwards, these are displayed in the *Color* column of a *ListView* component showing bookings. In DataMiner 10.0.0/10.0.2, this property is renamed to *VisualBackground*. See [Customizing the color of booking blocks](xref:Embedding_a_Resource_Manager_component#customizing-the-color-of-booking-blocks).
+> - If colors are defined using the *Visual.Background* property of bookings, from DataMiner 9.6.13 onwards, these can be displayed in the *Visual.Background* property column of a *ListView* component showing bookings, if the column is set to column type *Color*. In DataMiner 10.0.0/10.0.2, this property is renamed to *VisualBackground*. See [Customizing the color of booking blocks](xref:Embedding_a_Resource_Manager_component#customizing-the-color-of-booking-blocks).
 
 ## Component options
 


### PR DESCRIPTION
The color of a booking is determined by booking property "Visualbackground". A booking timeline will use that color on a booking item by default. A booking listview can show this color by adding the property column "Visualbackground" and choose column type  'Color' to show the color instead of  a color textrepresentation.