### PR TITLE
Replace IAS toolkit class library instructions with NuGet

### DIFF
--- a/develop/TOOLS/Interactive_Automation_Script_Toolkit.md
+++ b/develop/TOOLS/Interactive_Automation_Script_Toolkit.md
@@ -4,11 +4,7 @@ uid: Interactive_Automation_Script_Toolkit
 
 # Interactive Automation Script Toolkit
 
-## About
-
-The Interactive Automation Script Toolkit (or “IAS Toolkit” in short) is a library that can be used to create interactive Automation scripts. 
-Its main purpose is to make developing interactive Automation scripts easier. 
-Where you previously had to deal with UIBlocks of different types, you can now use TextBoxes and Buttons.
+The Interactive Automation Script Toolkit (or “IAS Toolkit” in short) is a library that can be used to create interactive Automation scripts. Its main purpose is to make developing interactive Automation scripts easier. Where you previously had to deal with UIBlocks of different types, you can now use TextBoxes and Buttons.
 
 Main features:
 
@@ -25,37 +21,15 @@ Main features:
 - Reduces development time
 
 > [!TIP]
-> For more information on how to get started, 
-> see [Getting started with the IAS Toolkit](xref:Getting_Started_with_the_IAS_Toolkit).
+> For more information on how to get started, see [Getting started with the IAS Toolkit](xref:Getting_Started_with_the_IAS_Toolkit).
 
 ## Versions
 
-#### 1.0.X
-
-The first version of the toolkit that was made available as a library. 
-It is compatible with DataMiner version 10.1 and up.
-
-#### 2.0.X
-
-Adds support for TreeViews. 
-It is compatible with DataMiner version 10.1.2 and up.
-
-#### 3.0.X
-
-Fixes some issues with the TreeView widget. 
-It is compatible with DataMiner 10.1.5 and up.
-
-#### 4.0.X
-
-Adds support for uploading files using the FileSelector widget. 
-It is compatible with DataMiner 10.1.8 and up.
-
-#### 5.0.X
-
-Adds support for a focus lost event on many widgets.
-It is compatible with DataMiner 10.1.10 and up.
-
-### 6.0.X
-
-Adds support for button styles. 
-It is compatible with DataMiner 10.3.1 and up.
+| Version | Description |
+|--|--|
+| 1.0.x | The first version of the toolkit that was made available as a library. Compatible with **DataMiner 10.1** and higher. |
+| 2.0.x | Adds support for TreeViews. Compatible with **DataMiner 10.1.2** and higher. |
+| 3.0.x | Fixes issues with the TreeView widget. Compatible with **DataMiner 10.1.5** and higher. |
+| 4.0.x | Adds support for uploading files using the FileSelector widget. Compatible with **DataMiner 10.1.8** and higher. |
+| 5.0.x | Adds support for a focus lost event on many widgets. Compatible with **DataMiner 10.1.10** and higher. |
+| 6.0.x | Adds support for button styles. Compatible with **DataMiner 10.3.1** and higher. |

--- a/develop/TOOLS/Interactive_Automation_Script_Toolkit.md
+++ b/develop/TOOLS/Interactive_Automation_Script_Toolkit.md
@@ -6,79 +6,56 @@ uid: Interactive_Automation_Script_Toolkit
 
 ## About
 
-The Interactive Automation Script Toolkit (or “IAS Toolkit” in short) is a class library that can be used to create interactive Automation scripts. Its main purpose is to make developing interactive Automation scripts easier. Where you previously had to deal with UIBlocks of different types, you can now use TextBoxes and Buttons.
+The Interactive Automation Script Toolkit (or “IAS Toolkit” in short) is a library that can be used to create interactive Automation scripts. 
+Its main purpose is to make developing interactive Automation scripts easier. 
+Where you previously had to deal with UIBlocks of different types, you can now use TextBoxes and Buttons.
 
 Main features:
 
-- Widgets instead of UIBlocks
+- Dedicated classes for each widget
+
+- Event driven
 
 - Focus on building scripts
 
-- Handling UI updates is done in the background
+- Eliminates a lot of boilerplate code
 
 - Easily create complex and robust scripts
 
-- Introduces eventing
-
 - Reduces development time
+
+> [!TIP]
+> For more information on how to get started, 
+> see [Getting started with the IAS Toolkit](xref:Getting_Started_with_the_IAS_Toolkit).
 
 ## Versions
 
