### PR TITLE
Update NT_FILL_ARRAY.md

### DIFF
--- a/develop/api/NotifyTypes/NT_FILL_ARRAY.md
+++ b/develop/api/NotifyTypes/NT_FILL_ARRAY.md
@@ -29,7 +29,7 @@ protocol.NotifyProtocol(193/*NT_FILL_ARRAY*/ , tableID, tableContent);
 - Only the provided content will be present in the table after this call. In case the provided content should only be added to the table, use the NT_FILL_ARRAY_NO_DELETE call. See NT_FILL_ARRAY_NO_DELETE (194).
 - In case the column data contains null references, the corresponding cells will be cleared.
 - When NT_FILL_ARRAY is used, the column type must be set to "retrieved". In case other column types are present between the specified columns (e.g. columns of type "custom"), these other columns will be skipped.
-- The primary key should always be a string value. Even if it's an integer, you should still cast it to a string before calling FillArray.
+- The primary key should always be a string value. Even if it is an integer, you should still cast it to a string before calling FillArray.
 - The FillArray method cannot be used together with the "autoincrement" column option.
 - From DataMiner 8.0.9 onwards (RN7351), it is possible to set an additional flag indicating that some cells should be cleared (using protocol.Clear) or preserved (using protocol.Leave). To enable this, set the second entry of the tableInfo to true as indicated below:
 

--- a/develop/api/NotifyTypes/NT_FILL_ARRAY.md
+++ b/develop/api/NotifyTypes/NT_FILL_ARRAY.md
@@ -29,6 +29,7 @@ protocol.NotifyProtocol(193/*NT_FILL_ARRAY*/ , tableID, tableContent);
 - Only the provided content will be present in the table after this call. In case the provided content should only be added to the table, use the NT_FILL_ARRAY_NO_DELETE call. See NT_FILL_ARRAY_NO_DELETE (194).
 - In case the column data contains null references, the corresponding cells will be cleared.
 - When NT_FILL_ARRAY is used, the column type must be set to "retrieved". In case other column types are present between the specified columns (e.g. columns of type "custom"), these other columns will be skipped.
+- The primary key should always be a string value. Even if it's an integer, you should still cast it to a string before calling FillArray.
 - The FillArray method cannot be used together with the "autoincrement" column option.
 - From DataMiner 8.0.9 onwards (RN7351), it is possible to set an additional flag indicating that some cells should be cleared (using protocol.Clear) or preserved (using protocol.Leave). To enable this, set the second entry of the tableInfo to true as indicated below:
 


### PR DESCRIPTION
Extra remark for integer value primary keys. Because it will not throw any exception or log any error and that can be confusing.