### PR TITLE
Update GRPCConnection type example

### DIFF
--- a/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/ConnectionSettings_txt.md
+++ b/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/ConnectionSettings_txt.md
@@ -131,5 +131,5 @@ This file contains default connection settings to be used by DataMiner client ap
   ```txt
   10.10.7.1 type=RemotingConnection;polling=1000;zip=true
   10.11.*;168.* type=RemotingConnection;polling=1000;zip=false
-  * type=RemotingConnection;polling=0;zip=true
+  * type=RemotingConnection
   ```


### PR DESCRIPTION
Previous example was confusing, as "polling" and "zip" aren't valid options for the GRPCConnection type. Refer https://community.dataminer.services/question/grpc-connection-polling-value-required-when-configured-on-dms-running-the-latest-v10-3-2/ I expect further improvements will be provided by Bert B (as mentioned in his post).