### PR TITLE
Update Troubleshooting_Trending.md

### DIFF
--- a/user-guide/Troubleshooting/Troubleshooting_Flowcharts/Troubleshooting_Trending.md
+++ b/user-guide/Troubleshooting/Troubleshooting_Flowcharts/Troubleshooting_Trending.md
@@ -27,7 +27,7 @@ classDef classSolution fill:#58595b,stroke:#58595b,color:#ffffff,stroke-width:0p
 %% Define blocks %%
 START([Trend issue])
 GetDELT{{Get a .dmimport package with trend data,\nunzip it and check the 'Database' folder.}}
-TrendDataInspector{{"Check the data with the trend data inspector.\n(Client test tool => Advanced => Test => Trend Data Inspector)"}}
+TrendDataInspector{{"Check the data with the trend data inspector."}}
 QueryDatabase{{Query the database directly.}}
 DataPresent([Is the data there?])
 ReadIssue([Read issue])
@@ -53,6 +53,9 @@ class DataPresent classDecision;
 class NotFixed classSolution;
 class ReadIssue,WriteIssue classExternalRef;
 </div>
+
+> [!NOTE]
+> More details on accessing the Trend Inspector can be found [here](xref:SLNetClientTest_trend_data_inspector)
 
 ### Read Issue
 
@@ -88,6 +91,11 @@ class DataPresent classDecision;
 class NotFixed classSolution;
 </div>
 
+
+> [!NOTE]
+> More details on the Trend Logging can be found [here](xref:Computer_settings#debug-settings).
+> More details on following a Cube session via the Client Test tool can be found [here](xref:SLNetClientTest_tracking_dma_communication). Tracking the 'Requests/Responses' communication should be sufficient.
+ 
 ### Write Issue
 
 <div class="mermaid">

--- a/user-guide/Troubleshooting/Troubleshooting_Flowcharts/Troubleshooting_Trending.md
+++ b/user-guide/Troubleshooting/Troubleshooting_Flowcharts/Troubleshooting_Trending.md
@@ -42,6 +42,7 @@ TrendDataInspector --- DataPresent
 DataPresent --- |Yes|ReadIssue
 DataPresent --- |No|WriteIssue
 %% Define hyperlinks %%
+click TrendDataInspector "https://docs.dataminer.services/user-guide/Reference/DataMiner_Tools/SLNetClientTest_tool/SLNetClientTest_tool_diagnostic_procedures/SLNetClientTest_trend_data_inspector.html"
 click ReadIssue "#read-issue" "Trending"
 click WriteIssue "#write-issue" "Trending"
 %% Apply styles to blocks %%
@@ -53,9 +54,6 @@ class DataPresent classDecision;
 class NotFixed classSolution;
 class ReadIssue,WriteIssue classExternalRef;
 </div>
-
-> [!NOTE]
-> More details on accessing the Trend Inspector can be found [here](xref:SLNetClientTest_trend_data_inspector)
 
 ### Read Issue
 
@@ -91,11 +89,11 @@ class DataPresent classDecision;
 class NotFixed classSolution;
 </div>
 
-
 > [!NOTE]
-> More details on the Trend Logging can be found [here](xref:Computer_settings#debug-settings).
-> More details on following a Cube session via the Client Test tool can be found [here](xref:SLNetClientTest_tracking_dma_communication). Tracking the 'Requests/Responses' communication should be sufficient.
- 
+>
+> - For more information on trend logging, see [Debug settings](xref:Computer_settings#debug-settings).
+> - For more information on following a Cube session via the SLNetClientTest tool, see [Tracking DMA communication](xref:SLNetClientTest_tracking_dma_communication). Tracking the requests and responses should be sufficient.
+
 ### Write Issue
 
 <div class="mermaid">


### PR DESCRIPTION
Links added to provide details as it's not always easy to know or find these.

I wasn't sure if I had to add the links directly to the Mermaid shapes or via a note, i.e. in terms of being future-proof

Overview diagram > Trend Inspector shape, I removed the details within the shape since I added the link towards its DM Docs page