### PR TITLE
Update TCP-IP_socket_message_reference.md

### DIFF
--- a/user-guide/Advanced_Functionality/TCPIP_Sockets/TCP-IP_socket_message_reference.md
+++ b/user-guide/Advanced_Functionality/TCPIP_Sockets/TCP-IP_socket_message_reference.md
@@ -680,7 +680,7 @@ or
 - **Command**
 
   ```txt
-  0x09Set_Parameter;[1];[2];[3];[4];[5];[6];[7]0x0D
+  \tSet_Parameter;[1];[2];[3];[4];[5];[6];[7]\r
   ```
 
   \[1\] DMA ID


### PR DESCRIPTION
Syntax was correct, but example references to \tSet_Parameter;5;20848;100;double;;;0\r so made the syntax correct