### PR TITLE
Added a not on importing user vs authenticating users

### DIFF
--- a/user-guide/Advanced_Functionality/Security/About_DMS_Security/User_management.md
+++ b/user-guide/Advanced_Functionality/Security/About_DMS_Security/User_management.md
@@ -16,7 +16,7 @@ DataMiner supports the following types of directories for user management:
 By default, DataMiner will import users from its local Active Directory.
 
 > [!NOTE]
-> Importing users via these methods does not necessarily allow these users to sign in. For user authentication, see [User authentication](#user-authentication).
+> Importing users via these methods does not necessarily allow these users to sign in. See [User authentication](#user-authentication).
 
 ## Local users
 

--- a/user-guide/Advanced_Functionality/Security/About_DMS_Security/User_management.md
+++ b/user-guide/Advanced_Functionality/Security/About_DMS_Security/User_management.md
@@ -15,6 +15,9 @@ DataMiner supports the following types of directories for user management:
 
 By default, DataMiner will import users from its local Active Directory.
 
+> [!NOTE]
+> Importing users via these methods does not necessarily allow these users to sign in. For user authentication, see [User authentication](#user-authentication).
+
 ## Local users
 
 Apart from directory users, DataMiner also has a notion of local users, i.e. users created within the DataMiner System. Behind the scenes, when a new local user is created, DataMiner will create a new Windows user. Local users are completely managed by the Windows Server hosting your DataMiner System. This means Windows is responsible for password storage, complexity, and audit trail requirements.


### PR DESCRIPTION
Seems user gets confused when using something like OpenLDAP to import the user, that they can automatically log in. Added a note that Importing does not encessarily mean the user can log in.