### PR TITLE
Link to cloud endpoint config + small correction

### DIFF
--- a/user-guide/Cloud_Platform/AboutCloudPlatform/Custom_cloud_endpoint_configuration.md
+++ b/user-guide/Cloud_Platform/AboutCloudPlatform/Custom_cloud_endpoint_configuration.md
@@ -26,7 +26,7 @@ You can **adjust or completely disable** this endpoint for each DataMiner CloudG
 1. Restart DataMiner CloudGateway on each server for the changes to take effect.
 
 > [!NOTE]
-> Make sure that the configured ports also are open on the internal network, so other DataMiner Extension Modules can access these endpoints hosted in DataMiner CloudGateway.
+> Make sure that the configured ports are also open on the internal network, so other DataMiner Extension Modules can access these endpoints hosted in DataMiner CloudGateway.
 
 > [!IMPORTANT]
 > Disabling the dataminer.services endpoint for each DataMiner CloudGateway will also disable features that depend on this DxM, such as Remote Log Collection. DataMiner CloudGateway can only start if the configured port is available on the hosting server.

--- a/user-guide/Cloud_Platform/Connecting_to_cloud/Connect_to_cloud_with_DMZ.md
+++ b/user-guide/Cloud_Platform/Connecting_to_cloud/Connect_to_cloud_with_DMZ.md
@@ -20,6 +20,9 @@ From version 2.7.0 of the CloudGateway DxM onwards, you can connect a DMS to dat
 
    - Make sure the DxMs on all servers can communicate towards dataminer.services thought the DMZ CloudGateway on port 5100.
 
+     > [!NOTE]
+     > If communication through port 5100 is not possible, it is possible to configure a different port. See [Customizing the dataminer.services endpoint configuration](Custom_cloud_endpoint_configuration).
+
 1. Install the [DMZ Cloud Pack](https://community.dataminer.services/dataminer-cloud-pack/) on the DMZ server.
 
 1. On the DataMiner nodes, install the DxMs that need to connect with the DMA or do not require internet access. At present, these are *CoreGateway*, *FieldControl*, *SupportAssistant*, *ArtifactDeployer* and *Orchestrator*. For a Failover setup, you should install these DxMs on both Agents in the Failover pair.

--- a/user-guide/Cloud_Platform/Connecting_to_cloud/Connect_to_cloud_with_DMZ.md
+++ b/user-guide/Cloud_Platform/Connecting_to_cloud/Connect_to_cloud_with_DMZ.md
@@ -21,7 +21,7 @@ From version 2.7.0 of the CloudGateway DxM onwards, you can connect a DMS to dat
    - Make sure the DxMs on all servers can communicate towards dataminer.services thought the DMZ CloudGateway on port 5100.
 
      > [!NOTE]
-     > If communication through port 5100 is not possible, it is possible to configure a different port. See [Customizing the dataminer.services endpoint configuration](Custom_cloud_endpoint_configuration).
+     > If communication through port 5100 is not possible, it is possible to configure a different port. See [Customizing the dataminer.services endpoint configuration](xref:Custom_cloud_endpoint_configuration).
 
 1. Install the [DMZ Cloud Pack](https://community.dataminer.services/dataminer-cloud-pack/) on the DMZ server.
 


### PR DESCRIPTION
This change is intended to make the documentation more clear based on https://community.dataminer.services/question/are-custom-cloudgateway-configurations-mandatory/.