### PR TITLE
Change path of elasticsearch.yml in Linux and Windows

### DIFF
--- a/user-guide/Advanced_Functionality/Databases/Elasticsearch_database/Configuring_Elasticsearch_backups/Configuring_Elasticsearch_backups_Windows_Linux.md
+++ b/user-guide/Advanced_Functionality/Databases/Elasticsearch_database/Configuring_Elasticsearch_backups/Configuring_Elasticsearch_backups_Windows_Linux.md
@@ -97,11 +97,11 @@ Examples:
 
    - For Windows: `C:\Program Files\Elasticsearch\logs\[cluster.name].log`
 
-     You can find the cluster name in `/etc/Elasticsearch/Elasticsearch.yml`.
+     You can find the cluster name in `C:\Program Files\Elasticsearch\config\Elasticsearch.yml`.
 
    - For Linux: `/var/log/elasticsearch/[cluster.name].log`
 
-     You can find the cluster name in `C:\Program Files\Elasticsearch\config\Elasticsearch.yml`.
+     You can find the cluster name in `/etc/Elasticsearch/Elasticsearch.yml`.
 
    If you do not have enough rights to the shared folder, use the `chmod` and `chown` command.
 


### PR DESCRIPTION
It was the opposite path. The windows path was on the Linux and the Linux on the Windows