### PR TITLE
Cassandra update procedure: emphasise a new PowerShell prompt should be used

### DIFF
--- a/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Cassandra_updating.md
+++ b/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Cassandra_updating.md
@@ -79,7 +79,7 @@ To update the Cassandra version:
 
    `[System.Environment]::SetEnvironmentVariable('JAVA_HOME','C:\progra~1\Cassandra\Java\',[System.EnvironmentVariableTarget]::Machine)`
 
-1. Open a PowerShell prompt (as Administrator) and execute the following command to register the Cassandra service:
+1. Open a **new PowerShell prompt** (as Administrator) and execute the following command to register the Cassandra service:
 
    `cd 'C:\Program Files\Cassandra\bin\'; .\cassandra.ps1 -install`
 


### PR DESCRIPTION
Updating the system environment variables only takes effect in newly started prompts. This might not have been entirely clear according to this Dojo question: https://community.dataminer.services/question/cassandra-ps1-install-is-returning-an-error-for-step17-in-updating-cassandra-procedure/