### PR TITLE
SLProtocol bitness update

### DIFF
--- a/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_32_Bit_Process.md
+++ b/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_32_Bit_Process.md
@@ -1,0 +1,50 @@
+---
+uid: Activating_SLProtocol_as_a_32_Bit_Process
+---
+
+# Activating SLProtocol as a 32-bit process
+
+From **DataMiner 10.3.9 onwards** SLProtocol will be 64-bit by default but a fallback soft-launch has been provided.
+
+This is a soft-launch feature that can be activated from **DataMiner 10.3.9 onwards**. There are **two ways** to activate this soft-launch feature, depending on whether you want to combine this with an upgrade action or not.
+
+> [!NOTE]
+> While this can be activated on only some of the DMAs in a cluster, we strongly recommend that you use the same configuration on all DMAs.
+
+## Activation with upgrade
+
+1. Create an empty text file named *SoftLaunchX86_SLProtocol.txt* in the folder `C:\Skyline DataMiner\Tools` on each DMA. There is no need to stop the DMAs for this.
+
+1. Install the DataMiner upgrade package.
+
+## Activation without upgrade
+
+1. Stop all DMAs where you want to enable this feature.
+
+1. Launch a command line prompt as administrator on each of the DMAs.
+
+1. Navigate to `C:\Skyline DataMiner\Tools\` in the prompts.
+
+1. Execute `RegisterSLProtocolAsX86.bat` from the prompts.
+
+1. Restart the DMAs.
+
+### Examples
+
+- Command line example:
+
+  ```bash
+  C:\> cd "C:\Skyline DataMiner\Tools\"
+  C:\Skyline DataMiner\Tools> RegisterSLProtocolAsX86.bat
+  ```
+
+- PowerShell example:
+
+  ```pwsh
+  PS C:\> cd "C:\Skyline DataMiner\Tools\"
+  PS C:\Skyline DataMiner\Tools> .\RegisterSLProtocolAsX86.bat
+  ```
+
+## Rollback
+
+[Activating SLProtocol as a 64-bit process](xref:Activating_SLProtocol_as_a_64_Bit_Process)

--- a/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_32_Bit_Process.md
+++ b/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_32_Bit_Process.md
@@ -47,4 +47,4 @@ This is a soft-launch feature that can be activated from **DataMiner 10.3.9 onwa
 
 ## Rollback
 
-[Activating SLProtocol as a 64-bit process](xref:Activating_SLProtocol_as_a_64_Bit_Process)
+See [Activating SLProtocol as a 64-bit process](xref:Activating_SLProtocol_as_a_64_Bit_Process).

--- a/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_32_Bit_Process.md
+++ b/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_32_Bit_Process.md
@@ -4,7 +4,7 @@ uid: Activating_SLProtocol_as_a_32_Bit_Process
 
 # Activating SLProtocol as a 32-bit process
 
-From **DataMiner 10.3.9 onwards** SLProtocol will be 64-bit by default but a fallback soft-launch has been provided.
+From DataMiner 10.3.9/10.4.0 onwards, SLProtocol is a 64-bit process by default. However, a fallback soft-launch has been provided.<!-- RN 36725 -->
 
 This is a soft-launch feature that can be activated from **DataMiner 10.3.9 onwards**. There are **two ways** to activate this soft-launch feature, depending on whether you want to combine this with an upgrade action or not.
 

--- a/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_64_Bit_Process.md
+++ b/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_64_Bit_Process.md
@@ -4,7 +4,7 @@ uid: Activating_SLProtocol_as_a_64_Bit_Process
 
 # Activating SLProtocol as a 64-bit process
 
-This is a soft-launch feature that can be activated from **DataMiner 10.1.8 onwards**. There are **two ways** to activate this soft-launch feature, depending on whether you want to combine this with an upgrade action or not.
+This is a soft-launch feature that can be activated from **DataMiner 10.1.8 onwards** and is default from **DataMiner 10.3.9 onwards**. There are **two ways** to activate this soft-launch feature, depending on whether you want to combine this with an upgrade action or not.
 
 > [!NOTE]
 > While this can be activated on only some of the DMAs in a cluster, we strongly recommend that you use the same configuration on all DMAs.

--- a/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_64_Bit_Process.md
+++ b/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_64_Bit_Process.md
@@ -42,3 +42,7 @@ This is a soft-launch feature that can be activated from **DataMiner 10.1.8 onwa
   PS C:\> cd "C:\Skyline DataMiner\Tools\"
   PS C:\Skyline DataMiner\Tools> .\RegisterSLProtocolAsX64.bat
   ```
+
+## Rollback
+
+[Activating SLProtocol as a 32-bit process](xref:Activating_SLProtocol_as_a_32_Bit_Process)

--- a/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_64_Bit_Process.md
+++ b/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_64_Bit_Process.md
@@ -4,7 +4,9 @@ uid: Activating_SLProtocol_as_a_64_Bit_Process
 
 # Activating SLProtocol as a 64-bit process
 
