### PR TITLE
Incorrect Example

### DIFF
--- a/develop/schemadoc/Protocol/Protocol.Params.Param-confirmPopup.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param-confirmPopup.md
@@ -21,5 +21,5 @@ Overrides the "*Never ask for confirmation after setting parameter value*" setti
 ## Examples
 
 ```xml
-<Param id="1" backup="true">
+<Param id="1" confirmPopup="always">
 ```


### PR DESCRIPTION
The provided example is not correct since it's using the backup attribute instead of the confirmPopup one.