### PR TITLE
Update Querying_an_Elasticsearch_database.md

### DIFF
--- a/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
+++ b/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
@@ -46,6 +46,68 @@ This will return the name of the index, the state of the index, and its size.
 
 Especially the name and state of the index may be interesting for debugging purposes.
 
+### Manually setting the replication counts for indices
+
+To get the relevent information on all indices and set replication count in the Elasticsearch database, enter the query below.
+
+```txt
+GET _cluster/health?level=shards&pretty
+```
+
+This will return the name of the indices, state of the indices and number of replica set as following.
+
+```txt
+ "indices" : {
+    "dms-alarms-2022.06.11.05-000016" : {
+      "status" : "green",
+      "number_of_shards" : 3,
+      "number_of_replicas" : 0,
+      "active_primary_shards" : 3,
+      "active_shards" : 3,
+      "relocating_shards" : 0,
+      "initializing_shards" : 0,
+      "unassigned_shards" : 0,
+      "shards" : {
+        "0" :
+    },
+    "dms-alarms-2023.03.22.10-000063" : {
+      "status" : "green",
+      "number_of_shards" : 3,
+      "number_of_replicas" : 0,
+      "active_primary_shards" : 3,
+      "active_shards" : 3,
+      "relocating_shards" : 0,
+      "initializing_shards" : 0,
+      "unassigned_shards" : 0,
+      "shards" : {
+        "0" :
+    },
+```
+
+To manually set the replica count to 2 use the following query.
+
+```txt
+PUT /<my-index>/_settings
+{
+  "index" :{
+    "number_of_replica" : 2
+  }
+}
+```
+
+To set the replica count to 2 for all of the indices use the following query.
+
+```txt
+PUT /all/_settings
+{
+  "index" :{
+    "number_of_replica" : 2
+  }
+}
+```
+
+
+
 ### Retrieving the number of hits + example records
 
 To query a specific index, use the *_search* functionality:

--- a/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
+++ b/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
@@ -48,10 +48,10 @@ Especially the name and state of the index may be interesting for debugging purp
 
 ### Manually setting the replication count for indices
 
-Follosing commands allow you to alter the number of replicas (per shard) for indices matching the specific criteria. This is useful if you would like to reduce your per-node shard count and also if there are more replicas then the number of nodes, which is not very useful and put an unnecessary strain to the system. Furthermore you can use it to cutomize the availability of your ElasticSearch database.
+With the queries below, you can alter the number of replicas (per shard) for indices matching the specific criteria. This is useful if you want to reduce your per-node shard count, and also if there are more replicas than the number of nodes, which can put an unnecessary strain on the system. You can also use it to customize the availability of your Elasticsearch database.
 
-Note:
-This setting only applies for current data and does not apply to new data. As the newer data added by DataMiner will again have the default amount of replicas.
+> [!NOTE]
+> This setting only applies for current data. It does not apply to new data. The newer data added by DataMiner will again have the default number of replicas.
 
 To set the replication count for indices in the Elasticsearch database, first enter the query below:
 
