### PR TITLE
Changes to the filterConfig file

### DIFF
--- a/filterConfig.yml
+++ b/filterConfig.yml
@@ -1,6 +1,6 @@
 apiRules:
 - include:
-    uiRegex: ^Skyline\.DataMiner\.Net\.AutomationUI\.Objects
+    uidRegex: ^Skyline\.DataMiner\.Net\.AutomationUI\.Objects
     type: Namespace
 - exclude:
     uidRegex: ^Tamir\.SharpSsh\.jsch\.ChannelSftp$
@@ -520,15 +520,6 @@ apiRules:
     type: Namespace
 - include:
     uidRegex: ^Skyline\.DataMiner\.Net\.Trending$
-    type: Namespace
-- exclude:
-    uidRegex: ^Skyline\.DataMiner\.
-    type: Namespace
-- exclude:
-    uidRegex: ^Skyline\.DataMiner\.*$
-    type: Namespace
-- exclude:
-    uidRegex: ^Skyline\.DataMiner\.Net\.*$
     type: Namespace
 - exclude:
     uidRegex: ^SLDataGateway\.


### PR DESCRIPTION
- Typo in first rule results in not correctly parsing the rest of the rules.
- Excluding a namespace doesn't make it possible to separately include classes