### PR TITLE
Added reference links + extended example

### DIFF
--- a/develop/devguide/Connector/UIComponentsCustomTableContextMenu.md
+++ b/develop/devguide/Connector/UIComponentsCustomTableContextMenu.md
@@ -9,10 +9,11 @@ It is possible to define a custom context menu for tables.
 To define a custom context menu, define a parameter with the same name as the table and the suffix "_ContextMenu". Each discrete entry represents a menu item and can be one of the following types:
 
 - Action: This will trigger the QAction.
-- Action with dependencies: The user will be asked to enter a value for each parameter specified in the dependencyValues attribute.
-- Action with rowselection: This is only available if the user has selected one or more rows in the table. The index of each row will be passed to the QAction.
-- Automation script: This will start an automation script instead of triggering a QAction. It uses the same syntax as for Visio and you can use * for dummies to use the current element and specify parameter IDs of columns of the selected row to use as values for script parameters.
-- Separator: This displays a separator line between menu items.
+- Action with dependencies: The user will be asked to enter a value for each parameter specified in the [dependencyValues](xref:Protocol.Params.Param.Measurement.Discreets.Discreet-dependencyValues) attribute.
+- Action with [rowselection](xref:Protocol.Params.Param.Measurement.Discreets.Discreet-options#tableselection): This is only available if the user has selected one or more rows in the table. The index of each row will be passed to the QAction.
+- Action with [confirmation](xref:Protocol.Params.Param.Measurement.Discreets.Discreet-options.html#confirmabc): This action will only be executed when the user confirms the pop-up.
+- [Automation script](xref:Protocol.Params.Param.Measurement.Discreets.Discreet-options#script): This will start an automation script instead of triggering a QAction. It uses the same syntax as for Visio and you can use * for dummies to use the current element and specify parameter IDs of columns of the selected row to use as values for script parameters.
+- [Separator](xref:Protocol.Params.Param.Measurement.Discreets.Discreet-options#separator): This displays a separator line between menu items.
 
 ```xml
 <Param id="2099">
@@ -34,7 +35,11 @@ To define a custom context menu, define a parameter with the same name as the ta
             <Display>Add new row...</Display>
             <Value>add</Value>
          </Discreet>
-         <Discreet options="table:selection">
+         <Discreet options="table:singleSelection" dependencyValues="2001;2002?;2003:[value:2003];2004?:[value:2004]">
+            <Display>Duplicate item...</Display>
+            <Value>duplicate</Value>
+         </Discreet>
+         <Discreet options="table:selection;confirm:The selected item(s) will be deleted permanently.">
             <Display>Delete selected row(s)...</Display>
             <Value>delete</Value>
          </Discreet>
@@ -50,6 +55,16 @@ To define a custom context menu, define a parameter with the same name as the ta
             <Display>Clear table</Display>
             <Value>clear</Value>
          </Discreet>
+         <Discreet options="separator">
+            <Display>Separator 2</Display>
+            <Value>-2</Value>
+         </Discreet>
+         <!-- Level must be first option in the list of options into the Discreet@options attribute -->
+         <Discreet options="level:5">
+            <Display>Depends on Level Access</Display>
+            <Value>access</Value>
+         </Discreet>
+         <!-- Script must be last option in the list of options into the Discreet@options attribute -->
          <Discreet options="script:Context Menu from a Protocol|d1=[this element]|p1=[value:1001];p2=[value:2002]|||NoConfirmation">
             <Display>Start script</Display>
             <Value>script1</Value>


### PR DESCRIPTION
It was not clear for juniors or people unfamiliar with context menu's what the exact options were.
- Added the documentation links to the top section where the actions are explained. 
- Added a new action 'Action with Confirmation'.
- Extended the first XML example with more options to showcase the different scenario's and possible options to make it more clear.