@@ -111,7 +111,8 @@ PUT /all/_settings
 }
 ```
 
-Note: For ElasticSearch version 6.8.23 replace PUT /all/_settings with PUT /*/_settings as PUT /all/_settings does not work with ElasticSearch version 6.8.23
+> [!NOTE]
+> For Elasticsearch version 6.8.23, replace `PUT /all/_settings` with `PUT /*/_settings`. The former does not work with that version of Elasticsearch.
 
 ### Retrieving the number of hits + example records
 

--- a/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
+++ b/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
@@ -48,11 +48,10 @@ Especially the name and state of the index may be interesting for debugging purp
 
 ### Manually setting the replication count for indices
 
-The following commands allow you to alter the number of replicas per shard.
-This would typically be used to configure redundancy and availability based on the amount of Elasticsearch nodes you have available.
+With the queries below, you can alter the number of replicas per shard. This is typically done to configure redundancy and availability based on the number of Elasticsearch nodes you have available.
 
 > [!TIP]
-> If the amount of shards you have is too large, decreasing the amount of replicas per shard is one option to decrease the strain on the system.
+> If the number of shards you have is too large, decreasing the number of replicas per shard is one option to decrease the strain on the system.
 
 > [!NOTE]
 > This setting only applies for current data. It does not apply to new data. The newer data added by DataMiner will again have the default number of replicas.

--- a/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
+++ b/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
@@ -51,8 +51,8 @@ Especially the name and state of the index may be interesting for debugging purp
 The following commands allow you to alter the number of replicas per shard.
 This would typically be used to configure redundancy and availability based on the amount of Elasticsearch nodes you have available.
 
-!TIP
-If the amount of shards you have is too large, decreasing the amount of replicas per shard is one option to decrease the strain on the system.
+> [!TIP]
+> If the amount of shards you have is too large, decreasing the amount of replicas per shard is one option to decrease the strain on the system.
 
 > [!NOTE]
 > This setting only applies for current data. It does not apply to new data. The newer data added by DataMiner will again have the default number of replicas.

--- a/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
+++ b/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
@@ -48,7 +48,11 @@ Especially the name and state of the index may be interesting for debugging purp
 
 ### Manually setting the replication count for indices
 
-With the queries below, you can alter the number of replicas (per shard) for indices matching the specific criteria. This is useful if you want to reduce your per-node shard count, and also if there are more replicas than the number of nodes, which can put an unnecessary strain on the system. You can also use it to customize the availability of your Elasticsearch database.
+The following commands allow you to alter the number of replicas per shard.
+This would typically be used to configure redundancy and availability based on the amount of Elasticsearch nodes you have available.
+
+!TIP
+If the amount of shards you have is too large, decreasing the amount of replicas per shard is one option to decrease the strain on the system.
 
 > [!NOTE]
 > This setting only applies for current data. It does not apply to new data. The newer data added by DataMiner will again have the default number of replicas.
@@ -111,8 +115,6 @@ PUT /all/_settings
 }
 ```
 
-> [!NOTE]
-> For Elasticsearch version 6.8.23, replace `PUT /all/_settings` with `PUT /*/_settings`. The former does not work with that version of Elasticsearch.
 
 ### Retrieving the number of hits + example records
 

--- a/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
+++ b/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
@@ -22,9 +22,9 @@ To connect to Kibana:
 1. On the server with the Elasticsearch database, navigate to `C:\Program Files\Elasticsearch\Kibana\bin` and run *Kibana.bat* as an administrator.
 
     > [!TIP]
-    > We recommend to run *Kibana.bat* using an elevated command line, as it takes a while to start the Kibana server and this will allow you to see when it has started.
+    > We recommend running *Kibana.bat* using an elevated command line, as it takes a while to start the Kibana server and this will allow you to see when it has started.
 
-2. Open any browser window and navigate to <http://ElasticNodeIP:5601> (e.g. <http://127.0.0.1:5601>) to access Kibana.
+1. Open any browser window and navigate to <http://ElasticNodeIP:5601> (e.g. <http://127.0.0.1:5601>) to access Kibana.
 
 ## Basic queries
 
@@ -46,15 +46,15 @@ This will return the name of the index, the state of the index, and its size.
 
 Especially the name and state of the index may be interesting for debugging purposes.
 
-### Manually setting the replication counts for indices
+### Manually setting the replication count for indices
 
-To get the relevent information on all indices and set replication count in the Elasticsearch database, enter the query below.
+To set the replication count for indices in the Elasticsearch database, first enter the query below:
 
 ```txt
 GET _cluster/health?level=shards&pretty
 ```
 
-This will return the name of the indices, state of the indices and number of replica set as following.
+This will return the name of the indices, the state of the indices, and the number of replicas:
 
 ```txt
  "indices" : {
@@ -84,7 +84,7 @@ This will return the name of the indices, state of the indices and number of rep
     },
 ```
 
-To manually set the replica count to 2 use the following query.
+You can then for example set the replica count to 2 for a specific index using the following query:
 
 ```txt
 PUT /<my-index>/_settings
