### PR TITLE
Update DomBehaviorDefinition.md

### DIFF
--- a/user-guide/Advanced_Modules/DOM/DOM_actions.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_actions.md
@@ -12,7 +12,7 @@ An action is always executed in a specific context, i.e. for a context object. C
 
 ## Defining an action
 
-You can define an action by adding an `IDomActionDefinition` to the `ActionDefinitions` list of a `DomBehaviorDefinition`. Each action definition has an ID (of type string) and a condition (of type `IDomCondition`). Note that the ID must be unique for this `DomBehaviorDefinition` and it can only contain lower-case characters. There is currently only one action type.
+You can define an action by adding an `IDomActionDefinition` to the `ActionDefinitions` list of a `DomBehaviorDefinition`. Each action definition has an ID (of type string) and a condition (of type `IDomCondition`). Note that the ID can only contain lower-case characters and must be unique across this `DomBehaviorDefinition` and its parent or child definitions. There is currently only one action type.
 
 ### ExecuteScriptDomActionDefinition
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DomBehaviorDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DomBehaviorDefinition.md
@@ -95,4 +95,4 @@ When something goes wrong during the CRUD actions, the `TraceData` can contain o
 | DuplicateButtonDefinitionIds | There are `IDomButtonDefinition` defined with duplicate IDs. *ButtonDefinitionIds* contains the ID(s) of the duplicate definition(s). |
 
 > [!NOTE]
-> When a DomBehaviorDefinition inherits from another definition, make sure that the IDs of the `StatusSectionDefinitionLinks`, `ButtonDefinitions` and `ActionDefinitions` are unique accross both parent & child definition.
+> When a `DomBehaviorDefinition` inherits from another definition, make sure that the IDs of the `StatusSectionDefinitionLinks`, `ButtonDefinitions` and `ActionDefinitions` are unique accross both parent & child definition.

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DomBehaviorDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DomBehaviorDefinition.md
@@ -35,9 +35,12 @@ One `DomBehaviorDefinition` can inherit from another. However, there are importa
 - It can only inherit from the `ModuleDomBehaviorDefinition` (the ID is defined in the *ModuleBehaviorDefinition* property of the `ModuleSettings`).
 
 - The inheriting definition can only contain an ID, parent ID, and extra:
-  - `DomStatusSectionDefinitionLinks` for `SectionDefinitions` that are not already defined on the module definition
-  - `ButtonDefinitions` (with other IDs than those defined on the parent)
-  - `ActionDefinitions` (with other IDs than those defined on the parent)
+
+  - `DomStatusSectionDefinitionLinks` for `SectionDefinitions` that are not already defined on the module definition.
+
+  - `ButtonDefinitions` (with other IDs than those defined on the parent).
+
+  - `ActionDefinitions` (with other IDs than those defined on the parent).
 
 Adding extra statuses or transitions on the child definition is not allowed.
 
@@ -78,7 +81,7 @@ When something goes wrong during the CRUD actions, the `TraceData` can contain o
 | Reason | Description |
 |--|--|
 | InvalidParentId | The `DomBehaviorDefinition.ParentId` property contains an unexpected ID. If a module `DomBehaviorDefinition` is defined, it must contain the ID of that definition. If that is not the case, it should be empty. |
-| InheritingDefinitionContainsInvalidData | This `DomBehaviorDefinition` is inheriting from another `DomBehaviorDefinition`, but it contains data that is not allowed. Only the `StatusSectionDefinitionLinks`, `ButtonDefinitions` and `ActionDefinitions` can contain extra objects. |
+| InheritingDefinitionContainsInvalidData | This `DomBehaviorDefinition` is inheriting from another `DomBehaviorDefinition`, but it contains data that is not allowed. Only the `StatusSectionDefinitionLinks`, `ButtonDefinitions`, and `ActionDefinitions` can contain extra objects. |
 | StatusTransitionsReferenceNonExistingStatuses | There was at least one `DomStatusTransition` that references a status that does not exist. *StatusTransitionsIds* contains the ID(s) of the invalid transition(s). |
 | StatusSectionDefinitionLinksReferenceNonExistingStatuses | There was at least one `DomStatusSectionDefinitionLink` that referenced a status that does not exist. *DomStatusSectionDefinitionLinkIds* contains the ID(s) of the invalid `DomStatusSectionDefinitionLink(s)`. |
 | InvalidStatusIds | There was at least one status defined with an invalid ID (should only contain lowercase characters). *StatusIds* contains the ID(s) of the invalid status(es). |

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DomBehaviorDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DomBehaviorDefinition.md
@@ -34,7 +34,12 @@ One `DomBehaviorDefinition` can inherit from another. However, there are importa
 
 - It can only inherit from the `ModuleDomBehaviorDefinition` (the ID is defined in the *ModuleBehaviorDefinition* property of the `ModuleSettings`).
 
