### PR TITLE
Fixed StandaloneElasticBackupTool argument name casing

### DIFF
--- a/user-guide/Reference/DataMiner_Tools/Standalone_Elastic_Backup_Tool.md
+++ b/user-guide/Reference/DataMiner_Tools/Standalone_Elastic_Backup_Tool.md
@@ -72,7 +72,7 @@ To take a backup/snapshot, use the following arguments:
   - If none is defined and only one repository is found in the Elasticsearch cluster, then that one will be used.
   - If none is defined and none can be found, no backup will be taken.
 
-- `--snapshotname` or `-n`: The (lowercase) name of the snapshot to be taken.
+- `--SnapshotName` or `-n`: The (lowercase) name of the snapshot to be taken.
 
   Default: `DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss");`
 
@@ -82,7 +82,7 @@ To restore a backup/snapshot, use the following arguments:
 
 - `--repo` or `-r`: The repository containing the backup to be restored. If none is defined and only one repository is found in the Elasticsearch cluster, then that one will be used. If none is defined and none can be found, an error will be thrown.
 
-- `--snapshotname` or `-n`: The name of the snapshot to be restored.
+- `--SnapshotName` or `-n`: The name of the snapshot to be restored.
 
 > [!NOTE]
 >


### PR DESCRIPTION
The argument name is 'SnapshotName', documentation said 'snapshotname'. The exe fails when executing with the argument in lowercase.