-This is a soft-launch feature that can be activated from **DataMiner 10.1.8/10.2.0 onwards**<!-- RN 30063 --> and is default from **DataMiner 10.3.9/10.4.0 onwards**.<!-- RN 36725 --> There are **two ways** to activate this soft-launch feature, depending on whether you want to combine this with an upgrade action or not.
+This is a soft-launch feature that can be activated from **DataMiner 10.1.8/10.2.0 onwards**<!-- RN 30063 -->. It is activated by default from **DataMiner 10.3.9/10.4.0 onwards**.<!-- RN 36725 -->
+
+There are **two ways** to activate this soft-launch feature, depending on whether you want to combine this with an upgrade action or not.
 
 > [!NOTE]
 > While this can be activated on only some of the DMAs in a cluster, we strongly recommend that you use the same configuration on all DMAs.
@@ -45,4 +47,4 @@ This is a soft-launch feature that can be activated from **DataMiner 10.1.8/10.2
 
 ## Rollback
 
-[Activating SLProtocol as a 32-bit process](xref:Activating_SLProtocol_as_a_32_Bit_Process)
+See [Activating SLProtocol as a 32-bit process](xref:Activating_SLProtocol_as_a_32_Bit_Process).

--- a/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_64_Bit_Process.md
+++ b/user-guide/Reference/Soft-launch_options/Activating_SLProtocol_as_a_64_Bit_Process.md
@@ -4,7 +4,7 @@ uid: Activating_SLProtocol_as_a_64_Bit_Process
 
 # Activating SLProtocol as a 64-bit process
 
-This is a soft-launch feature that can be activated from **DataMiner 10.1.8 onwards** and is default from **DataMiner 10.3.9 onwards**. There are **two ways** to activate this soft-launch feature, depending on whether you want to combine this with an upgrade action or not.
+This is a soft-launch feature that can be activated from **DataMiner 10.1.8/10.2.0 onwards**<!-- RN 30063 --> and is default from **DataMiner 10.3.9/10.4.0 onwards**.<!-- RN 36725 --> There are **two ways** to activate this soft-launch feature, depending on whether you want to combine this with an upgrade action or not.
 
 > [!NOTE]
 > While this can be activated on only some of the DMAs in a cluster, we strongly recommend that you use the same configuration on all DMAs.

--- a/user-guide/Reference/Soft-launch_options/Overview_of_Soft_Launch_Options.md
+++ b/user-guide/Reference/Soft-launch_options/Overview_of_Soft_Launch_Options.md
@@ -345,6 +345,12 @@ Enables SLProtocol as a 64-bit process. This option is not configured in *SoftLa
 - **Minimum version**: 10.1.8
 - **Estimated release version**: 10.3.9
 
+### SLProtocolAsX86
+
+Enables SLProtocol as a 32-bit process. This option is not configured in *SoftLaunchOptions.xml*. For more information on how to activate this, refer to [Activating SLProtocol as a 32-bit process](xref:Activating_SLProtocol_as_a_32_Bit_Process).
+
+- **Minimum version**: 10.3.9
+  
 ### SrmOwnServices
 
 Enables ownership support for SRM services.

--- a/user-guide/Reference/Soft-launch_options/Overview_of_Soft_Launch_Options.md
+++ b/user-guide/Reference/Soft-launch_options/Overview_of_Soft_Launch_Options.md
@@ -343,14 +343,15 @@ Enables the service profiles export and import in the DataMiner Cube Services ap
 Enables SLProtocol as a 64-bit process. This option is not configured in *SoftLaunchOptions.xml*. For more information on how to activate this, refer to [Activating SLProtocol as a 64-bit process](xref:Activating_SLProtocol_as_a_64_Bit_Process).
 
 - **Minimum version**: 10.1.8
-- **Estimated release version**: 10.3.9
+- **Release version**: 10.3.9
 
 ### SLProtocolAsX86
 
 Enables SLProtocol as a 32-bit process. This option is not configured in *SoftLaunchOptions.xml*. For more information on how to activate this, refer to [Activating SLProtocol as a 32-bit process](xref:Activating_SLProtocol_as_a_32_Bit_Process).
 
 - **Minimum version**: 10.3.9
-  
+- **Release version**: N/A
+
 ### SrmOwnServices
 
 Enables ownership support for SRM services.

--- a/user-guide/toc.yml
+++ b/user-guide/toc.yml
@@ -3760,6 +3760,8 @@
           topicUid: Overview_of_Soft_Launch_Options
         - name: Activating SLProtocol as a 64-bit process
           topicUid: Activating_SLProtocol_as_a_64_Bit_Process
+        - name: Activating SLProtocol as a 32-bit process
+          topicUid: Activating_SLProtocol_as_a_32_Bit_Process
     - name: DataMiner Extension Modules
       topicUid: DataMinerExtensionModules
     - name: Custom branding


### PR DESCRIPTION
From Dataminer 10.3.9 onwards, SLProtocol will be 64-bit.
A soft-launch is provided to go back to 32-bit for compatibility reasons.
Updated documentation with this soft-launch.