### PR TITLE
Add note to Executable UIBlock

### DIFF
--- a/develop/devguide/Automation/UIBlockTypesOverview.md
+++ b/develop/devguide/Automation/UIBlockTypesOverview.md
@@ -118,7 +118,7 @@ Examples:
   ```
   
 > [!NOTE]
-> Automation scripts with an executable component are currently only supported in DataMiner Cube. These are not yet supported in DataMiner web apps.
+> Automation scripts with an executable component are currently only supported in DataMiner Cube. These are not supported in DataMiner web apps.
 
 ## FileSelector
 

--- a/develop/devguide/Automation/UIBlockTypesOverview.md
+++ b/develop/devguide/Automation/UIBlockTypesOverview.md
@@ -116,6 +116,9 @@ Examples:
   ...
   MyDialogBox.AppendBlock(blockItem);
   ```
+  
+> [!NOTE]
+> Automation scripts with an executable component are currently only supported in DataMiner Cube. These are not yet supported in DataMiner web apps.
 
 ## FileSelector
 


### PR DESCRIPTION
The Executable UIBlock does not work in dataminer web apps, a note was added to make this clear.