### PR TITLE
Update Protocol.PortSettings.SlowPollBase.DefaultValue.md

### DIFF
--- a/develop/schemadoc/Protocol/Protocol.PortSettings.SlowPollBase.DefaultValue.md
+++ b/develop/schemadoc/Protocol/Protocol.PortSettings.SlowPollBase.DefaultValue.md
@@ -25,12 +25,12 @@ Contains on of the following predefined values.
 
 ```xml
 <SlowPollBase>
-  <DefaultValue>Number</DefaultValue>
+  <DefaultValue>number</DefaultValue>
 </SlowPollBase>
 ```
 
 ```xml
 <SlowPollBase>
-  <DefaultValue>Time</DefaultValue>
+  <DefaultValue>time</DefaultValue>
 </SlowPollBase>
 ```


### PR DESCRIPTION
Values in the 'Examples' must be lowercase to comply with Type EnumTypePortSlowPollBase https://docs.dataminer.services/develop/schemadoc/Protocol/EnumTypePortSlowPollBase.html