### PR TITLE
Adding more specifics for PackageManifest

### DIFF
--- a/develop/schemadoc/PackageManifest/Manifest.Content.AutomationScripts.AutomationScript.Selection.Name.md
+++ b/develop/schemadoc/PackageManifest/Manifest.Content.AutomationScripts.AutomationScript.Selection.Name.md
@@ -4,7 +4,7 @@ uid: Manifest.Content.AutomationScripts.AutomationScript.Selection.Name
 
 # Name element
 
-Specifies the name of the Automation script from the Automation script solution to be included.
+Specifies the name of the Automation script from the Automation script solution to be included. The extension (.xml) needs to be included.
 
 ## Content type
 

--- a/develop/schemadoc/PackageManifest/Manifest.Content.AutomationScripts.AutomationScript.Selection.md
+++ b/develop/schemadoc/PackageManifest/Manifest.Content.AutomationScripts.AutomationScript.Selection.md
@@ -14,4 +14,4 @@ In case the Automation script solution consists of multiple Automation scripts, 
 
 |Name|Occurrences|Description|
 |--- |--- |--- |
-|&nbsp;&nbsp;[Name](xref:Manifest.Content.AutomationScripts.AutomationScript.Selection.Name)|[1, *]|Specifies the name of the Automation script from the Automation script solution to be included.|
+|&nbsp;&nbsp;[Name](xref:Manifest.Content.AutomationScripts.AutomationScript.Selection.Name)|[1, *]|Specifies the name of the Automation script from the Automation script solution to be included. The extension (.xml) needs to be included.|


### PR DESCRIPTION
When specifying scripts in the PackageManifest, the .xml is needed as well.