### PR TITLE
Added limitations for indexed loggertables

### DIFF
--- a/develop/devguide/Connector/AdvancedLoggerTablesImplementation.md
+++ b/develop/devguide/Connector/AdvancedLoggerTablesImplementation.md
@@ -163,7 +163,7 @@ To implement a logger table, perform the following steps:
 
     - Partitioning in Cassandra is supported from DataMiner version 9.0.0 (RN12170) onwards. If ColumnDefinition is set to "DATETIME" and the Partition tag is set, Cassandra will use a TTL with the specified time. (See [Time to live](xref:AdvancedDataMinerDataPersistenceNoSqlCassandra#time-to-live).)
 
-      From DataMiner version 9.5.7 (RN 16738) onwards, you can specify the TTL of a logger table column via the Partition tag on any column. This is also supported for Elasticsearch.
+      From DataMiner version 9.5.7 (RN 16738) onwards, you can specify the TTL of a logger table column via the Partition tag on any column. This is also supported for the indexing database.
 
       ```xml
       <Param id="1003" trending="false">
@@ -200,11 +200,11 @@ To implement a logger table, perform the following steps:
 > [!NOTE]
 > In regular tables, performing an AddRow specifying a key that already exists does not change the row data. This is not the case for logger tables, which will update the row.
 
-## Elasticsearch logger tables
+## Indexed logger tables
 
-From DataMiner 9.6.4 (RN 13552) onwards, it is possible to store a logger table in Elasticsearch instead of Cassandra.
+From DataMiner 9.6.4 (RN 13552) onwards, it is possible to store a logger table in the indexing database instead of Cassandra.
 
-To indicate that a logger table should be stored in Elasticsearch instead of Cassandra, set the [IndexingOptions@enabled](xref:Protocol.Params.Param.Database.IndexingOptions-enabled) attribute to true:
+To indicate that a logger table should be stored in the indexing database instead of Cassandra, set the [IndexingOptions@enabled](xref:Protocol.Params.Param.Database.IndexingOptions-enabled) attribute to true:
 
 ```xml
 <Database>
@@ -212,14 +212,18 @@ To indicate that a logger table should be stored in Elasticsearch instead of Cas
 </Database>
 ```
 
+Logger tables have the following restriction when using the indexing database:
+    - The columnName cannot start with -, _ or +
+    - The columnName cannot include \, /, *, ?, ", <, >, ' ' (space character), ',', #, . or :
+
 > [!NOTE]
 >
-> - Elasticsearch has a background process that will check for all expired documents and add them to a bulk delete request. This means records may stay longer (but never shorter) than the specified TTL time.
-> - Updating rows is an expensive operation in Elasticsearch.
+> - The indexing database has a background process that will check for all expired documents and add them to a bulk delete request. This means records may stay longer (but never shorter) than the specified TTL time.
+> - Updating rows is an expensive operation in the indexing database.
 
 ### Infinite TTL
 
-From DataMiner 9.6.4 (RN 19993) onwards, in order to prevent indices from rolling over in Elasticsearch, it is possible to specify an infinite TTL.
+From DataMiner 9.6.4 (RN 19993) onwards, in order to prevent indices from rolling over in the indexing database, it is possible to specify an infinite TTL.
 
 ```xml
 <Database>
@@ -232,7 +236,7 @@ From DataMiner 9.6.4 (RN 19993) onwards, in order to prevent indices from rollin
 >
 > - The partitionsToKeep attribute value is ignored when Partition is set to “infinite”.
 > - The column does not need to be a datetime column. Any column type is supported.
-> - The value "infinite" only works on tables with IndexingOptions@enabled = true (i.e. logger tables stored in Elasticsearch).
+> - The value "infinite" only works on tables with IndexingOptions@enabled = true (i.e. logger tables stored in the indexing database).
 
 ## Designing logger tables
 

--- a/develop/devguide/Connector/AdvancedLoggerTablesImplementation.md
+++ b/develop/devguide/Connector/AdvancedLoggerTablesImplementation.md
@@ -212,9 +212,10 @@ To indicate that a logger table should be stored in the indexing database instea
 </Database>
 ```
 
-Logger tables have the following restriction when using the indexing database:
-    - The columnName cannot start with -, _ or +
-    - The columnName cannot include \, /, *, ?, ", <, >, ' ' (space character), ',', #, . or :
+When logger tables are stored the indexing database, the following restrictions apply:
+
+- The columnName must not start with `-`, `_`, or `+`.
+- The columnName must not include `\`, `/`, `*`, `?`, `"`, `<`, `>`, " " (space character), `,`, `#`, `.`, or `:`.
 
 > [!NOTE]
 >


### PR DESCRIPTION
Changed ElasticSearch to "the indexing database" as we support multiple versions