### PR TITLE
Missing Executable part

### DIFF
--- a/develop/devguide/Automation/UIBlockTypesOverview.md
+++ b/develop/devguide/Automation/UIBlockTypesOverview.md
@@ -92,6 +92,19 @@ blockItem.Type = UIBlockType.DropDown;
 MyDialogBox.AppendBlock(blockItem);
 ```
 
+## Executable
+
+Allows you to run a program execution.
+
+Example:
+
+```csharp
+UIBlockDefinition blockItem = new UIBlockDefinition();
+blockItem.Type = UIBlockType.Executable;
+...
+MyDialogBox.AppendBlock(blockItem);
+```
+
 ## FileSelector
 
 Allows you to define a newly created dialog box item as a file selector control.

--- a/develop/devguide/Automation/UIBlockTypesOverview.md
+++ b/develop/devguide/Automation/UIBlockTypesOverview.md
@@ -96,14 +96,30 @@ MyDialogBox.AppendBlock(blockItem);
 
 Allows you to run a program execution.
 
-Example:
+Examples:
+
+- Open the program Notepad on the client device where the interactive script is running.
 
 ```csharp
 UIBlockDefinition blockItem = new UIBlockDefinition();
 blockItem.Type = UIBlockType.Executable;
+blockItem.Extra = "notepad.exe";
+MyDialogBox.AppendBlock(blockItem);
+```
+
+- Open a file with Notepad on the client device where the interactive script is running.
+
+```csharp
+UIBlockDefinition blockItem = new UIBlockDefinition();
+blockItem.Type = UIBlockType.Executable;
+blockItem.Extra = "notepad.exe";
+blockItem.AddDropDownOption("Arguments", @"C:\Skyline DataMiner\Files\VersionCompatibility.txt");
 ...
 MyDialogBox.AppendBlock(blockItem);
 ```
+> [!NOTE]
+> You can specifiy arguments when launching a program execution.
+> To do this, you have to call method *AddDropDownOption* on the item with key *Arguments* and value the arguments you want to pass on.
 
 ## FileSelector
 

--- a/develop/devguide/Automation/UIBlockTypesOverview.md
+++ b/develop/devguide/Automation/UIBlockTypesOverview.md
@@ -98,12 +98,13 @@ Allows you to run a program execution.
 
 Examples:
 
-- Open the program Notepad on the client device where the interactive script is running.
+- Open the program Notepad++ on the client device where the interactive script is running.
 
 ```csharp
 UIBlockDefinition blockItem = new UIBlockDefinition();
 blockItem.Type = UIBlockType.Executable;
-blockItem.Extra = "notepad.exe";
+blockItem.Extra = "notepad++.exe";
+...
 MyDialogBox.AppendBlock(blockItem);
 ```
 

--- a/develop/devguide/Automation/UIBlockTypesOverview.md
+++ b/develop/devguide/Automation/UIBlockTypesOverview.md
@@ -94,7 +94,8 @@ MyDialogBox.AppendBlock(blockItem);
 
 ## Executable
 
-Allows you to run a program execution.
+Allows you to run a program execution. To do this, you must fill in the property 'Extra' with the name of the program you want to execute.
+You can also specify arguments when launching a program execution. To do so, call the method *AddDropDownOption* on the item with key *Arguments*, using the arguments you want to pass on as the value.
 
 Examples:
 
@@ -118,9 +119,6 @@ Examples:
   ...
   MyDialogBox.AppendBlock(blockItem);
   ```
-
-> [!NOTE]
-> You can specify arguments when launching a program execution. To do so, call the method *AddDropDownOption* on the item with key *Arguments*, using the arguments you want to pass on as the value.
 
 ## FileSelector
 

--- a/develop/devguide/Automation/UIBlockTypesOverview.md
+++ b/develop/devguide/Automation/UIBlockTypesOverview.md
@@ -100,27 +100,27 @@ Examples:
 
 - Open the program Notepad++ on the client device where the interactive script is running.
 
-```csharp
-UIBlockDefinition blockItem = new UIBlockDefinition();
-blockItem.Type = UIBlockType.Executable;
-blockItem.Extra = "notepad++.exe";
-...
-MyDialogBox.AppendBlock(blockItem);
-```
+  ```csharp
+  UIBlockDefinition blockItem = new UIBlockDefinition();
+  blockItem.Type = UIBlockType.Executable;
+  blockItem.Extra = "notepad++.exe";
+  ...
+  MyDialogBox.AppendBlock(blockItem);
+  ```
 
 - Open a file with Notepad on the client device where the interactive script is running.
 
-```csharp
-UIBlockDefinition blockItem = new UIBlockDefinition();
-blockItem.Type = UIBlockType.Executable;
-blockItem.Extra = "notepad.exe";
-blockItem.AddDropDownOption("Arguments", @"C:\Skyline DataMiner\Files\VersionCompatibility.txt");
-...
-MyDialogBox.AppendBlock(blockItem);
-```
+  ```csharp
+  UIBlockDefinition blockItem = new UIBlockDefinition();
+  blockItem.Type = UIBlockType.Executable;
+  blockItem.Extra = "notepad.exe";
+  blockItem.AddDropDownOption("Arguments", @"C:\Skyline DataMiner\Files\VersionCompatibility.txt");
+  ...
+  MyDialogBox.AppendBlock(blockItem);
+  ```
+
 > [!NOTE]
-> You can specifiy arguments when launching a program execution.
-> To do this, you have to call method *AddDropDownOption* on the item with key *Arguments* and value the arguments you want to pass on.
+> You can specify arguments when launching a program execution. To do so, call the method *AddDropDownOption* on the item with key *Arguments*, using the arguments you want to pass on as the value.
 
 ## FileSelector
 

--- a/develop/devguide/Automation/UIBlockTypesOverview.md
+++ b/develop/devguide/Automation/UIBlockTypesOverview.md
@@ -94,7 +94,7 @@ MyDialogBox.AppendBlock(blockItem);
 
 ## Executable
 
-Allows you to run a program execution. To do this, you must fill in the property 'Extra' with the name of the program you want to execute.
+Allows you to run a program execution. To do this, you must fill in the property *Extra* with the name of the program you want to execute.
 You can also specify arguments when launching a program execution. To do so, call the method *AddDropDownOption* on the item with key *Arguments*, using the arguments you want to pass on as the value.
 
 Examples:


### PR DESCRIPTION
The Executable information was missing.
It allows the user to run a program execution on the client device.
Example+Info on how-to: https://intranet.skyline.be/DataMiner/Lists/Release%20Notes/DispForm.aspx?ID=35418