### PR TITLE
User-defined API load testing benchmarks [RN35880] [DCP206612]

### DIFF
--- a/user-guide/Reference/Metrics/dataminer_metrics.md
+++ b/user-guide/Reference/Metrics/dataminer_metrics.md
@@ -68,5 +68,6 @@ All specifications are provided based on the assumption that DMAs are running on
 - [Service benchmarks](xref:service_benchmarks)
 - [Service profile benchmarks](xref:service_profile_benchmarks)
 - [Service & Resource Management benchmarks](xref:service_resource_management_benchmarks)
+- [User-defined API benchmarks](xref:user-defined_API_benchmarks)
 - [View benchmarks](xref:view_benchmarks)
 - [Visual Overview benchmarks](xref:visual_overview_benchmarks)

--- a/user-guide/Reference/Metrics/user-defined_API_benchmarks.md
+++ b/user-guide/Reference/Metrics/user-defined_API_benchmarks.md
@@ -1,0 +1,28 @@
+---
+uid: user-defined_API_benchmarks
+---
+
+# User-defined API benchmarks
+
+## Specifications of the test VM server 1
+
+- Intel Core i7-12700
+- 8 cores
+- 32GB RAM
+- HDD
+- Windows 10
+
+## Specifications of the test client PC 1
+
+- Intel Core i7-12700
+- 12 cores
+- 32GB DDR-5 RAM
+- SSD
+- Windows 11
+
+## Benchmarks
+
+| \# | Specification | Scope | Metric | Configuration |
+| -- | ------------- | ----- | ------ | ------------- |
+| 1 | Server call duration of 2500 API tokens and 2500 API definitions from server 1 to client 1 | DMA | 2s - 2.5s | Clean DMA, no other data |
+| 2 | Load testing of 2500 API tokens and 2500 API definitions in DataMiner Cube of client 1 | Cube | 3s - 3.5s | Clean DMA, no other data |

--- a/user-guide/Reference/Metrics/user-defined_API_benchmarks.md
+++ b/user-guide/Reference/Metrics/user-defined_API_benchmarks.md
@@ -4,7 +4,7 @@ uid: user-defined_API_benchmarks
 
 # User-defined API benchmarks
 
-## Specifications of the test VM server 1
+## Specifications of the test VM server
 
 - Intel Core i7-12700
 - 8 cores
@@ -12,7 +12,7 @@ uid: user-defined_API_benchmarks
 - HDD
 - Windows 10
 
-## Specifications of the test client PC 1
+## Specifications of the test client
 
 - Intel Core i7-12700
 - 12 cores
@@ -24,5 +24,5 @@ uid: user-defined_API_benchmarks
 
 | \# | Specification | Scope | Metric | Configuration |
 | -- | ------------- | ----- | ------ | ------------- |
-| 1 | Server call duration of 2500 API tokens and 2500 API definitions from server 1 to client 1 | DMA | 2s - 2.5s | Clean DMA, no other data |
-| 2 | Load testing of 2500 API tokens and 2500 API definitions in DataMiner Cube of client 1 | Cube | 3s - 3.5s | Clean DMA, no other data |
+| 1 | Time for the client to retrieve 2500 API tokens and 2500 API definitions from the server | DMA | 2s - 2.5s | Clean DMA without other data |
+| 2 | Time for the client to show 2500 API tokens and 2500 API definitions in DataMiner Cube (including the time to retrieve these from the server) | Cube | 3s - 3.5s | Clean DMA without other data |


### PR DESCRIPTION
server load and client load benchmarks when loading 2500 API tokens and 2500 API definitions.