### PR TITLE
Update Placeholders_for_variables_in_shape_data_values.md

### DIFF
--- a/user-guide/Basic_Functionality/Visio/reference/Placeholders_for_variables_in_shape_data_values.md
+++ b/user-guide/Basic_Functionality/Visio/reference/Placeholders_for_variables_in_shape_data_values.md
@@ -501,6 +501,10 @@ value=1005 == alpha;value=1005 == beta;value=1005 == gamma; value=1005 == delta;
 >   ```txt
 >   [RegexReplace:[Sep:,#]x#y#z]
 >   ```
+>   - RegexReplace can also be used to remove the unit suffix of a parameter to be able to use it as a term in an operation with the sum placeholder. In the param placeholder used on a parameter that has a unit, this is needed to enable the sum operator to [parse the value into an integer](xref:\[Sum:X,Y,Z\]). A simple example, where the suffix "*Frames*" is removed to calculate a sum of parameter with id 5 and  a fixed value 17.
+>   ```txt
+>   [sum:[RegexReplace:\sFrames$,[param:*,5],],17]
+>   ```
 
 ### \[Reservation:...\]
 

--- a/user-guide/Basic_Functionality/Visio/reference/Placeholders_for_variables_in_shape_data_values.md
+++ b/user-guide/Basic_Functionality/Visio/reference/Placeholders_for_variables_in_shape_data_values.md
@@ -479,20 +479,6 @@ In this placeholder, specify three items, separated by commas:
 | y    | The input (e.g. a session variable).              |
 | z    | The string that will replace each of the matches. |
 
-Example:
-
-In case the *sessionvar* variable contains the value “*alpha\|beta\|gamma\|delta*”, you can place the following placeholder in the value of a shape data field:
-
-```txt
-[RegexReplace:(?<token>[^|]+)((?<separator>[|])|$),[var:sessionvar],value=1005 == ${token};]
-```
-
-The placeholder will then be replaced by the following string of text:
-
-```txt
-value=1005 == alpha;value=1005 == beta;value=1005 == gamma; value=1005 == delta;
-```
-
 > [!NOTE]
 >
 > - \[RegexReplace:x,y,z\] placeholders can be nested.
@@ -501,10 +487,26 @@ value=1005 == alpha;value=1005 == beta;value=1005 == gamma; value=1005 == delta;
 >   ```txt
 >   [RegexReplace:[Sep:,#]x#y#z]
 >   ```
->   - RegexReplace can also be used to remove the unit suffix of a parameter to be able to use it as a term in an operation with the sum placeholder. In the param placeholder used on a parameter that has a unit, this is needed to enable the sum operator to [parse the value into an integer](\[Sum:...\]). A simple example, where the suffix "*Frames*" is removed to calculate a sum of parameter with id 5 and  a fixed value 17.
->   ```txt
->   [sum:[RegexReplace:\sFrames$,[param:*,5],],17]
->   ```
+
+Examples:
+
+- In case the *sessionvar* variable contains the value “*alpha\|beta\|gamma\|delta*”, you can place the following placeholder in the value of a shape data field:
+
+  ```txt
+  [RegexReplace:(?<token>[^|]+)((?<separator>[|])|$),[var:sessionvar],value=1005 == ${token};]
+  ```
+
+  The placeholder will then be replaced by the following string of text:
+
+  ```txt
+  value=1005 == alpha;value=1005 == beta;value=1005 == gamma; value=1005 == delta;
+  ```
+
+- You can use this placeholder to remove the unit suffix of a parameter, so that it can be used within the [Sum](#sumxyz) placeholder. This is necessary if the sum uses a [param](#paramdmaidelementidparameterid) placeholder and the value of the parameter includes a unit, to make sure that value can be parsed into an integer. For example, to remove the unit "Frames" and calculate the sum of the parameter with ID 5 and a fixed value of 17, you can use this placeholder:
+
+  ```txt
+  [sum:[RegexReplace:\sFrames$,[param:*,5],],17]
+  ```
 
 ### \[Reservation:...\]
 

--- a/user-guide/Basic_Functionality/Visio/reference/Placeholders_for_variables_in_shape_data_values.md
+++ b/user-guide/Basic_Functionality/Visio/reference/Placeholders_for_variables_in_shape_data_values.md
@@ -501,7 +501,7 @@ value=1005 == alpha;value=1005 == beta;value=1005 == gamma; value=1005 == delta;
 >   ```txt
 >   [RegexReplace:[Sep:,#]x#y#z]
 >   ```
->   - RegexReplace can also be used to remove the unit suffix of a parameter to be able to use it as a term in an operation with the sum placeholder. In the param placeholder used on a parameter that has a unit, this is needed to enable the sum operator to [parse the value into an integer](xref:\[Sum:X,Y,Z\]). A simple example, where the suffix "*Frames*" is removed to calculate a sum of parameter with id 5 and  a fixed value 17.
+>   - RegexReplace can also be used to remove the unit suffix of a parameter to be able to use it as a term in an operation with the sum placeholder. In the param placeholder used on a parameter that has a unit, this is needed to enable the sum operator to [parse the value into an integer](\[Sum:...\]). A simple example, where the suffix "*Frames*" is removed to calculate a sum of parameter with id 5 and  a fixed value 17.
 >   ```txt
 >   [sum:[RegexReplace:\sFrames$,[param:*,5],],17]
 >   ```


### PR DESCRIPTION
I personally think the example that is now in the documentation is already very advanced (and difficult to understand) if you are not already familiar with regular expressions. I think by adding a more simple example (by removing the Frames suffix) it is more clear what you can do with it. This suggestion originates from a custom training I provided to TV2 about advanced vision, where they need this RegExReplace, but did not hear yet of Regular Expressions. 

It also relates to this Dojo Question: [link](https://community.dataminer.services/question/how-can-the-sum-of-parameters-with-units-be-calculated-in-a-visio/)