### PR TITLE
Update Installing_DM_using_the_DM_Installer.md

### DIFF
--- a/user-guide/Getting_started/Installing_a_DMA/Installing_DM_using_the_DM_Installer.md
+++ b/user-guide/Getting_started/Installing_a_DMA/Installing_DM_using_the_DM_Installer.md
@@ -9,7 +9,8 @@ uid: Installing_DM_using_the_DM_installer
 
 The DataMiner installer allows you to run a default DataMiner installation, which includes a Cassandra database on the C drive, or to run a custom installation. A custom installation can for instance be used to install a MySQL database instead of a Cassandra database.
 
-DataMiner software can only be installed on the C: drive. Currently there is no option to select another drive for the installation of DataMiner installation.
+> [!NOTE]
+> The DataMiner software can only be installed on the C: drive. It is currently not possible to select another drive for the installation of DataMiner.
 
 ## Before you run the installer
 

--- a/user-guide/Getting_started/Installing_a_DMA/Installing_DM_using_the_DM_Installer.md
+++ b/user-guide/Getting_started/Installing_a_DMA/Installing_DM_using_the_DM_Installer.md
@@ -9,6 +9,8 @@ uid: Installing_DM_using_the_DM_installer
 
 The DataMiner installer allows you to run a default DataMiner installation, which includes a Cassandra database on the C drive, or to run a custom installation. A custom installation can for instance be used to install a MySQL database instead of a Cassandra database.
 
+DataMiner software can only be installed on the C: drive. Currently there is no option to select another drive for the installation of DataMiner installation.
+
 ## Before you run the installer
 
 1. Make sure the necessary .NET and .NET Framework versions are installed. See [DataMiner Compute Requirements](xref:DataMiner_Compute_Requirements).


### PR DESCRIPTION
The current documentation does not specify that DataMiner can only be installed on the C: drive. Please if we can confirm with Lab team in case they are working on a coming new feature to allow instal DataMiner on another drive