### PR TITLE
Added the DomBehaviorDefinitionId to the DomDefinition page

### DIFF
--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DomDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DomDefinition.md
@@ -19,7 +19,7 @@ The table below lists the properties of the `DomDefinition` object. It also indi
 | Name | string | Yes | The name of the `DomDefinition`. |
 | SectionDefinitionLinks | List\<[SectionDefinitionLink](#sectiondefinitionlink)> | Yes | Contains the required/allowed `SectionDefinitions`. |
 | VisualStructure | DomDefinitionVisualStructure | No | Contains settings related to the client UI. Most of these do not apply for DOM. This property should be ignored since it will be removed in the near future. |
-| DomBehaviorDefinitionId | DomBehaviorDefinitionId | Yes | ID of the `DomBehaviorDefinition` where this `DomDefinition` is linked to. See [DomBehaviorDefinition](xref:DomBehaviorDefinition). |
+| DomBehaviorDefinitionId | DomBehaviorDefinitionId | Yes | ID of the `DomBehaviorDefinition` that this `DomDefinition` is linked to. See [DomBehaviorDefinition](xref:DomBehaviorDefinition). |
 | ModuleSettingsOverrides | [ModuleSettingsOverrides](#modulesettingsoverrides) | No | Used to override some `ModuleSettings`. See [DomInstanceNameDefinition](xref:DomInstanceNameDefinition). |
 
 ### SectionDefinitionLink

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DomDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DomDefinition.md
@@ -19,6 +19,7 @@ The table below lists the properties of the `DomDefinition` object. It also indi
 | Name | string | Yes | The name of the `DomDefinition`. |
 | SectionDefinitionLinks | List\<[SectionDefinitionLink](#sectiondefinitionlink)> | Yes | Contains the required/allowed `SectionDefinitions`. |
 | VisualStructure | DomDefinitionVisualStructure | No | Contains settings related to the client UI. Most of these do not apply for DOM. This property should be ignored since it will be removed in the near future. |
+| DomBehaviorDefinitionId | DomBehaviorDefinitionId | Yes | ID of the `DomBehaviorDefinition` where this `DomDefinition` is linked to. See [DomBehaviorDefinition](xref:DomBehaviorDefinition). |
 | ModuleSettingsOverrides | [ModuleSettingsOverrides](#modulesettingsoverrides) | No | Used to override some `ModuleSettings`. See [DomInstanceNameDefinition](xref:DomInstanceNameDefinition). |
 
 ### SectionDefinitionLink


### PR DESCRIPTION
This property has been on the DomDefinition class for quite some time, but for some reason, we seem to have forgotten to add it to this file.