### PR TITLE
HTTPS on DMA: add note to the URL rewrite section

### DIFF
--- a/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/Setting_up_HTTPS_on_a_DMA.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/Setting_up_HTTPS_on_a_DMA.md
@@ -100,8 +100,9 @@ Redirecting HTTP traffic to HTTPS is recommended when external systems (or clien
    1. Under *Inbound rules*, select *Blank rule*, and click *OK*.
 
    1. Under *Pattern*, fill in the following pattern: *(.\*)*
-       > [!NOTE]
-       > Make sure to include the brackets.
+
+      > [!NOTE]
+      > Make sure to include the parentheses.
 
    1. Under *Conditions*, click *Add*, and add the following condition:
 

--- a/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/Setting_up_HTTPS_on_a_DMA.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/Setting_up_HTTPS_on_a_DMA.md
@@ -100,6 +100,8 @@ Redirecting HTTP traffic to HTTPS is recommended when external systems (or clien
    1. Under *Inbound rules*, select *Blank rule*, and click *OK*.
 
    1. Under *Pattern*, fill in the following pattern: *(.\*)*
+       > [!NOTE]
+       > Make sure to include the brackets.
 
    1. Under *Conditions*, click *Add*, and add the following condition:
 


### PR DESCRIPTION
Added a note in the section on setting up HTTP to HTTPS rerouting, as I noticed people often do not include the brackets.