### PR TITLE
Added note of Newtonsoft version

### DIFF
--- a/user-guide/Standard_Apps/SRM/srm_getting_started/implementing_virtual_functions/creating_profile_load_scripts.md
+++ b/user-guide/Standard_Apps/SRM/srm_getting_started/implementing_virtual_functions/creating_profile_load_scripts.md
@@ -65,7 +65,7 @@ var nodeProfileConfiguration = LoadNodeProfileConfiguration(engine);
 var helper = new ProfileParameterEntryHelper(engine, configurationInfo?.OrchestrationLogger);
 ```
 > [!NOTE]
-> When working in Visual Studio, make sure to add a reference to Newtonsoft 11.x. Newer versions of Newtonsoft might not work together with the SRM framework.
+> When working in Visual Studio, make sure to add a reference to Newtonsoft 13.x if you use SRM 1.2.30 or higher, or Newtonsoft 11.x for older SRM versions. Newer versions of Newtonsoft might not work together with the SRM framework.
 
 ### Retrieving profile parameter values
 

--- a/user-guide/Standard_Apps/SRM/srm_getting_started/implementing_virtual_functions/creating_profile_load_scripts.md
+++ b/user-guide/Standard_Apps/SRM/srm_getting_started/implementing_virtual_functions/creating_profile_load_scripts.md
@@ -64,6 +64,8 @@ var configurationInfo = LoadResourceConfigurationInfo(engine);
 var nodeProfileConfiguration = LoadNodeProfileConfiguration(engine);
 var helper = new ProfileParameterEntryHelper(engine, configurationInfo?.OrchestrationLogger);
 ```
+> [!NOTE]
+> When working in Visual Studio, make sure to add a reference to Newtonsoft 11.x. Newer versions of Newtonsoft might not work together with the SRM framework.
 
 ### Retrieving profile parameter values
 


### PR DESCRIPTION
All PLS scripts do need to use Newtonsoft version 11.x to avoid PLS crashes. From SRM 1.2.30 onwards (not released yet) you'll have to use version 13.x