### PR TITLE
Added Note in case multiple Threads are defined

### DIFF
--- a/develop/schemadoc/Protocol/Protocol.Groups.Group-connection.md
+++ b/develop/schemadoc/Protocol/Protocol.Groups.Group-connection.md
@@ -21,7 +21,7 @@ In case of multiple connections, you can use this attribute to specify the conne
 Default port: 0
 
 > [!NOTE]
-> In case extra [Threads](xref:Protocol.Threads.Thread) are defined in the protocol, make sure every poll group has this connection attribute defined to indicate which thread to use. 
+> In case extra [threads](xref:Protocol.Threads.Thread) are defined in the protocol, make sure every poll group has this connection attribute defined to indicate which thread to use. 
 
 Example:
 

--- a/develop/schemadoc/Protocol/Protocol.Groups.Group-connection.md
+++ b/develop/schemadoc/Protocol/Protocol.Groups.Group-connection.md
@@ -20,6 +20,9 @@ In case of multiple connections, you can use this attribute to specify the conne
 
 Default port: 0
 
+> [!NOTE]
+> In case extra [Threads](xref:Protocol.Threads.Thread) are defined in the protocol, make sure every poll group has this connection attribute defined to indicate which thread to use. 
+
 Example:
 
 ```xml


### PR DESCRIPTION
Added note in case multiple threads are defined in the protocol, that the connection attribute should be defined to indicate which thread to use.