### PR TITLE
Failover: manual switch when online DMA unavailable

### DIFF
--- a/user-guide/Advanced_Functionality/Failover/Configuring_Failover/Advanced_Failover_options.md
+++ b/user-guide/Advanced_Functionality/Failover/Configuring_Failover/Advanced_Failover_options.md
@@ -18,7 +18,9 @@ Go to this tab to specify whether Failover should occur manually or automaticall
 - If you choose *Manual*, switching can be done with the *Switch* button at the bottom of the *Failover* dialog box.
 
   > [!NOTE]
-  > Manual switching is not possible when the backup DMA is not running. In that case the *Switch* button will be unavailable.
+  >
+  > - Manual switching is not possible when the offline DMA is not running. In that case, the *Switch* button will be unavailable.
+  > - If the online DMA becomes unavailable for some reason, you can switch by connecting to the offline DMA with DataMiner Cube. You will then get the option to bring that DMA online.
 
 ## Synchronization
 


### PR DESCRIPTION
Change based on https://community.dataminer.services/question/manual-failover-when-the-online-dma-is-disconnected/.