### PR TITLE
Dynamic drop-down read parameter type string

### DIFF
--- a/develop/devguide/Connector/UIComponentsDropDownList.md
+++ b/develop/devguide/Connector/UIComponentsDropDownList.md
@@ -200,7 +200,7 @@ When you add a drop-down list, it is possible to show a check box for one entry 
 When a standard drop-down list is configured, the items to choose from are statically defined in the protocol. Alternatively, you can also create a dynamic drop-down list. To do so, create a parameter that holds the dynamic entries in a parameter (by providing a semicolon-separated list of entries) and refer to this parameter using the dependencyId attribute.
 
 ```xml
-<Param id="400">
+<Param id="400" trending="false">
   <Name>DynamicDependencyLinkSpeed</Name>
   <Description>Link Speed</Description>
   <Information>
@@ -229,9 +229,7 @@ When a standard drop-down list is configured, the items to choose from are stati
      </Positions>
   </Display>
   <Measurement>
-     <Type>discreet</Type>
-     <Discreets dependencyId="402">
-     </Discreets>
+     <Type>string</Type>
   </Measurement>
 </Param>
 <Param id="401" setter="true">


### PR DESCRIPTION
The read parameter of which the write parameter has a dynamic drop-down list should be a normal string type parameter. It's the write parameter that provides the drop-down list that the user can select items from. The read parameter is simply displaying this as a string value, there is no need to link that to the dependencyId parameter. Also added the trending="false" attribute for consistency as there is no alarm monitoring present.