### PR TITLE
Remove comment for inexistent input parameter

### DIFF
--- a/src/Base Class Library/Common/Skyline/DataMiner/Library/Common/Serializing/SerializerFactory.cs
+++ b/src/Base Class Library/Common/Skyline/DataMiner/Library/Common/Serializing/SerializerFactory.cs
@@ -11,7 +11,6 @@
 		/// <summary>
 		/// Creates a serializer specifically for use by the InterApp module.
 		/// </summary>
-		/// <param name="baseType">The type of the base class to serialize or deserialize.</param>
 		/// <returns>An instance of type ISerializer.</returns>
 		public static ISerializer CreateInterAppSerializer()
 		{


### PR DESCRIPTION
Summary comment has a param tag for 'baseType', but there is no parameter by that name

This looks to be generated code from somewhere else so probably needs updating there