### PR TITLE
Update user-defined API navigation

### DIFF
--- a/user-guide/Advanced_Functionality/Security/DataMiner_user_permissions.md
+++ b/user-guide/Advanced_Functionality/Security/DataMiner_user_permissions.md
@@ -1664,15 +1664,15 @@ Permission to create and edit tokens for user-defined APIs.
 
 Permission to delete tokens for user-defined APIs.
 
-#### Modules \> User-defined APIs \> Definitions \> UI available
+#### Modules \> User-defined APIs \> APIs \> UI available
 
 Permission to view API definitions for user-defined APIs.
 
-#### Modules \> User-defined APIs \> Definitions \> Add/Edit
+#### Modules \> User-defined APIs \> APIs \> Add/Edit
 
 Permission to create and edit API definitions for user-defined APIs. In order to create or edit API definitions, you also need the [Automation > execute](#modules--automation--execute) permission.
 
-#### Modules \> User-defined APIs \> Definitions \> Delete
+#### Modules \> User-defined APIs \> APIs \> Delete
 
 Permission to delete API definitions for user-defined APIs.
 


### PR DESCRIPTION
the security group of API definition is changed to API. this should also be reflected in the documentation.