-#### 1.0.4.3
+#### 1.0.X
 
-Version 1.0.4.3 is the first version of the toolkit that was made available as a class library. It is compatible with DataMiner version 10.0.5.0-9038 and higher.
+The first version of the toolkit that was made available as a library. 
+It is compatible with DataMiner version 10.1 and up.
 
-- You can download the 1.0.4.3 toolkit from [DataMiner Dojo](https://community.dataminer.services/download/ias-toolkit-1-0-4-3/).
+#### 2.0.X
 
-- You can download the 1.0.4.3 toolkit documentation from [DataMiner Dojo](https://community.dataminer.services/download/ias-toolkit-1-0-4-3-documentation/).
+Adds support for TreeViews. 
+It is compatible with DataMiner version 10.1.2 and up.
 
-#### 1.0.5.2
+#### 3.0.X
 
-Version 1.0.5.2 of the toolkit adds support for TreeViews. It is compatible with DataMiner version 10.1.2.0-9815 and higher.
+Fixes some issues with the TreeView widget. 
+It is compatible with DataMiner 10.1.5 and up.
 
-- You can download the 1.0.5.2 toolkit from [DataMiner Dojo](https://community.dataminer.services/download/ias-toolkit-1-0-5-2-10-1-2-0-9815/).
+#### 4.0.X
 
-- You can download the 1.0.5.2 toolkit documentation from [DataMiner Dojo](https://community.dataminer.services/download/ias-toolkit-1-0-5-2-documentation/).
+Adds support for uploading files using the FileSelector widget. 
+It is compatible with DataMiner 10.1.8 and up.
 
-#### 1.0.6.5
+#### 5.0.X
 
-Version 1.0.6.5 of the toolkit fixes some issues with the TreeView widget. It is compatible with DataMiner 10.1.5.0-10032 and higher.
+Adds support for a focus lost event on many widgets.
+It is compatible with DataMiner 10.1.10 and up.
 
-- You can download the 1.0.6.5 toolkit from [DataMiner Dojo](https://community.dataminer.services/download/ias-toolkit-1-0-6-5-10-1-5-0-10032/).
+### 6.0.X
 
-- You can download the 1.0.6.5 toolkit documentation from [DataMiner Dojo](https://community.dataminer.services/download/ias-toolkit-1-0-6-5-documentation/).
-
-#### 1.0.7.2
-
-Version 1.0.7.2 of the toolkit adds support for uploading files using the FileSelector widget. It is compatible with DataMiner 10.1.8 and higher.
-
-- You can download the 1.0.7.2 toolkit from [DataMiner Dojo](https://community.dataminer.services/download/ias-toolkit-1-0-7-2-10-1-8/).
-
-- You can download the 1.0.7.2 toolkit documentation from [DataMiner Dojo](https://community.dataminer.services/download/ias-toolkit-1-0-7-2-documentation/).
-
-## Installation
-
-Installation of the Interactive Automation Script Toolkit is the same as for any other class library.
-
-You will need:
-
-- [Visual Studio](xref:TOOVisualStudio)
-
-- [The DIS plugin](xref:DIS)
-
-- A version of the [IAS Toolkit](#versions) compatible with your DataMiner version
-
-To install the toolkit:
-
-1. Download the version of the toolkit that is compatible with your DataMiner version. You can do so using the links in the version overview above, or via the [overview of the class library packages](https://community.dataminer.services/class-library-packages/). Once you have downloaded your version, you do not need to unzip it. Just place it somewhere where you can easily find it again.
-
-1. In Visual Studio, navigate to the DIS menu and open the DIS settings.
-
-1. In the Class Library tab, add a new class library and link it to the downloaded zip file. It should look something like this:
-
-   ![ClassLibrary](~/develop/images/ClassLibrarySettings.png)
-
-You are now ready to start using the Interactive Automation Script Toolkit.
-
-> [!TIP]
-> For more information on how to get started, see [Getting started with the IAS Toolkit](xref:Getting_Started_with_the_IAS_Toolkit).
+Adds support for button styles. 
+It is compatible with DataMiner 10.3.1 and up.

--- a/develop/devguide/Automation/Howto/Getting_Started_with_the_IAS_Toolkit.md
+++ b/develop/devguide/Automation/Howto/Getting_Started_with_the_IAS_Toolkit.md
@@ -6,18 +6,16 @@ uid: Getting_Started_with_the_IAS_Toolkit
 
 ## Introduction
 
-The Interactive Automation Script Toolkit ( or “IAS Toolkit” in short) is a library that can be used to create interactive Automation scripts. 
-Its main purpose is to make developing interactive Automation scripts easier.
+The Interactive Automation Script Toolkit (or “IAS Toolkit” in short) is a library that can be used to create interactive Automation scripts. Its main purpose is to make developing interactive Automation scripts easier.
 
 > [!TIP]
 > For more information on its **main features**, and the **different versions**, see [Interactive Automation Script Toolkit](xref:Interactive_Automation_Script_Toolkit).
 
-To choose your version of the IAS Toolkit, the first thing you need to know is the [version of DataMiner](xref:Interactive_Automation_Script_Toolkit#versions) where you want your script to run. 
-As DataMiner keeps improving, so does its support for newer, more advanced IAS components. 
-In this introduction, DataMiner version 10.1.2 is used. This means that [version 2.0.X](https://www.nuget.org/packages/Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit/2.0.0) of the toolkit can be used.
+To choose your version of the IAS Toolkit, the first thing you need to know is the [version of DataMiner](xref:Interactive_Automation_Script_Toolkit#versions) where you want your script to run. As DataMiner keeps improving, so does its support for newer, more advanced IAS components.
 
-Just like for protocol and regular Automation script development, our IDE of choice is [Visual Studio](xref:TOOVisualStudio) with the latest version of [DIS](xref:DIS). 
-If you do not have DIS installed, you can find more information on how to do so under [Installing and configuring the software](xref:Installing_and_configuring_the_software).
+In this introduction, DataMiner version 10.1.2 is used. This means that [version 2.0.x](https://www.nuget.org/packages/Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit/2.0.0) of the toolkit can be used.
+
+Just like for protocol and regular Automation script development, our IDE of choice is [Visual Studio](xref:TOOVisualStudio) with the latest version of [DIS](xref:DIS). If you do not have DIS installed, you can find more information on how to do so under [Installing and configuring the software](xref:Installing_and_configuring_the_software).
 
 ## Creating a new script
 
@@ -33,23 +31,22 @@ To start creating your script:
 
    ![IAS2](~/develop/images/IAS2.png)
 
-## Install the library
+## Installing the library
 
 1. Open [NuGet Package Manager](https://learn.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio) in Visual Studio.
-2. Search for [Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit](https://www.nuget.org/packages/Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit)
-3. Select a [version](xref:Interactive_Automation_Script_Toolkit#versions) that is compatible with your DataMiner version.
-4. Click _Install_.
+
+1. Search for [Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit](https://www.nuget.org/packages/Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit).
+
+1. Select a [version](xref:Interactive_Automation_Script_Toolkit#versions) that is compatible with your DataMiner version.
+
+1. Click *Install*.
 
 > [!TIP]
 > For more information on using NuGet packages, see [Consuming NuGet packages](xref:Consuming_NuGet).
 
 ## Defining an InteractiveController
 
-With the steps above, you have created a regular Automation script. 
-But if you want this script to display something, you need to define an *InteractiveController*. 
-This controller is used to display dialogs. 
-It will also handle UI updates and trigger the events on the widgets. 
-It is part of the following namespace:
+With the steps above, you have created a regular Automation script. But if you want this script to display something, you need to define an *InteractiveController*. This controller is used to display dialogs. It will also handle UI updates and trigger the events on the widgets. It is part of the following namespace:
 
 `Skyline.DataMiner.Utils.InteractiveAutomationScript`
 
@@ -85,18 +82,13 @@ public class Script
 
 ## Building the UI
 
-Now you can start to develop the first dialog. A dialog is a single page in an IAS that requires user input. 
-For this example, we will make a dialog with the title “Hello World”, a label, a text box, and a button. 
-Whenever this button is clicked, the username of the user who launched the script should be displayed in the text box.
+Now you can start to develop the first dialog. A dialog is a single page in an IAS that requires user input. For this example, we will make a dialog with the title “Hello World”, a label, a text box, and a button. Whenever this button is clicked, the username of the user who launched the script should be displayed in the text box.
 
    ![IAS3](~/develop/images/IAS3.png)
 
-Before you start programming a dialog, it can be useful to create a mockup of the script. 
-While this may be a bit redundant for this example, it can be very useful when you create bigger, more complex dialogs.
+Before you start programming a dialog, it can be useful to create a mockup of the script. While this may be a bit redundant for this example, it can be very useful when you create bigger, more complex dialogs.
 
-To create a dialog, you need to create a class that inherits the Dialog class. 
-In this case, we will call it “HelloWorldDialog”. 
-In the constructor of each dialog, you need to define an Engine parameter, which you need to pass to the dialog constructor using the _base_ keyword.
+To create a dialog, you need to create a class that inherits the *Dialog* class. In this case, we will call it “HelloWorldDialog”. In the constructor of each dialog, you need to define an *Engine* parameter, which you need to pass to the dialog constructor using the *base* keyword.
 
 ```csharp
 public class HelloWorldDialog : Dialog
@@ -107,10 +99,10 @@ public class HelloWorldDialog : Dialog
 }
 ```
 
-Next, set the title of the dialog using the *Title* property, and define the different widgets used in the dialog. 
-Ideally, you should always try to keep the [background logic separated from the UI logic](https://community.dataminer.services/courses/dataminer-automation/lessons/model-view-presenter/). 
-This increases the maintainability of the script. 
-In this use case, we are making the text box and the button publicly available as they will be used in the background logic.
+Next, set the title of the dialog using the *Title* property, and define the different widgets used in the dialog. Ideally, you should always try to keep the background logic separated from the UI logic. This increases the maintainability of the script. In this use case, we are making the text box and the button publicly available as they will be used in the background logic.
+
+> [!TIP]
+> See also: [Model View Presenter](https://community.dataminer.services/courses/dataminer-automation/lessons/model-view-presenter/)
 
 ```csharp
 public class HelloWorldDialog : Dialog
@@ -130,8 +122,7 @@ public class HelloWorldDialog : Dialog
 }
 ```
 
-In order to display the widgets, you will need to add them to your dialog using the *AddWidget* method. 
-With this method, you can link a widget to a cell in a grid layout, where cell 0;0 is in the top-left corner of the dialog.
+In order to display the widgets, you will need to add them to your dialog using the *AddWidget* method. With this method, you can link a widget to a cell in a grid layout, where cell 0;0 is in the top-left corner of the dialog.
 
 ```csharp
 public class HelloWorldDialog : Dialog
@@ -192,24 +183,20 @@ You can now publish the script to your DMA, using either of the following ways:
 
 - Navigate to the *IAS_Helloworld.xml* file in Visual Studio and use the *DIS Publish* button (requires that your DMA is configured in the DIS settings).
 
-- Use a CI/CD workflow to publish the script to your DataMiner system.
+- Use a CI/CD workflow to publish the script to your DataMiner System.
 
-> [!TIP]
-> Instructions on setting up a CI/CD workflow can be found [here for GitHub](xref:CICD_on_GitHub) or [here for GitLab](xref:Deploying_Automation_scripts_from_a_GitLab_repository).
+  > [!TIP]
+  > For instructions on setting up a CI/CD workflow, see [CI/CD using GitHub](xref:CICD_on_GitHub) or [CI/CD using GitLab](xref:Deploying_Automation_scripts_from_a_GitLab_repository).
 
-If everything goes well, you will see your script in the Automation module of the DataMiner Cube client.
+If everything goes well, you will see your script in the Automation module in DataMiner Cube.
 
-To take a look at the script in action, click the Execute button in the lower right corner and then click *Execute now*.
+To take a look at the script in action, click the *Execute* button in the lower right corner and then click *Execute now*.
 
    ![IAS4](~/develop/images/IAS4.png)
 
 ## Handling events
 
-To make sure something actually happens when a user clicks the button in the script, you need to use events. 
-If you have ever worked with WPF or WinForms, this will feel very similar. 
-Every interactive widget in the toolkit exposes one or more events depending on the possible actions on the widget. 
-In the case of a button, it has an event that is triggered whenever it is pressed. 
-For more information on events, check out [this Microsoft article](https://learn.microsoft.com/en-us/dotnet/standard/events/).
+To make sure something actually happens when a user clicks the button in the script, you need to use events. If you have ever worked with WPF or WinForms, this will feel very similar. Every interactive widget in the toolkit exposes one or more events depending on the possible actions on the widget. In the case of a button, it has an event that is triggered whenever it is pressed. For more information on events, check out [this Microsoft article](https://learn.microsoft.com/en-us/dotnet/standard/events/).
 
 ```csharp
 /// <summary>
@@ -247,7 +234,6 @@ If you update the script on your DMA, your username will be added in the text bo
 
 ## What is next?
 
-Now that you have made a first script, play around with the toolkit some more: practice makes perfect! 
-Check out the other types of widgets, experiment with the widget properties, try to span widgets across multiple columns, etc.
+Now that you have made a first script, play around with the toolkit some more: practice makes perfect! Check out the other types of widgets, experiment with the widget properties, try to span widgets across multiple columns, etc.
 
 Or go follow our [Automation script training](https://community.dataminer.services/courses/dataminer-automation/)!

--- a/develop/devguide/Automation/Howto/Getting_Started_with_the_IAS_Toolkit.md
+++ b/develop/devguide/Automation/Howto/Getting_Started_with_the_IAS_Toolkit.md
@@ -6,14 +6,18 @@ uid: Getting_Started_with_the_IAS_Toolkit
 
 ## Introduction
 
-The Interactive Automation Script Toolkit ( or “IAS Toolkit” in short) is a class library that can be used to create interactive Automation scripts. Its main purpose is to make developing interactive Automation scripts easier.
+The Interactive Automation Script Toolkit ( or “IAS Toolkit” in short) is a library that can be used to create interactive Automation scripts. 
+Its main purpose is to make developing interactive Automation scripts easier.
 
 > [!TIP]
-> For more information on its **main features**, the **different versions**, and **how to install** the IAS Toolkit, see [Interactive Automation Script Toolkit](xref:Interactive_Automation_Script_Toolkit).
+> For more information on its **main features**, and the **different versions**, see [Interactive Automation Script Toolkit](xref:Interactive_Automation_Script_Toolkit).
 
-To choose your version of the IAS Toolkit, the first thing you need to know is the [version of DataMiner](xref:Interactive_Automation_Script_Toolkit#versions) where you want your script to run. As DataMiner keeps improving, so does its support for newer, more advanced IAS components. In this introduction, DataMiner version 10.1.2.0-9866 is used. This means that [version 1.0.5.2](https://community.dataminer.services/download/ias-toolkit-1-0-5-2-10-1-2-0-9815/) of the toolkit can be used.
+To choose your version of the IAS Toolkit, the first thing you need to know is the [version of DataMiner](xref:Interactive_Automation_Script_Toolkit#versions) where you want your script to run. 
+As DataMiner keeps improving, so does its support for newer, more advanced IAS components. 
+In this introduction, DataMiner version 10.1.2 is used. This means that [version 2.0.X](https://www.nuget.org/packages/Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit/2.0.0) of the toolkit can be used.
 
-Just like for protocol and regular Automation script development, our IDE of choice is [Visual Studio](xref:TOOVisualStudio) with the latest version of [DIS](xref:DIS). If you do not have DIS installed, you can find more information on how to do so under [Installing and configuring the software](xref:Installing_and_configuring_the_software).
+Just like for protocol and regular Automation script development, our IDE of choice is [Visual Studio](xref:TOOVisualStudio) with the latest version of [DIS](xref:DIS). 
+If you do not have DIS installed, you can find more information on how to do so under [Installing and configuring the software](xref:Installing_and_configuring_the_software).
 
 ## Creating a new script
 
@@ -29,18 +33,32 @@ To start creating your script:
 
    ![IAS2](~/develop/images/IAS2.png)
 
+## Install the library
+
+1. Open [NuGet Package Manager](https://learn.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio) in Visual Studio.
+2. Search for [Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit](https://www.nuget.org/packages/Skyline.DataMiner.Utils.InteractiveAutomationScriptToolkit)
+3. Select a [version](xref:Interactive_Automation_Script_Toolkit#versions) that is compatible with your DataMiner version.
+4. Click _Install_.
+
+> [!TIP]
+> For more information on using NuGet packages, see [Consuming NuGet packages](xref:Consuming_NuGet).
+
 ## Defining an InteractiveController
 
-With the steps above, you have created a regular Automation script. But if you want this script to display something, you need to define an *InteractiveController*. This controller is used to display dialogs. It will also handle UI updates and trigger the events on the widgets. It is part of the following namespace:
+With the steps above, you have created a regular Automation script. 
+But if you want this script to display something, you need to define an *InteractiveController*. 
+This controller is used to display dialogs. 
+It will also handle UI updates and trigger the events on the widgets. 
+It is part of the following namespace:
 
-`Skyline.DataMiner.DeveloperCommunityLibrary.InteractiveAutomationToolkit`
+`Skyline.DataMiner.Utils.InteractiveAutomationScript`
 
 The script now looks like this:
 
 ```csharp
 using System;
 using Skyline.DataMiner.Automation;
-using Skyline.DataMiner.DeveloperCommunityLibrary.InteractiveAutomationToolkit;
+using Skyline.DataMiner.Utils.InteractiveAutomationScript;
 /// <summary>
 /// DataMiner Script Class.
 /// </summary>
@@ -67,13 +85,18 @@ public class Script
 
 ## Building the UI
 
-Now you can start to develop the first dialog. A dialog is a single page in an IAS that requires user input. For this example, we will make a dialog with the title “Hello World”, a label, a text box, and a button. Whenever this button is clicked, the username of the user who launched the script should be displayed in the text box.
+Now you can start to develop the first dialog. A dialog is a single page in an IAS that requires user input. 
+For this example, we will make a dialog with the title “Hello World”, a label, a text box, and a button. 
+Whenever this button is clicked, the username of the user who launched the script should be displayed in the text box.
 
    ![IAS3](~/develop/images/IAS3.png)
 
-Before you start programming a dialog, it can be useful to create a mockup of the script. While this may be a bit redundant for this example, it can be very useful when you create bigger, more complex dialogs.
+Before you start programming a dialog, it can be useful to create a mockup of the script. 
+While this may be a bit redundant for this example, it can be very useful when you create bigger, more complex dialogs.
 
-To create a dialog, you need to create a class that inherits the Dialog class. In this case, we will call it “HelloWorldDialog”. In the constructor of each dialog, you need to define an Engine parameter, which you need to pass to the dialog constructor using the base keyword.
+To create a dialog, you need to create a class that inherits the Dialog class. 
+In this case, we will call it “HelloWorldDialog”. 
+In the constructor of each dialog, you need to define an Engine parameter, which you need to pass to the dialog constructor using the _base_ keyword.
 
 ```csharp
 public class HelloWorldDialog : Dialog
@@ -84,7 +107,10 @@ public class HelloWorldDialog : Dialog
 }
 ```
 
-Next, set the title of the dialog using the *Title* property, and define the different widgets used in the dialog. Ideally, you should always try to keep the background logic separated from the UI logic. This increases the maintainability of the script. In this use case, we are making the text box and the button publicly available as they will be used in the background logic.
+Next, set the title of the dialog using the *Title* property, and define the different widgets used in the dialog. 
+Ideally, you should always try to keep the [background logic separated from the UI logic](https://community.dataminer.services/courses/dataminer-automation/lessons/model-view-presenter/). 
+This increases the maintainability of the script. 
+In this use case, we are making the text box and the button publicly available as they will be used in the background logic.
 
 ```csharp
 public class HelloWorldDialog : Dialog
@@ -104,7 +130,8 @@ public class HelloWorldDialog : Dialog
 }
 ```
 
-In order to display the widgets, you will need to add them to your dialog using the *AddWidget* method. With this method, you can link a widget to a cell in a grid layout, where cell 0;0 is in the top-left corner of the dialog.
+In order to display the widgets, you will need to add them to your dialog using the *AddWidget* method. 
+With this method, you can link a widget to a cell in a grid layout, where cell 0;0 is in the top-left corner of the dialog.
 
 ```csharp
 public class HelloWorldDialog : Dialog
@@ -165,9 +192,12 @@ You can now publish the script to your DMA, using either of the following ways:
 
 - Navigate to the *IAS_Helloworld.xml* file in Visual Studio and use the *DIS Publish* button (requires that your DMA is configured in the DIS settings).
 
-- Import your script into the Automation module on your DMA.
+- Use a CI/CD workflow to publish the script to your DataMiner system.
 
-If everything goes well, you will see that you have two C# code blocks. The first one will contain all class library code and is autogenerated by DIS, the second one contains the code you have written.
+> [!TIP]
+> Instructions on setting up a CI/CD workflow can be found [here for GitHub](xref:CICD_on_GitHub) or [here for GitLab](xref:Deploying_Automation_scripts_from_a_GitLab_repository).
+
+If everything goes well, you will see your script in the Automation module of the DataMiner Cube client.
 
 To take a look at the script in action, click the Execute button in the lower right corner and then click *Execute now*.
 
@@ -175,7 +205,11 @@ To take a look at the script in action, click the Execute button in the lower ri
 
 ## Handling events
 
-To make sure something actually happens when a user clicks the button in the script, you need to use events. If you have ever worked with WPF or WinForms, this will feel very similar. Every interactive widget in the toolkit exposes one or more events depending on the possible actions on the widget. In the case of a button, it has an event that is triggered whenever it is pressed. For more information on events, check out [this Microsoft article](https://learn.microsoft.com/en-us/dotnet/standard/events/).
+To make sure something actually happens when a user clicks the button in the script, you need to use events. 
+If you have ever worked with WPF or WinForms, this will feel very similar. 
+Every interactive widget in the toolkit exposes one or more events depending on the possible actions on the widget. 
+In the case of a button, it has an event that is triggered whenever it is pressed. 
+For more information on events, check out [this Microsoft article](https://learn.microsoft.com/en-us/dotnet/standard/events/).
 
 ```csharp
 /// <summary>
@@ -213,6 +247,7 @@ If you update the script on your DMA, your username will be added in the text bo
 
 ## What is next?
 
-Now that you have made a first script, play around with the toolkit some more: practice makes perfect! Check out the other types of widgets, experiment with the widget properties, try to span widgets across multiple columns, etc.
+Now that you have made a first script, play around with the toolkit some more: practice makes perfect! 
+Check out the other types of widgets, experiment with the widget properties, try to span widgets across multiple columns, etc.
 
 Or go follow our [Automation script training](https://community.dataminer.services/courses/dataminer-automation/)!

--- a/user-guide/Advanced_Modules/Automation_module/Using_CSharp/Building_interactive_Automation_scripts_with_CSharp.md
+++ b/user-guide/Advanced_Modules/Automation_module/Using_CSharp/Building_interactive_Automation_scripts_with_CSharp.md
@@ -9,9 +9,10 @@ In an Automation script, you can define custom-made dialog boxes in C# code bloc
 In DataMiner Cube, it is also possible to add these dialog boxes using the script action *User interaction*. For more information, see [User interaction](xref:User_interaction).
 
 > [!NOTE]
+>
 > - For detailed information on the classes, methods and properties that can be used in C# code blocks of Automation scripts, see [Skyline.DataMiner.Automation](xref:Skyline.DataMiner.Automation).
 > - For more information on how to abort an interactive Automation script, see [How do I abort a running Automation script?](xref:How_do_I_abort_a_running_Automation_script)
-> - For a high-level API to build interactive automation scripts, see the [Interactive Automation Script Toolkit](xref:Interactive_Automation_Script_Toolkit) library. 
+> - For a high-level API to build interactive Automation scripts, see [Interactive Automation Script Toolkit](xref:Interactive_Automation_Script_Toolkit).
 
 ## Example of a dialog box displaying information
 

--- a/user-guide/Advanced_Modules/Automation_module/Using_CSharp/Building_interactive_Automation_scripts_with_CSharp.md
+++ b/user-guide/Advanced_Modules/Automation_module/Using_CSharp/Building_interactive_Automation_scripts_with_CSharp.md
@@ -11,6 +11,7 @@ In DataMiner Cube, it is also possible to add these dialog boxes using the scrip
 > [!NOTE]
 > - For detailed information on the classes, methods and properties that can be used in C# code blocks of Automation scripts, see [Skyline.DataMiner.Automation](xref:Skyline.DataMiner.Automation).
 > - For more information on how to abort an interactive Automation script, see [How do I abort a running Automation script?](xref:How_do_I_abort_a_running_Automation_script)
+> - For a high-level API to build interactive automation scripts, see the [Interactive Automation Script Toolkit](xref:Interactive_Automation_Script_Toolkit) library. 
 
 ## Example of a dialog box displaying information
 


### PR DESCRIPTION
Updated the pages to mention the publicly released nuget package instead of the class library package. Replaced script import instruction with links to CI/CD