### PR TITLE
Added note with reason for group-connection

### DIFF
--- a/develop/schemadoc/Protocol/Protocol.Threads.Thread.md
+++ b/develop/schemadoc/Protocol/Protocol.Threads.Thread.md
@@ -60,3 +60,6 @@ To link a group to a thread, set the connection attribute to the connection ID o
   </Content>
 </Group>
 ```
+
+> [!NOTE]
+> When using multiple threads, it is important that each poll group has the [connection](xref:Protocol.Groups.Group-connection) attribute defined to indicate which connection/thread to use. This can avoid unexpected behavior on SLPort when the same group is executed on different threads in a similar time frame.

--- a/develop/schemadoc/Protocol/Protocol.Threads.Thread.md
+++ b/develop/schemadoc/Protocol/Protocol.Threads.Thread.md
@@ -62,4 +62,4 @@ To link a group to a thread, set the connection attribute to the connection ID o
 ```
 
 > [!NOTE]
-> When using multiple threads, it is important that each poll group has the [connection](xref:Protocol.Groups.Group-connection) attribute defined to indicate which connection/thread to use. This can avoid unexpected behavior on SLPort when the same group is executed on different threads in a similar time frame.
+> When multiple threads are used, it is important that each poll group has the [connection](xref:Protocol.Groups.Group-connection) attribute defined to indicate which connection/thread to use. This can avoid unexpected behavior in SLPort when the same group is executed on different threads in a similar time frame.

--- a/develop/schemadoc/Protocol/Protocol.Threads.Thread.md
+++ b/develop/schemadoc/Protocol/Protocol.Threads.Thread.md
@@ -62,4 +62,4 @@ To link a group to a thread, set the connection attribute to the connection ID o
 ```
 
 > [!NOTE]
-> When multiple threads are used, it is important that each poll group has the [connection](xref:Protocol.Groups.Group-connection) attribute defined to indicate which connection/thread to use. This can avoid unexpected behavior in SLPort when the same group is executed on different threads in a similar time frame.
+> When multiple threads are used, it is important that each poll group has the [connection](xref:Protocol.Groups.Group-connection) attribute defined to indicate which connection/thread to use. This prevents unexpected behavior in SLPort when the same group is executed on different threads in a similar time frame.


### PR DESCRIPTION
Added note to indicate reasoning on why it's important to add the group-connection attribute when using additional threads.