### PR TITLE
Update SLNetClientTest_clear_from_event_cache.md

### DIFF
--- a/user-guide/Reference/DataMiner_Tools/SLNetClientTest_tool/SLNetClientTest_tool_advanced_procedures/SLNetClientTest_clear_from_event_cache.md
+++ b/user-guide/Reference/DataMiner_Tools/SLNetClientTest_tool/SLNetClientTest_tool_advanced_procedures/SLNetClientTest_clear_from_event_cache.md
@@ -42,5 +42,7 @@ To do:
 
 1. If you are still logged in to DataMiner Cube, log out and log in again to see the change.
 
+1. If the alarm is still showing in a dashboard, restart IIS on the DMA your dashboard is connected to clear the alarm from the dashboard cache.
+
 > [!WARNING]
 > Always be extremely careful when using the SLNetClientTest tool, as it can have far-reaching consequences on the functionality of your DataMiner System.


### PR DESCRIPTION
Added information related to clearing alarm from a dashboard after it has been removed from the SLNet cache.