### PR TITLE
Deprecate in favor of snapshots

### DIFF
--- a/user-guide/Reference/DataMiner_Tools/Standalone_Elastic_Backup_Tool.md
+++ b/user-guide/Reference/DataMiner_Tools/Standalone_Elastic_Backup_Tool.md
@@ -6,6 +6,10 @@ uid: Standalone_Elastic_Backup_Tool
 
 From DataMiner 10.0.13 onwards, this tool allows you to back up and restore Elasticsearch database clusters. By default, it is available on a DMA in the folder `C:\Skyline DataMiner\Tools`.
 
+> [!IMPORTANT]
+> The **Standalone Elastic Backup tool** is being deprecated in favor of Elasticsearch's own snapshot functionality.
+> Therefore we recommend that you take a database backup using the [Elasticsearch snapshot functionality](xref: Configuring_Elasticsearch_backups_Windows_Linux)
+
 ## Syntax
 
 Use the following general syntax when you run this tool:

--- a/user-guide/Reference/DataMiner_Tools/Standalone_Elastic_Backup_Tool.md
+++ b/user-guide/Reference/DataMiner_Tools/Standalone_Elastic_Backup_Tool.md
@@ -7,8 +7,7 @@ uid: Standalone_Elastic_Backup_Tool
 From DataMiner 10.0.13 onwards, this tool allows you to back up and restore Elasticsearch database clusters. By default, it is available on a DMA in the folder `C:\Skyline DataMiner\Tools`.
 
 > [!IMPORTANT]
-> The **Standalone Elastic Backup tool** is being deprecated in favor of Elasticsearch's own snapshot functionality.
-> Therefore we recommend that you take a database backup using the [Elasticsearch snapshot functionality](xref: Configuring_Elasticsearch_backups_Windows_Linux)
+> The standalone Elastic Backup tool is being **deprecated** in favor of Elasticsearch's own snapshot functionality. We therefore recommend that you take database backups using the [Elasticsearch snapshot functionality](xref: Configuring_Elasticsearch_backups_Windows_Linux) instead.
 
 ## Syntax
 


### PR DESCRIPTION
Added important note deprecating the standalone elastic backup tool and referring to the snapshot document.