### PR TITLE
Patch 13

### DIFF
--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/OpenSearch_Database/Installing_OpenSearch_database.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/OpenSearch_Database/Installing_OpenSearch_database.md
@@ -78,7 +78,7 @@ Make sure the firewall ports are open for OpenSearch. OpenSearch operates on TCP
 
 ### Mounting the data drive
 
-In most cases, a separate hard drive will be used to store database data. The data drive has to be mounted and path to the data directory has to be specified in the Openseconfiguration file (see below).
+In most cases, a separate hard drive will be used to store database data. The data drive has to be mounted and path to the data directory has to be specified in the parameter *path.data* in *opensearch.yml* configuration file. An example of *opensearch.yml* can be found in the section [Initial configuration](#initial-configuration).
 
 The following example command mounts the drive */dev/sdb1* to the directory */media/data*: `sudo mount /dev/sdb1 /media/data`
 

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/OpenSearch_Database/Installing_OpenSearch_database.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/OpenSearch_Database/Installing_OpenSearch_database.md
@@ -83,12 +83,15 @@ In most cases, a separate hard drive will be used to store database data. The da
 
 ### Initial Configuration
 
+1. Configure the Linux setting *vm.max_map_count* as explained in the section [Important settings](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/#important-settings) of the OpenSearch documentation.
+
 1. Follow [Step 3: Set up OpenSearch in your environment](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/debian/#step-3-set-up-opensearch-in-your-environment) and change the *JVM Heap Space*.
 
    > [!IMPORTANT]
    > For production systems, Java heap size must be set higher than the default setting. We recommend that at least 8 GB is assigned for Java heap.
 
-1. For every node in your cluster, configure the *OpenSearch.yml* file as illustrated in the example below (the example uses three nodes). For more details on configuring an OpenSearch cluster, please see [Creating a cluster](https://opensearch.org/docs/latest/tuning-your-cluster/cluster/) in the official documentation.
+1. Configure OpenSearch nodes and set up a cluster. See the official documentation: [Creating a cluster](https://opensearch.org/docs/latest/tuning-your-cluster/cluster/).
+   Below is an example *opensearch.yml* file for a node in a three node cluster. Security in this example is disabled for the ease of testing.
 
    ```yml
    # Use a descriptive name for your cluster:
@@ -116,9 +119,9 @@ In most cases, a separate hard drive will be used to store database data. The da
    #
    # Set the bind address to a specific IP (IPv4 or IPv6), best is to use the real-ip of the node:
    #
-   network.host: 10.11.22.33
+   network.host: 166.206.186.146
    
-   network.publish_host: 10.11.22.33
+   network.publish_host: 166.206.186.146
    #
    # Set a custom port for HTTP:
    #
@@ -131,7 +134,7 @@ In most cases, a separate hard drive will be used to store database data. The da
    # Pass an initial list of hosts to perform discovery when this node is started:
    # The default list of hosts is ["127.0.0.1", "[::1]"]
    #
-   discovery.seed_hosts: ["10.11.22.31","10.11.22.32","10.11.22.33"]
+   discovery.seed_hosts: ["166.206.186.146","166.206.186.147","166.206.186.148"]
    
    discovery.type: zen
    cluster.initial_cluster_manager_nodes: ["opensearchnode1"]
@@ -164,7 +167,7 @@ In most cases, a separate hard drive will be used to store database data. The da
      # Pass an initial list of hosts to perform discovery when this node is started:
      # The default list of hosts is ["127.0.0.1", "[::1]"]
      #
-     discovery.seed_hosts: ["10.11.22.33"]
+     discovery.seed_hosts: ["166.206.186.146"]
      discovery.type: single-node  
      ```
 
@@ -182,7 +185,7 @@ Follow [Step 2: (Optional) Test OpenSearch](https://opensearch.org/docs/latest/i
 
 Optionally, you can set up OpenSearch Dashboards, which is the equivalent of Kibana for Elasticsearch. To do so, follow the instructions under [Installing OpenSearch Dashboards (Debian)](https://opensearch.org/docs/latest/install-and-configure/install-dashboards/debian/).
 
-You can for example install this on a Ubuntu Server from an APT repository or using .deb-packages. You will then be able to connect to your server using `http(s)://ipaddress:5601`(example: http(s)://10.11.22.33:5601).
+You can for example install this on a Ubuntu Server from an APT repository or using .deb-packages. You will then be able to connect to your server using `http(s)://ipaddress:5601`(example: http(s)://166.206.186.146:5601).
 
 To configure TLS, instead of using .pem certificates as recommended in the [OpenSearch documentation](https://opensearch.org/docs/latest/install-and-configure/install-dashboards/tls/), we recommend using .p12 files for trust and keystore. You can generate these using the [Generate-TLS-Certificates](https://github.com/SkylineCommunications/generate-tls-certificates) script maintained by the Skyline security team.
 

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/OpenSearch_Database/Installing_OpenSearch_database.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/OpenSearch_Database/Installing_OpenSearch_database.md
@@ -12,12 +12,12 @@ OpenSearch is only supported on Linux. DataMiner is compatible with the followin
 - OpenSearch 2.X
 
 > [!NOTE]
-> - We promote the use of Ubuntu LTS as the preferred Linux distribution. As such, the commands mentioned below will work on any Debian-based system, including Ubuntu.
+> We promote the use of Ubuntu LTS as the preferred Linux distribution. As such, the commands mentioned below will work on any Debian-based system, including Ubuntu.
 
 ## Installation and initial configuration
 
 > [!NOTE]
-> - For more information, please refer to the official [OpenSearch Documentation](https://opensearch.org/docs/latest/).
+> For more information, refer to the official [OpenSearch Documentation](https://opensearch.org/docs/latest/).
 
 ### Installation from an APT repository
 
@@ -39,49 +39,50 @@ Make sure the firewall ports are open for OpenSearch. OpenSearch operates on TCP
 - To add the correct ports to the firewall, you can for example use the following commands:
 
   - Commands node 1:
-  
+
     `$ sudo ufw allow from [IP node 2] to [IP node 1] proto tcp port 9200,9300`
-  
+
     `$ sudo ufw allow from [IP node 3] to [IP node 1] proto tcp port 9200,9300`
-  
+
   - Commands node 2:
-  
+
     `$ sudo ufw allow from [IP node 1] to [IP node 2] proto tcp port 9200,9300`
-  
+
     `$ sudo ufw allow from [IP node 3] to [IP node 2] proto tcp port 9200,9300`
   
   - Commands node 3:
-  
+
     `$ sudo ufw allow from [IP node 1] to [IP node 3] proto tcp port 9200,9300`
-  
+
     `$ sudo ufw allow from [IP node 2] to [IP node 3] proto tcp port 9200,9300`
 
 - Make sure all DMAs in the DMS can connect to port 9200 and 9300:
 
   - Connectivity for DMA 1 (with OpenSearch Dashboards connection allowed):
-  
+
     `$ sudo ufw allow from [IP node DMA 1] to [IP node 1] proto tcp port 9200,9300,5601`  
-    
+
     `$ sudo ufw allow from [IP node DMA 1] to [IP node 2] proto tcp port 9200,9300,5601`  
-    
+
     `$ sudo ufw allow from [IP node DMA 1] to [IP node 3] proto tcp port 9200,9300,5601`  
-  
+
   - Connectivity for DMA 2:
-  
+
     `$ sudo ufw allow from [IP node DMA 2] to [IP node 1] proto tcp port 9200,9300`  
-    
+
     `$ sudo ufw allow from [IP node DMA 2] to [IP node 2] proto tcp port 9200,9300`  
-    
+
     `$ sudo ufw allow from [IP node DMA 2] to [IP node 3] proto tcp port 9200,9300`  
-  
+
   - And so on.
 
 ### Mounting the data drive
 
 In most cases, a separate hard drive will be used to store database data. The data drive has to be mounted and path to the data directory has to be specified in the Openseconfiguration file (see below).
-   - The following example command mounts the drive */dev/sdb1* to the directory */media/data*: `sudo mount /dev/sdb1 /media/data`
 
-### Initial Configuration
+The following example command mounts the drive */dev/sdb1* to the directory */media/data*: `sudo mount /dev/sdb1 /media/data`
+
+### Initial configuration
 
 1. Configure the Linux setting *vm.max_map_count* as explained in the section [Important settings](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/#important-settings) of the OpenSearch documentation.
 
@@ -91,7 +92,8 @@ In most cases, a separate hard drive will be used to store database data. The da
    > For production systems, Java heap size must be set higher than the default setting. We recommend that at least 8 GB is assigned for Java heap.
 
 1. Configure OpenSearch nodes and set up a cluster. See the official documentation: [Creating a cluster](https://opensearch.org/docs/latest/tuning-your-cluster/cluster/).
-   Below is an example *opensearch.yml* file for a node in a three node cluster. Security in this example is disabled for the ease of testing.
+
+   Below is an example *opensearch.yml* file for a node in a three-node cluster. Security in this example is disabled for the ease of testing.
 
    ```yml
    # Use a descriptive name for your cluster:
@@ -148,17 +150,17 @@ In most cases, a separate hard drive will be used to store database data. The da
    ```
 
    - If you want a node to be a **data node**, add the following configuration in *OpenSearch.yml*:
- 
+
      ```yml
      node.roles: [ data, ingest ]
      ```
- 
+
    - If you want a node to be the **cluster manager node** (a.k.a. the master node), add the following configuration in *OpenSearch.yml*:
- 
+
      ```yml
      node.roles: [ cluster_manager ]
      ```
- 
+
    - For a single OpenSearch node, set the *discovery.type* setting to *single-node* and remove the *cluster.initial_cluster_manager_nodes* setting:
 
      ```yml
@@ -171,13 +173,13 @@ In most cases, a separate hard drive will be used to store database data. The da
      discovery.type: single-node  
      ```
 
-1. Restart OpenSearch service to apply the changes:
+1. Restart the OpenSearch service to apply the changes:
 
    ```bash
    sudo systemctl restart opensearch
    ```
 
-## Testing OpenSearch installation
+## Testing the OpenSearch installation
 
 Follow [Step 2: (Optional) Test OpenSearch](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/debian/#step-2-optional-test-opensearch) from the installation guide. Remember to also **query the plugins endpoint**.
 


### PR DESCRIPTION
Major restructuring of the OpenSearch installation guide.
Added:
- Firewall configuration
- Information about mounting the data drive
- additional info about configuring a single node database

Reordered:
- Initial configuration goes with disabled security (same as for Elastic)
- Security section goes after the installation & testing section.

Removed:
- `indices.query.bool.max_clause_count` setting should be set to "2147483647" (I strongly disagree with this recommendation).

Not sure:
- is the setting "http.port: 9200" necessary? I believe it can be commented out.
- what the setting "node.max_local_storage_nodes: 3" is for and whether it can be left as is for a single node.