### PR TITLE
Update Protocol.Params.Param.Measurement.Type.md

### DIFF
--- a/develop/schemadoc/Protocol/Protocol.Params.Param.Measurement.Type.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param.Measurement.Type.md
@@ -112,7 +112,7 @@ For example:
 </Measurement>
 ```
 
-See also
+See also:
 
 - [Options for measurement type “discreet”](xref:Protocol.Params.Param.Measurement.Type-options#options-for-measurement-type-discreet)
 - [Drop-down list](xref:UIComponentsDropDownList)
@@ -122,7 +122,7 @@ See also
 
 Used for visualizing a matrix. Only applicable for parameters of type “array” or “write”.
 
-See also
+See also:
 
 - [Options for measurement type “matrix”](xref:Protocol.Params.Param.Measurement.Type-options#options-for-measurement-type-matrix)
 - [Matrix](xref:UIComponentsMatrix)
@@ -131,7 +131,7 @@ See also
 
 The parameter will be displayed as a number.
 
-See also
+See also:
 
 - [Options for measurement type “number”](xref:Protocol.Params.Param.Measurement.Type-options#options-for-measurement-type-number)
 
@@ -145,7 +145,7 @@ In this case, the accompanying Protocol.Params.Param.Measurement.Discreets tag h
 
 Labels of page buttons must end with ”...”. So, inside a Protocol.Params.Param. Measurement.Discreets.Discreet tag, the Protocol.Params.Param.Measurement.Discreets.Discreet.Display tag must contain a button label ending with ”...”.
 
-See also
+See also:
 
 - [Page button](xref:UIComponentsPageButton)
 
@@ -160,7 +160,7 @@ The Param.Display.Range tag is used to define the range of the progress bar. If 
 > [!NOTE]
 > The measurement type "progress" is only used with parameters of type "read".
 
-See also
+See also:
 
 - [Progress bar](xref:UIComponentsProgressBar)
 
@@ -174,7 +174,7 @@ Example:
 <Type lines="3" case="upper" options="hscroll;tab=100;fixedfont">string</Type>
 ```
 
-See also
+See also:
 
 - [Options for measurement type “string”](xref:Protocol.Params.Param.Measurement.Type-options#options-for-measurement-type-string)
 
@@ -202,7 +202,7 @@ Example:
 > - The measurement type "title" is only used with parameters of type "read".
 > - To include support for the legacy System Display application, add the “connect” option (`options="end;connect"`).
 
-See also
+See also:
 
 - [Options for measurement type “title”](xref:Protocol.Params.Param.Measurement.Type-options#options-for-measurement-type-title)
 - [Title](xref:UIComponentsTitle)
@@ -212,8 +212,6 @@ See also
 
 When a parameter of type “write” includes only two discreet values, it can be represented by a toggle button. When the “read” parameter associated with the “write” parameter contains the first discreet value, the second discreet value will be used in the set command when the toggle button is clicked.
 
-In this case, the accompanying Protocol.Params.Param.Measurement.Discreets tag is used for the parameter of type READ or READ BIT. In rare cases it can be set on the parameter of type WRITE.
-
-See also
+See also:
 
 - [Toggle button](xref:UIComponentsToggleButton)

--- a/develop/schemadoc/Protocol/Protocol.Params.Param.Measurement.Type.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param.Measurement.Type.md
@@ -216,4 +216,4 @@ In this case, the accompanying Protocol.Params.Param.Measurement.Discreets tag i
 
 See also
 
-- [Group box](xref:UIComponentsToggleButton)
+- [Toggle button](xref:UIComponentsToggleButton)


### PR DESCRIPTION
Fixes the bullet text to match the link it is referencing to: Toggle button.

I suggest you also ask an expert to revise the explanation about [togglebutton](https://docs.dataminer.services/develop/schemadoc/Protocol/Protocol.Params.Param.Measurement.Type.html?q=togglebutton#togglebutton), because it is NOT consistent with the explanation in [Toggle button](https://docs.dataminer.services/develop/devguide/Connector/UIComponentsToggleButton.html) page .