### PR TITLE
Update TOOQASNMPSimulator.md

### DIFF
--- a/develop/TOOLS/TOOQASNMPSimulator/TOOQASNMPSimulator.md
+++ b/develop/TOOLS/TOOQASNMPSimulator/TOOQASNMPSimulator.md
@@ -4,8 +4,8 @@ uid: TOOQASNMPSimulator
 
 # Skyline Device Simulator
 
-> [!IMPORTANT]
-> This section might include some information that is only applicable to Skyline employees and/or links that are only accessible to Skyline employees.
+> [!CAUTION]
+> This tool is provided "As Is" with no representation or warranty whatsoever. Skyline Communications will not provide any maintenance or support for this tool.
 
 The main purpose of this tool is to simulate device behavior while the device is not available. It allows you to poll simulated SNMP devices with static and changing data. You can send and receive traps. It is also able to reply to incoming inform messages. Polling dynamically simulated HTTP devices (GET and POST operations) is also supported. This tool is available on every DMA from DataMiner 10.1.5 onwards. It is located in the folder `C:\Skyline DataMiner\Tools\QADeviceSimulator`.
 
@@ -22,6 +22,3 @@ In this section:
 
 > [!NOTE]
 > Prior to DataMiner 10.2.12/10.3.0, this tool is known as "QA Device Simulator".
-
-> [!CAUTION]
-> This tool is provided "As Is" with no representation or warranty whatsoever. Skyline Communications will not provide any maintenance or support for this tool.


### PR DESCRIPTION
Skyline Device simulator is now fully available to customers so removed the "skyliners only" banner. The "this tool is provided as is" banner seems very important though, so I moved it from the end of the page to the top.