### PR TITLE
Add RNs for CGW

### DIFF
--- a/release-notes/CommunicationGateway/CommunicationGateway_1.0.0.md
+++ b/release-notes/CommunicationGateway/CommunicationGateway_1.0.0.md
@@ -8,8 +8,6 @@ uid: CommunicationGateway_1.0.0
 
 #### New Communication Gateway module [ID_34945] [ID_35195] [ID_35390] [ID_35470] [ID_35575] [ID_35622] [ID_35576] [ID_35321] [ID_35711] [ID_35754] [ID_35853] [ID_36140]
 
-A new Communication Gateway module is now available as a DxM (DataMiner Extension Module).
+A new Communication Gateway module is now available as a DxM (DataMiner Extension Module). This module makes it possible for connectors or scripts running in the DataMiner environment to communicate with devices that require a gRPC connection.
 
-##### Installation and setup
-
-Please follow the installation procedures for DxMs that are not included in the DataMiner Cloud Pack as described in [Managing cloud-connected nodes](xref:Managing_cloud-connected_nodes#deploying-a-dxm-on-a-node)
+To install this DxM, follow the [installation procedure for DxMs that are not included in the DataMiner Cloud Pack](xref:Managing_cloud-connected_nodes#deploying-a-dxm-on-a-node).

--- a/release-notes/CommunicationGateway/CommunicationGateway_1.0.0.md
+++ b/release-notes/CommunicationGateway/CommunicationGateway_1.0.0.md
@@ -1,0 +1,15 @@
+---
+uid: CommunicationGateway_1.0.0
+---
+
+# Communication Gateway 1.0.0
+
+## New features
+
+#### New Communication Gateway module [ID_34945] [ID_35195] [ID_35390] [ID_35470] [ID_35575] [ID_35622] [ID_35576] [ID_35321] [ID_35711] [ID_35754] [ID_35853] [ID_36140]
+
+A new Communication Gateway module is now available as a DxM (DataMiner Extension Module).
+
+##### Installation and setup
+
+Please follow the installation procedures for DxMs that are not included in the DataMiner Cloud Pack as described in [Managing cloud-connected nodes](xref:Managing_cloud-connected_nodes#deploying-a-dxm-on-a-node)

--- a/release-notes/CommunicationGateway/CommunicationGateway_1.1.0.md
+++ b/release-notes/CommunicationGateway/CommunicationGateway_1.1.0.md
@@ -1,0 +1,13 @@
+---
+uid: CommunicationGateway_1.1.0
+---
+
+# Communication Gateway 1.1.0
+
+## New features
+
+### Added support for additional gRPC services [ID_36281]
+
+* Support for Arista CloudVision
+
+* Support for Mellanox Telemetry Agent

--- a/release-notes/CommunicationGateway/CommunicationGateway_1.1.0.md
+++ b/release-notes/CommunicationGateway/CommunicationGateway_1.1.0.md
@@ -8,6 +8,4 @@ uid: CommunicationGateway_1.1.0
 
 ### Added support for additional gRPC services [ID_36281]
 
-* Support for Arista CloudVision
-
-* Support for Mellanox Telemetry Agent
+The Communication Gateway module now supports Arista CloudVision and Mellanox Telemetry Agent gRPC services.

--- a/release-notes/CommunicationGateway/CommunicationGateway_1.2.0.md
+++ b/release-notes/CommunicationGateway/CommunicationGateway_1.2.0.md
@@ -1,0 +1,11 @@
+---
+uid: CommunicationGateway_1.2.0
+---
+
+# Communication Gateway 1.2.0
+
+## New features
+
+### DotNet target version upgrade [ID_36579]
+
+* The module is now targeting .NET6.0 and no longer uses .NET5.0, which is out of support.

--- a/release-notes/CommunicationGateway/CommunicationGateway_1.2.0.md
+++ b/release-notes/CommunicationGateway/CommunicationGateway_1.2.0.md
@@ -8,4 +8,4 @@ uid: CommunicationGateway_1.2.0
 
 ### DotNet target version upgrade [ID_36579]
 
-* The module is now targeting .NET6.0 and no longer uses .NET5.0, which is out of support.
+The Communication Gateway module now targets .NET 6.0 and no longer uses .NET 5.0, which is out of support.

--- a/release-notes/toc.yml
+++ b/release-notes/toc.yml
@@ -564,14 +564,14 @@
       - name: Data Aggregator 1.0.0
         topicUid: DataAggregator_1.0.0
     - name: Communication Gateway release notes
-      topicUid: CommunicationGateway_1.0.0
+      topicUid: CommunicationGateway_1.2.0
       items:
-      - name: Communication Gateway 1.0.0
-        topicUid: CommunicationGateway_1.0.0        
-      - name: Communication Gateway 1.1.0
-        topicUid: CommunicationGateway_1.1.0        
       - name: Communication Gateway 1.2.0
         topicUid: CommunicationGateway_1.2.0
+      - name: Communication Gateway 1.1.0
+        topicUid: CommunicationGateway_1.1.0
+      - name: Communication Gateway 1.0.0
+        topicUid: CommunicationGateway_1.0.0
     - name: Class Library release notes
       topicUid: ClassLibrary_Range_1.4
       items:

--- a/release-notes/toc.yml
+++ b/release-notes/toc.yml
@@ -563,6 +563,15 @@
       items:
       - name: Data Aggregator 1.0.0
         topicUid: DataAggregator_1.0.0
+    - name: Communication Gateway release notes
+      topicUid: CommunicationGateway_1.0.0
+      items:
+      - name: Communication Gateway 1.0.0
+        topicUid: CommunicationGateway_1.0.0        
+      - name: Communication Gateway 1.1.0
+        topicUid: CommunicationGateway_1.1.0        
+      - name: Communication Gateway 1.2.0
+        topicUid: CommunicationGateway_1.2.0
     - name: Class Library release notes
       topicUid: ClassLibrary_Range_1.4
       items:


### PR DESCRIPTION
Some groundwork to document the different releases of the CommunicationGateway DxM.
The RN IDs are those that I could find in the repository of the DxM, while other OpenConfig RNs will exist that are related to the middleware for example.
Is this something that could be followed-up by the documentation team?