### PR TITLE
Add remark about the required parameters for PA PLS

### DIFF
--- a/user-guide/Standard_Apps/PA/Getting_Started_with_PA/Creating_Activities/PA_Creating_script_tasks.md
+++ b/user-guide/Standard_Apps/PA/Getting_Started_with_PA/Creating_Activities/PA_Creating_script_tasks.md
@@ -141,8 +141,8 @@ uid: PA_Creating_script_tasks
       > [!NOTE]
       > In the C# block, never try to directly retrieve data from the DOM instance, as this can have unexpected results.
 
-      > [!IMPORTANT]
-      > Check that the script has three parameters: *Info*, *ProcessInfo* and *ProfileInstance*.
+   > [!IMPORTANT]
+   > The script must have three parameters: *Info*, *ProcessInfo*, and *ProfileInstance*. Double-check to make sure that this is indeed the case.
 
 1. Link the script with the profile definition you created earlier.
 

--- a/user-guide/Standard_Apps/PA/Getting_Started_with_PA/Creating_Activities/PA_Creating_script_tasks.md
+++ b/user-guide/Standard_Apps/PA/Getting_Started_with_PA/Creating_Activities/PA_Creating_script_tasks.md
@@ -141,6 +141,9 @@ uid: PA_Creating_script_tasks
       > [!NOTE]
       > In the C# block, never try to directly retrieve data from the DOM instance, as this can have unexpected results.
 
+      > [!IMPORTANT]
+      > Check that the script has three parameters: *Info*, *ProcessInfo* and *ProfileInstance*.
+
 1. Link the script with the profile definition you created earlier.
 
    1. Go to the *Profiles* module and select your previously created profile definition in the *Definitions* tab.


### PR DESCRIPTION
Add remark about the required parameters on a script task profile load script.

Although the screenshot show those parameters and the PLS template should be copied, it might be unclear that they're needed.