-- The inheriting definition can only contain an ID, parent ID, and extra `DomStatusSectionDefinitionLinks` for `SectionDefinitions` that are not already defined on the module definition. Adding extra statuses or transitions is not allowed.
+- The inheriting definition can only contain an ID, parent ID, and extra:
+  - `DomStatusSectionDefinitionLinks` for `SectionDefinitions` that are not already defined on the module definition
+  - `ButtonDefinitions` (with other IDs that those defined on the parent)
+  - `ActionDefinitions` (with other IDs that those defined on the parent)
+
+Adding extra statuses or transitions on the child definition is not allowed.
 
 This logic makes it possible to define a complete status system that should be used by all `DomDefinitions`. With an inheriting `DomBehaviorDefinition`, you can then define the visibility, requirements etc. for fields of extra `SectionDefinitions`.
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DomBehaviorDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DomBehaviorDefinition.md
@@ -36,8 +36,8 @@ One `DomBehaviorDefinition` can inherit from another. However, there are importa
 
 - The inheriting definition can only contain an ID, parent ID, and extra:
   - `DomStatusSectionDefinitionLinks` for `SectionDefinitions` that are not already defined on the module definition
-  - `ButtonDefinitions` (with other IDs that those defined on the parent)
-  - `ActionDefinitions` (with other IDs that those defined on the parent)
+  - `ButtonDefinitions` (with other IDs than those defined on the parent)
+  - `ActionDefinitions` (with other IDs than those defined on the parent)
 
 Adding extra statuses or transitions on the child definition is not allowed.
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DomBehaviorDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DomBehaviorDefinition.md
@@ -78,7 +78,7 @@ When something goes wrong during the CRUD actions, the `TraceData` can contain o
 | Reason | Description |
 |--|--|
 | InvalidParentId | The `DomBehaviorDefinition.ParentId` property contains an unexpected ID. If a module `DomBehaviorDefinition` is defined, it must contain the ID of that definition. If that is not the case, it should be empty. |
-| InheritingDefinitionContainsInvalidData | This `DomBehaviorDefinition` is inheriting from another `DomBehaviorDefinition`, but it contains data that is not allowed. Only the `DomBehaviorDefinition.StatusSectionDefinitionLinks` can contain extra objects. |
+| InheritingDefinitionContainsInvalidData | This `DomBehaviorDefinition` is inheriting from another `DomBehaviorDefinition`, but it contains data that is not allowed. Only the `StatusSectionDefinitionLinks`, `ButtonDefinitions` and `ActionDefinitions` can contain extra objects. |
 | StatusTransitionsReferenceNonExistingStatuses | There was at least one `DomStatusTransition` that references a status that does not exist. *StatusTransitionsIds* contains the ID(s) of the invalid transition(s). |
 | StatusSectionDefinitionLinksReferenceNonExistingStatuses | There was at least one `DomStatusSectionDefinitionLink` that referenced a status that does not exist. *DomStatusSectionDefinitionLinkIds* contains the ID(s) of the invalid `DomStatusSectionDefinitionLink(s)`. |
 | InvalidStatusIds | There was at least one status defined with an invalid ID (should only contain lowercase characters). *StatusIds* contains the ID(s) of the invalid status(es). |
@@ -94,3 +94,5 @@ When something goes wrong during the CRUD actions, the `TraceData` can contain o
 | InvalidButtonDefinitionIds | There was at least one `IDomButtonDefinition` defined with an invalid ID (should only contain lowercase characters). *ButtonDefinitionIds* contains the ID(s) of the invalid definition(s). |
 | DuplicateButtonDefinitionIds | There are `IDomButtonDefinition` defined with duplicate IDs. *ButtonDefinitionIds* contains the ID(s) of the duplicate definition(s). |
 
+> [!NOTE]
+> When a DomBehaviorDefinition inherits from another definition, make sure that the IDs of the StatusSectionDefinitionLinks, ButtonDefinitions and ActionDefinitions are unique accross both parent & child definition.

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DomBehaviorDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DomBehaviorDefinition.md
@@ -95,4 +95,4 @@ When something goes wrong during the CRUD actions, the `TraceData` can contain o
 | DuplicateButtonDefinitionIds | There are `IDomButtonDefinition` defined with duplicate IDs. *ButtonDefinitionIds* contains the ID(s) of the duplicate definition(s). |
 
 > [!NOTE]
-> When a DomBehaviorDefinition inherits from another definition, make sure that the IDs of the StatusSectionDefinitionLinks, ButtonDefinitions and ActionDefinitions are unique accross both parent & child definition.
+> When a DomBehaviorDefinition inherits from another definition, make sure that the IDs of the `StatusSectionDefinitionLinks`, `ButtonDefinitions` and `ActionDefinitions` are unique accross both parent & child definition.


### PR DESCRIPTION
Updated the DomBehaviorDefinition page to more clearly reflect that you are allowed to define additional ButtonDefinitions and ActionDefinitions on the child DomBehviorDefinition. (Added for RN35156)