### PR TITLE
Update docs on securing databases to account for the changed TLS cert. generation scripts

### DIFF
--- a/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Security_Cassandra_TLS.md
+++ b/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Security_Cassandra_TLS.md
@@ -122,16 +122,16 @@ To enable client-server TLS encryption:
 
 1. Copy the Java Keystore (.jks file), or the PKCS12 store (.p12 file) if you used a script to generate the certificates, to the node
 
-2. Open the *cassandra.yaml* file, and locate the *client_encryption_options*.
+1. Open the *cassandra.yaml* file, and locate the *client_encryption_options*.
 
-3. Set *enabled* to **true** to enable TLS.
+1. Set *enabled* to **true** to enable TLS.
 
-4. Set *optional* to **false** to make sure TLS encrypted is required.
+1. Set *optional* to **false** to make sure TLS encrypted is required.
 
    > [!NOTE]
    > In order to test your changes without production impact, you can set *optional* to **true** until you have verified whether you can connect using TLS.
 
-5. Set *keystore* to the path to the .jks file containing the certificates. Set *keystore_password* to the *&lt;STRONG PASSWORD&gt;* you used to generate them.
+1. Set *keystore* to the path to the .jks file containing the certificates. Set *keystore_password* to the *&lt;STRONG PASSWORD&gt;* you used to generate them.
 
    ```txt
    client_encryption_options:
@@ -142,7 +142,7 @@ To enable client-server TLS encryption:
       keystore_password: <STRONG PASSWORD>
    ```
 
-6. Save the changes in the *cassandra.yaml* and **restart** the Cassandra service.
+1. Save the changes in the *cassandra.yaml* and **restart** the Cassandra service.
 
 ## Configuring the server_encryption_options
 

--- a/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Security_Cassandra_TLS.md
+++ b/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Security_Cassandra_TLS.md
@@ -120,29 +120,29 @@ The *client_encryption_options* allow you to encrypt all the traffic between Dat
 
 To enable client-server TLS encryption:
 
-1. Copy the Java KeyStores to the node
+1. Copy the Java Keystore (.jks file), or the PKCS12 store (.p12 file) if you used a script to generate the certificates, to the node
 
-1. Open the *cassandra.yaml* file, and locate the *client_encryption_options*.
+2. Open the *cassandra.yaml* file, and locate the *client_encryption_options*.
 
-1. Set *enabled* to **true** to enable TLS.
+3. Set *enabled* to **true** to enable TLS.
 
-1. Set *optional* to **false** to make sure TLS encrypted is required.
+4. Set *optional* to **false** to make sure TLS encrypted is required.
 
    > [!NOTE]
    > In order to test your changes without production impact, you can set *optional* to **true** until you have verified whether you can connect using TLS.
 
-1. Set *keystore* to the path to the .jks file containing the certificates. Set *keystore_password* to the *&lt;STRONG PASSWORD&gt;* you used to generate them.
+5. Set *keystore* to the path to the .jks file containing the certificates. Set *keystore_password* to the *&lt;STRONG PASSWORD&gt;* you used to generate them.
 
    ```txt
    client_encryption_options:
       enabled: true
       # If enabled and optional is set to true, both encrypted and unencrypted connections are handled.
       optional: false
-      keystore: path/to/<NODE IP>.jks
+      keystore: path/to/<NODE CERT STORE>
       keystore_password: <STRONG PASSWORD>
    ```
 
-1. Save the changes in the *cassandra.yaml* and **restart** the Cassandra service.
+6. Save the changes in the *cassandra.yaml* and **restart** the Cassandra service.
 
 ## Configuring the server_encryption_options
 
@@ -150,7 +150,7 @@ The *server_encryption_options* allow you to encrypt all the traffic between the
 
 To enable inter-node TLS encryption:
 
-1. Copy the Java KeyStores to the corresponding node
+1. Copy the Java Keystore (.jks file), or the PKCS12 store (.p12 file) if you used a script to generate the certificates, to the corresponding node
 
 1. Open the *cassandra.yaml* file, and locate the *server_encryption_options*.
 
@@ -168,9 +168,9 @@ To enable inter-node TLS encryption:
       internode_encryption: all
       # If enabled and optional is set to true, both encrypted and unencrypted connections are handled.
       optional: false