@@ -95,7 +95,7 @@ PUT /<my-index>/_settings
 }
 ```
 
-To set the replica count to 2 for all of the indices use the following query.
+To set the replica count to 2 for all indices, use the following query:
 
 ```txt
 PUT /all/_settings
@@ -105,8 +105,6 @@ PUT /all/_settings
   }
 }
 ```
-
-
 
 ### Retrieving the number of hits + example records
 

--- a/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
+++ b/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
@@ -106,7 +106,7 @@ PUT /<my-index>/_settings
 To set the replica count to 2 for all indices, use the following query:
 
 ```txt
-PUT /all/_settings
+PUT /_all/_settings
 {
   "index" :{
     "number_of_replicas" : 2

--- a/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
+++ b/user-guide/Advanced_Functionality/Databases/Database_queries/Querying_an_Elasticsearch_database.md
@@ -48,6 +48,11 @@ Especially the name and state of the index may be interesting for debugging purp
 
 ### Manually setting the replication count for indices
 
+Follosing commands allow you to alter the number of replicas (per shard) for indices matching the specific criteria. This is useful if you would like to reduce your per-node shard count and also if there are more replicas then the number of nodes, which is not very useful and put an unnecessary strain to the system. Furthermore you can use it to cutomize the availability of your ElasticSearch database.
+
+Note:
+This setting only applies for current data and does not apply to new data. As the newer data added by DataMiner will again have the default amount of replicas.
+
 To set the replication count for indices in the Elasticsearch database, first enter the query below:
 
 ```txt
@@ -90,7 +95,7 @@ You can then for example set the replica count to 2 for a specific index using t
 PUT /<my-index>/_settings
 {
   "index" :{
-    "number_of_replica" : 2
+    "number_of_replicas" : 2
   }
 }
 ```
@@ -101,10 +106,12 @@ To set the replica count to 2 for all indices, use the following query:
 PUT /all/_settings
 {
   "index" :{
-    "number_of_replica" : 2
+    "number_of_replicas" : 2
   }
 }
 ```
+
+Note: For ElasticSearch version 6.8.23 replace PUT /all/_settings with PUT /*/_settings as PUT /all/_settings does not work with ElasticSearch version 6.8.23
 
 ### Retrieving the number of hits + example records
 


### PR DESCRIPTION
I have added the following section.

Manually setting the replication counts for indices

To get the relevent information on all indices and set replication count in the Elasticsearch database, enter the query below.

GET _cluster/health?level=shards&pretty

This will return the name of the indices, state of the indices and number of replica set as following.


  "indices" : {
    "dms-alarms-2022.06.11.05-000016" : {
      "status" : "green",
      "number_of_shards" : 3,
      "number_of_replicas" : 0,
      "active_primary_shards" : 3,
      "active_shards" : 3,
      "relocating_shards" : 0,
      "initializing_shards" : 0,
      "unassigned_shards" : 0,
      "shards" : {
        "0" :
    },
    "dms-alarms-2023.03.22.10-000063" : {
      "status" : "green",
      "number_of_shards" : 3,
      "number_of_replicas" : 0,
      "active_primary_shards" : 3,
      "active_shards" : 3,
      "relocating_shards" : 0,
      "initializing_shards" : 0,
      "unassigned_shards" : 0,
      "shards" : {
        "0" :
    },


To manually set the replica count to 2 use the following query.

PUT /<my-index>/_settings
{
  "index" :{
    "number_of_replica" : 2
  }
}

To set the replica count to 2 for all of the indices use the following query.

PUT /all/_settings
{
  "index" :{
    "number_of_replica" : 2
  }
}