### PR TITLE
Add using directives to show required namespaces

### DIFF
--- a/user-guide/Advanced_Modules/DOM/DOM_ModuleSettings/ExecuteScriptOnDomInstanceActionSettings.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_ModuleSettings/ExecuteScriptOnDomInstanceActionSettings.md
@@ -9,9 +9,17 @@ This settings object contains the names of the scripts that should be executed w
 The scripts used must have a `OnDomInstanceCrud` entry point defined. This makes it possible to know for what action and `DomInstance` the script was triggered.
 
 ```csharp
-[AutomationEntryPoint(AutomationEntryPointType.Types.OnDomInstanceCrud)]
-public void OnDomInstanceCrud(Engine engine, Guid id, CrudType crudType)
+using System;
+using Skyline.DataMiner.Automation;
+using Skyline.DataMiner.Net.History;
+
+public class Script
 {
-  engine.GenerateInformation($"Script triggered for {crudType} action on DomInstance with ID: {id}");
+
+	[AutomationEntryPoint(AutomationEntryPointType.Types.OnDomInstanceCrud)]
+	public void OnDomInstanceCrud(Engine engine, Guid id, CrudType crudType)
+	{
+	  engine.GenerateInformation($"Script triggered for {crudType} action on DomInstance with ID: {id}");
+	}
 }
 ```


### PR DESCRIPTION
It is a little unexpected that CrudType is from the Skyline.DataMiner.Net.History namespace