### PR TITLE
Adjusted minimum ArtifactDeployer version support

### DIFF
--- a/user-guide/Cloud_Platform/AboutCloudPlatform/Connect_to_cloud_via_proxy.md
+++ b/user-guide/Cloud_Platform/AboutCloudPlatform/Connect_to_cloud_via_proxy.md
@@ -4,7 +4,7 @@ uid: Connect_to_cloud_via_proxy
 
 # Connecting to the cloud via proxy server
 
-From DataMiner CloudFeed 1.0.6, CloudGateway 2.7.0, and ArtifactDeployer 1.4.0 onwards, proxy support is available for these DxMs. This means that you can enable a proxy server so that all outgoing traffic towards the public internet will pass through that proxy server.
+From DataMiner CloudFeed 1.0.6, CloudGateway 2.7.0, and ArtifactDeployer 1.4.1 onwards, proxy support is available for these DxMs. This means that you can enable a proxy server so that all outgoing traffic towards the public internet will pass through that proxy server.
 
 The proxy server has to support both HTTP and WebSocket traffic.
 


### PR DESCRIPTION
Due to a bug in v1.4.0 it wasn't actually proxying some request