### PR TITLE
Update config_resource_scheduling.md

### DIFF
--- a/user-guide/Standard_Apps/SRM/srm_getting_started/config_resource_scheduling.md
+++ b/user-guide/Standard_Apps/SRM/srm_getting_started/config_resource_scheduling.md
@@ -56,17 +56,27 @@ A typical use case is to make use of the Resource Manager component in Visual Ov
 
    - When a user selects a time range on the timeline, the *SelectedtimeRange* variable will be populated with that time range.
 
-For example, in case you want to create a Visio drawing that will be assigned to a View, and have all resources associated with Elments part of that View presented on the Y-axis of the timeline:
-
-   - Add following shape data on page level:
-     - InitVar: `YAxisResources:[This View]`
-     - Options: `CardVariable`
-   - Add following shape data on a rectangle shape that will be used to embed the timeline:
-     - Component: `Reservations`
-     - Options: `CardVariable`
+   > [!TIP]
+   > For example, in case you want to create a Visio drawing that will be assigned to a view, and all resources associated with elements in that view should be presented on the Y-axis of the timeline:
+   >
+   > - Add the following shape data on page level:
+   >
+   >   | Shape data field | Value |
+   >   |--|--|
+   >   | InitVar | `YAxisResources:[This View]` |
+   >   | Options | `CardVariable` |
+   >
+   > - Add the following shape data on the rectangle shape that will be used to embed the timeline:
+   >
+   >   | Shape data field | Value |
+   >   | Component | `Reservations` |
+   >   | Options | `CardVariable` |
 
 1. Add a shape to the Visio drawing that executes the *SRM_BookResourcesQuickly* script, using the *SelectedResource* and *SelectedTimeRange* variables in the input data.
 
-Using same example, considering you have created a Booking Manager Element named 'Resource Scheduling', add a rectangle shape with following shape data:
-
-   - Execute: `script:SRM_BookResourcesQuickly||Input Data={"BookingManagerElement":"Resource Scheduling","TimeRange":"[RegexReplace:;,[cardvar:SelectedTimeRange],$]","ResourceIds":"[cardvar:SelectedResource]","AssignCapacityType":"Request"}|||NoConfirmation,CloseWhenFinished`
+   > [!TIP]
+   > Continuing from the same example as mentioned above, if you have a Booking Manager element named "Resource Scheduling", add a rectangle shape with the following shape data:
+   >
+   >   | Shape data field | Value |
+   >   |--|--|
+   >   | Execute | `script:SRM_BookResourcesQuickly||Input Data={"BookingManagerElement":"Resource Scheduling","TimeRange":"[RegexReplace:;,[cardvar:SelectedTimeRange],$]","ResourceIds":"[cardvar:SelectedResource]","AssignCapacityType":"Request"}|||NoConfirmation,CloseWhenFinished` |

--- a/user-guide/Standard_Apps/SRM/srm_getting_started/config_resource_scheduling.md
+++ b/user-guide/Standard_Apps/SRM/srm_getting_started/config_resource_scheduling.md
@@ -56,7 +56,17 @@ A typical use case is to make use of the Resource Manager component in Visual Ov
 
    - When a user selects a time range on the timeline, the *SelectedtimeRange* variable will be populated with that time range.
 
+For example, in case you want to create a Visio drawing that will be assigned to a View, and have all resources associated with Elments part of that View presented on the Y-axis of the timeline:
+
+   - Add following shape data on page level:
+     - InitVar: `YAxisResources:[This View]`
+     - Options: `CardVariable`
+   - Add following shape data on a rectangle shape that will be used to embed the timeline:
+     - Component: `Reservations`
+     - Options: `CardVariable`
+
 1. Add a shape to the Visio drawing that executes the *SRM_BookResourcesQuickly* script, using the *SelectedResource* and *SelectedTimeRange* variables in the input data.
 
-   > [!NOTE]
-   > A custom conversion script is needed to make sure the format of *SelectedTimeRange* matches what the wizard expects.
+Using same example, considering you have created a Booking Manager Element named 'Resource Scheduling', add a rectangle shape with following shape data:
+
+   - Execute: `script:SRM_BookResourcesQuickly||Input Data={"BookingManagerElement":"Resource Scheduling","TimeRange":"[RegexReplace:;,[cardvar:SelectedTimeRange],$]","ResourceIds":"[cardvar:SelectedResource]","AssignCapacityType":"Request"}|||NoConfirmation,CloseWhenFinished`


### PR DESCRIPTION
Added example to make Resource Scheduling more accessible for end users 
Removed the need for a conversion script, as this is no longer required