### PR TITLE
RN 36807: Disallow comma's in default alarm values

### DIFF
--- a/release-notes/DIS/DIS_2.42.md
+++ b/release-notes/DIS/DIS_2.42.md
@@ -38,6 +38,10 @@ This will allow you to validate the value of an attribute when applying an expor
 
 See also [release note 36622](xref:General_Main_Release_10.4.0_new_features#exportrule-elements-can-now-have-a-whereattribute-attribute-id_36622)
 
+#### Protocol Schema: Default Alarm Values aren't allowed to have comma's. [ID_36807]
+
+The protocol schema will now give a warning when comma's are being used in the default alarm value tags (`CH`, `MaH`, `MiH`, ...).
+
 ## Changes
 
 ### Enhancements

--- a/release-notes/DIS/DIS_2.42.md
+++ b/release-notes/DIS/DIS_2.42.md
@@ -38,9 +38,9 @@ This will allow you to validate the value of an attribute when applying an expor
 
 See also [release note 36622](xref:General_Main_Release_10.4.0_new_features#exportrule-elements-can-now-have-a-whereattribute-attribute-id_36622)
 
-#### Protocol Schema: Default Alarm Values aren't allowed to have comma's. [ID_36807]
+#### Protocol Schema: Commas are not allowed in default alarm values [ID_36807]
 
-The protocol schema will now give a warning when comma's are being used in the default alarm value tags (`CH`, `MaH`, `MiH`, ...).
+The protocol schema will now give a warning when commas are used in the default alarm value tags (`CH`, `MaH`, `MiH`, ...).
 
 ## Changes
 


### PR DESCRIPTION
[Release Note](https://intranet.skyline.be/DataMiner/Lists/Release%20Notes/DispForm.aspx?ID=36807)