### PR TITLE
Add note about supported TLS version for cassandra client-server encryption

### DIFF
--- a/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Security_Cassandra_TLS.md
+++ b/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Security_Cassandra_TLS.md
@@ -166,6 +166,9 @@ When you have done so:
 1. Go to *Advanced* and select *This cluster requires SSL*.
 
 1. Point it towards your *rootCA.jks* truststore file and use the password you used to generate it.
+   
+> [!NOTE]
+> Currenly, we only support TLS version 1.0 for the Client-Server encryption. If connecting to cassandra over TLS fails, make sure to check that this version is not disabled on operating system level.
 
 ## Connecting with DataMiner
 

--- a/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Security_Cassandra_TLS.md
+++ b/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Security_Cassandra_TLS.md
@@ -166,9 +166,9 @@ When you have done so:
 1. Go to *Advanced* and select *This cluster requires SSL*.
 
 1. Point it towards your *rootCA.jks* truststore file and use the password you used to generate it.
-   
+
 > [!NOTE]
-> Currenly, we only support TLS version 1.0 for the Client-Server encryption. If connecting to cassandra over TLS fails, make sure to check that this version is not disabled on operating system level.
+> Currently, we only support TLS version 1.0 for the client-server encryption. If connecting to Cassandra over TLS fails, make sure to check that this version is not disabled on operating system level.
 
 ## Connecting with DataMiner
 


### PR DESCRIPTION
Added a note about the supported TLS version for cassandra Client-Server encryption.
The supported version is no longer the recommended one so it often gets disabled by company GPO's.