### PR TITLE
Update Configuring_multiple_Elasticsearch_clusters.md

### DIFF
--- a/user-guide/Advanced_Functionality/Databases/Elasticsearch_database/Configuring_multiple_Elasticsearch_clusters.md
+++ b/user-guide/Advanced_Functionality/Databases/Elasticsearch_database/Configuring_multiple_Elasticsearch_clusters.md
@@ -50,7 +50,7 @@ To configure this setup:
     <Hosts>10.11.1.44,10.11.2.44,10.11.3.44</Hosts>
     <Username />
     <Password>root</Password>
-    <Prefix>replica</Prefix>
+    <Prefix>dms</Prefix>
     <FileOffloadIdentifier>cluster2</FileOffloadIdentifier>
     </ElasticCluster>
     </ElasticConnections>


### PR DESCRIPTION
After syncing with core-eco(Laurens & Simon) changed the replica tag to dms instead of replica.

@SLC-Laurens-Vercruysse , @OnyxBit what will we do with https://docs.dataminer.services/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/DB_xml.html#specifying-a-custom-prefix-for-the-elasticsearch-indexes documentation? Remove, change it, any suggestions?