### PR TITLE
Update UIComponentsTreeControlAlarmBubbleUp.md

### DIFF
--- a/develop/devguide/Connector/UIComponentsTreeControlAlarmBubbleUp.md
+++ b/develop/devguide/Connector/UIComponentsTreeControlAlarmBubbleUp.md
@@ -27,4 +27,7 @@ Each relation should define a unique property name:
 
 There is no alarm for a parameter in "Normal" state, so there will be no bubble-up: parent levels will be displayed in gray/Undefined instead of green/Normal.
 
+> [!NOTE]
+> Adding or deleting this option in a connector can give unexpected effects. The alarms can not bubble up until a new alarm is created or bubble up is still present when removed. A potential workaround is to reapply the alarm template. But keep in mind this will adjust the time the alarm is created and because of this you lose the history linked to the alarm. 
+
 Masked alarms will be ignored in the tree (similar to elements in the Surveyor). Since DataMiner version 7.5.5, the parameter itself will be displayed as masked; in earlier versions it will be displayed in alarm.

--- a/develop/devguide/Connector/UIComponentsTreeControlAlarmBubbleUp.md
+++ b/develop/devguide/Connector/UIComponentsTreeControlAlarmBubbleUp.md
@@ -28,6 +28,6 @@ Each relation should define a unique property name:
 There is no alarm for a parameter in "Normal" state, so there will be no bubble-up: parent levels will be displayed in gray/Undefined instead of green/Normal.
 
 > [!NOTE]
-> Adding or deleting this option in a connector can give unexpected effects. The alarms can not bubble up until a new alarm is created or bubble up is still present when removed. A potential workaround is to reapply the alarm template. But keep in mind this will adjust the time the alarm is created and because of this you lose the history linked to the alarm. 
+> Adding or deleting this option in a connector can have unexpected results, such as alarms that cannot bubble up until a new alarm is created, or bubble-up that remains present while the option has been removed. A potential workaround is to reapply the alarm template. However, keep in mind that this will adjust the time the alarm is created, which means that you will lose the history linked to the alarm.
 
 Masked alarms will be ignored in the tree (similar to elements in the Surveyor). Since DataMiner version 7.5.5, the parameter itself will be displayed as masked; in earlier versions it will be displayed in alarm.


### PR DESCRIPTION
The bubble up feature has unexpected effect when added or deleted from a tree control. This unexpected effect isn't described anywhere. The behavior is that the bubble up only happens when a new alarm is created. This is because then the additional property is added to the alarm. This can cause confusion when developing and confusion for users.