-      keystore: path/to/<NODE IP>.jks
+      keystore: path/to/<NODE CERT STORE>
       keystore_password: <YOUR PASSWORD>
-      truststore: /path/to/<NODE IP>.jks
+      truststore: /path/to/<NODE CERT STORE>
       truststore_password: <YOUR PASSWORD>
    ```
 

--- a/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Elasticsearch.md
+++ b/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Elasticsearch.md
@@ -71,14 +71,14 @@ By default all client-server communication with Elasticsearch is unencrypted.
 
 To configure TLS encryption for client-server communication:
 
-1. Request or generate a TLS certificate (the certificates should be in the PKCS#12 format). Make sure the IP address of the node is included in the *Subject Alternative Names* of the certificate.
+1. Request or generate a TLS certificate (the certificates should be in the PKCS#12 format). Make sure the IP address of the node is included in the *Subject Alternative Names* of the certificate. Elasticsearch comes with the `elasticsearch-certutil` tool installed, which can be used to generate certificates. However, we recommend that you use our [scripts for generating TLS certificates](https://github.com/SkylineCommunications/generate-tls-certificates), available on GitHub. There is a version of the script for Linux and Windows machines. The script requires two tools: *openssl* and the *Java keytool*. Both of these can run on Linux and Windows.
 
 1. Add the following lines to the *elasticsearch.yml* file:
 
    ```
    xpack.security.http.ssl.enabled: true
-   xpack.security.http.ssl.keystore.path: path/to/your/certificate
-   xpack.security.http.ssl.truststore.path: path/to/your/certificate
+   xpack.security.http.ssl.keystore.path: path/to/your/<NODE CERT STORE>
+   xpack.security.http.ssl.truststore.path: path/to/your/<NODE CERT STORE>
    ```
 
    If you are using a `.PEM` certificate generated using `openssl` utility, add the following lines to the *elasticsearch.yml* file instead:
@@ -93,7 +93,7 @@ To configure TLS encryption for client-server communication:
     of each node in cluster.
     ```
 
-1. Optionally, **for password-protected certificates**, execute the following commands **as Administrator** and enter the password when prompted:
+1. **For cert stores generated with the script or password-protected certificates**, execute the following commands **as Administrator** and enter the password when prompted:
 
    ```
    bin\elasticsearch-keystore add xpack.security.http.ssl.keystore.secure_password
@@ -143,7 +143,7 @@ To configure TLS encryption for inter-node communication:
     of each node in cluster.
     ```
 
-1. If you secured the node's certificate with a password, add the password to your Elasticsearch keystore by executing the following commands:
+1. For cert stores generated with the script or if you secured the node's certificate with a password, add the password to your Elasticsearch keystore by executing the following commands:
 
    ```
    bin/elasticsearch-keystore add xpack.security.transport.ssl.keystore.secure_password

--- a/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Elasticsearch.md
+++ b/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Elasticsearch.md
@@ -71,7 +71,9 @@ By default all client-server communication with Elasticsearch is unencrypted.
 
 To configure TLS encryption for client-server communication:
 
-1. Request or generate a TLS certificate (the certificates should be in the PKCS#12 format). Make sure the IP address of the node is included in the *Subject Alternative Names* of the certificate. Elasticsearch comes with the `elasticsearch-certutil` tool installed, which can be used to generate certificates. However, we recommend that you use our [scripts for generating TLS certificates](https://github.com/SkylineCommunications/generate-tls-certificates), available on GitHub. There is a version of the script for Linux and Windows machines. The script requires two tools: *openssl* and the *Java keytool*. Both of these can run on Linux and Windows.
+1. Request or generate a TLS certificate (the certificates should be in the PKCS#12 format). Make sure the IP address of the node is included in the *Subject Alternative Names* of the certificate.
+
+   Elasticsearch comes with the `elasticsearch-certutil` tool installed, which can be used to generate certificates. However, we recommend that you **use our [scripts for generating TLS certificates](https://github.com/SkylineCommunications/generate-tls-certificates)**, available on GitHub. There is a version of the script for Linux and Windows machines. The script requires two tools: *openssl* and the *Java keytool*. Both of these can run on Linux and Windows.
 
 1. Add the following lines to the *elasticsearch.yml* file:
 


### PR DESCRIPTION
The script to generate TLS certificates were changed to allow them to be used for elastic as well, so the docs have to be changed as well to account for the changed scripts