### PR TITLE
Update Generating_shapes_representing_bookings.md

### DIFF
--- a/user-guide/Basic_Functionality/Visio/generating_shapes/Generating_shapes_representing_bookings.md
+++ b/user-guide/Basic_Functionality/Visio/generating_shapes/Generating_shapes_representing_bookings.md
@@ -87,7 +87,7 @@ The following shape data fields can be added to the group containing the booking
   - WrapVertical
   - WrapHorizontal
 
-- **ChildrenSource**: To add bookings from a specific time range, add a **ChildrenSource** shape data field to the shape group and set its value to that time range (e.g. “StartTime=\<dateTime>| EndTime=\<dateTime>”).
+- **ChildrenSource**: To add bookings from a specific time range, add a **ChildrenSource** shape data field to the shape group and set its value to that time range (e.g. “StartTime=\<dateTime>|EndTime=\<dateTime>”).
 
   > [!NOTE]
   >

--- a/user-guide/Basic_Functionality/Visio/generating_shapes/Generating_shapes_representing_bookings.md
+++ b/user-guide/Basic_Functionality/Visio/generating_shapes/Generating_shapes_representing_bookings.md
@@ -87,7 +87,7 @@ The following shape data fields can be added to the group containing the booking
   - WrapVertical
   - WrapHorizontal
 
-- **ChildrenSource**: To add bookings from a specific time range, add a **ChildrenSource** shape data field to the shape group and set its value to that time range (e.g. “StartTime=\<dateTime>; EndTime=\<dateTime>”).
+- **ChildrenSource**: To add bookings from a specific time range, add a **ChildrenSource** shape data field to the shape group and set its value to that time range (e.g. “StartTime=\<dateTime>| EndTime=\<dateTime>”).
 
   > [!NOTE]
   >


### PR DESCRIPTION
Changed separator from ';' to '|', which is the default. Using';' will not work without changing the separator.