### PR TITLE
Added link to running Cassandra as non-SYSTEM user

### DIFF
--- a/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Cassandra_updating.md
+++ b/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Cassandra_updating.md
@@ -17,6 +17,9 @@ Doing a rolling upgrade basically means:
 
 ## Checking the Cassandra version
 
+> [!TIP]
+> To limit the impact of a breach through Cassandra, we recommended running the Cassandra service as a non-SYSTEM user. For more details, see [Running Cassandra as non-SYSTEM user](xref:Running_Cassandra_as_non-SYSTEM_user).
+
 We recommend that you periodically update your Cassandra database. This will ensure that all known vulnerabilities are fixed.
 
 To check the Cassandra version, go to *C:\Program Files\Cassandra\bin* and execute the following *nodetool* command:
@@ -28,17 +31,17 @@ With recent DataMiner versions, in case a Cassandra database per Agent is used, 
 > [!NOTE]
 > Cassandra 4.0 **no longer supports Windows**. This means that extra Linux servers will be required to host the Cassandra database.
 
-> [!TIP]
-> To limit the impact of a breach through Cassandra, we recommended running the Cassandra service as a non-SYSTEM user. For more details, see [Running Cassandra as non-SYSTEM user](xref:Running_Cassandra_as_non-SYSTEM_user).
-
 ## Updating the Cassandra version
 
 As with all software, it is good practice to ensure you are running the latest version to minimize the number of known vulnerabilities.
 
-> [!TIP]
+> [!NOTE]
 > A PowerShell script is available to update Cassandra easily. For more details see [Cassandra Hardening](https://github.com/SkylineCommunications/cassandra-hardening).
 
 To update the Cassandra version:
+
+> [!TIP]
+> To limit the impact of a breach through Cassandra, we recommended running the Cassandra service as a non-SYSTEM user. For more details, see [Running Cassandra as non-SYSTEM user](xref:Running_Cassandra_as_non-SYSTEM_user).
 
 ### [On Windows](#tab/tabid-1)
 


### PR DESCRIPTION
The tip with the link was already present once, but based on https://community.dataminer.services/question/error-1067-in-starting-cassandra-service/ I've now added it to the procedure to update Cassandra as well and moved the original tip to a more prominent place to make sure users definitely take it into account.