### PR TITLE
Update Adding_time_scoped_related_parameters_to_a_trend_graph.md

### DIFF
--- a/user-guide/Basic_Functionality/Trending/Advanced_analytics_trending/Relation_learning/Adding_time_scoped_related_parameters_to_a_trend_graph.md
+++ b/user-guide/Basic_Functionality/Trending/Advanced_analytics_trending/Relation_learning/Adding_time_scoped_related_parameters_to_a_trend_graph.md
@@ -4,7 +4,7 @@ uid: Adding_time_scoped_related_parameters_to_a_trend_graph
 
 # Adding time-scoped related parameters to a trend graph
 
-From DataMiner 10.3.8/10.4.0 onwards<!--RN 36434 -->, you can use the light bulb that appears after selecting a time range on a trend graph to add related parameters based only on the behavior during that time range. This is different from the lightbulb on the top right corner of the trend graph which proposes related parameters based on the entire history. Currently, only parameters from the same DataMiner Element can be proposed. The lightbulb only shows parameters related to one parameter, even if multiple curves are visisble on the trend graph. You can hover over the lightbulb icon to see for which parameter relations are proposed.
+From DataMiner 10.3.8/10.4.0 onwards<!--RN 36434 -->, when you select a time range of a trend graph, a light bulb icon will be displayed. Click this icon to add related parameters based only on the behavior during the selected time range. This is different from the light bulb in the top right corner of the trend graph, which proposes related parameters based on the entire history. Currently, only parameters from the same DataMiner element can be proposed. The light bulb only shows parameters related to one parameter, even if multiple curves are visible on the trend graph. You can hover over the light bulb icon to see for which parameter relations are proposed.
 
 You can for instance use this in case a parameter (e.g. the total available memory of a server) behaves oddly during a particular time range (e.g. a downward spike), in order to find out if other parameters of the same device also showed unusual behavior during the same time range.
 

--- a/user-guide/Basic_Functionality/Trending/Advanced_analytics_trending/Relation_learning/Adding_time_scoped_related_parameters_to_a_trend_graph.md
+++ b/user-guide/Basic_Functionality/Trending/Advanced_analytics_trending/Relation_learning/Adding_time_scoped_related_parameters_to_a_trend_graph.md
@@ -4,9 +4,9 @@ uid: Adding_time_scoped_related_parameters_to_a_trend_graph
 
 # Adding time-scoped related parameters to a trend graph
 
-From DataMiner 10.3.8/10.4.0 onwards<!--RN 36434 -->, you can use the light bulb in the top-right corner of a trend graph to add related parameters based only on the behavior of the parameters during the time range of a selected section of the trend graph.
+From DataMiner 10.3.8/10.4.0 onwards<!--RN 36434 -->, you can use the light bulb that appears after selecting a time range on a trend graph to add related parameters based only on the behavior during that time range. This is different from the lightbulb on the top right corner of the trend graph which proposes related parameters based on the entire history. Currently, only parameters from the same DataMiner Element can be proposed. The lightbulb only shows parameters related to one parameter, even if multiple curves are visisble on the trend graph. You can hover over the lightbulb icon to see for which parameter relations are proposed.
 
-You can for instance use this in a case a parameter (e.g. the total available memory of a server) behaves oddly during a particular time range (e.g. a downward spike), in order to find out if other parameters of the same device also showed unusual behavior during the same time range.
+You can for instance use this in case a parameter (e.g. the total available memory of a server) behaves oddly during a particular time range (e.g. a downward spike), in order to find out if other parameters of the same device also showed unusual behavior during the same time range.
 
 ## Prerequisites
 
@@ -23,7 +23,7 @@ To add a related parameter for a specific time range only:
 
 1. In a trend graph showing trend information for one single parameter, **select the section of the graph** where the parameter shows the behavior you are interested in. The way you can do so depends on the configuration of the trending user settings. See [Trending settings](xref:User_settings#trending-settings).
 
-1. Click the light bulb icon. This will open a menu with the parameters that are related based on the parameter behavior within the time range of the selected section.
+1. Click the light bulb icon. This will open a menu with the parameters related to your original parameter, but only taking into account the behavior within the time range of the selected region.
 
 1. Select the parameter you want to add.
 


### PR DESCRIPTION
I changed the first paragraph: it incorrectly referred the lightbulb icon on the top right of the trend graph, whereas a new lightbulb icon was introduced specifically for this feature. I also added some more info in that paragraph.

In the second paragraph, I removed "a" from "in a case".

Finally, the second item in the bottom section was reformulated.