### PR TITLE
Update Migrating_the_general_database_to_Cassandra.md

### DIFF
--- a/user-guide/Advanced_Functionality/Databases/Configuring_dedicated_clustered_storage/Migrating_existing_systems/Migrating_the_general_database_to_Cassandra.md
+++ b/user-guide/Advanced_Functionality/Databases/Configuring_dedicated_clustered_storage/Migrating_existing_systems/Migrating_the_general_database_to_Cassandra.md
@@ -28,22 +28,6 @@ The migration procedure has the following prerequisites:
 
 - The DataMiner Agents did not restart in the last 48 hours.
 
-> [!IMPORTANT]
-> To ensure that your Cassandra does not run out of memory under load, please configure the heap size for Cassandra before attempting a migration. 
-> Using the default "CMS" garbage collector, the heap space should ideally be between 8 and 16 Gb.
-> You can change the heap size **on Windows only** by performing the following procedure:
-> 
-> - Stop Cassandra
-> - Open regedit
-> - Navigate to HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Apache Software Foundation\Procrun 2.0\cassandra\Parameters\Java.
-> - Right click the “Options” and select Modify
-> - Add or update the entries containing **Xms** and **Xmx** with the heap size in MegaBytes. e.g. **-Xms8192M** and **-Xmx8192M** for 8 Gb
-> - Make these same changes in C:\Program Files\Cassandra\conf\jvm.options
-> - Restart Cassandra
-> 
-> For more information on how to tune the resources of Cassandra's Java Virtual Machine, including how to configure this on a Linux machine please see [Tuning the Java heap](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/operations/opsTuneJVM.html#opsTuneJVM__tuning-the-java-heap) .
->
-
 ## Before you start the migration wizard
 
 Before you start the Cassandra migration wizard, we recommend that you check the following things:
@@ -217,7 +201,32 @@ After you have followed the procedure above and system requirements are met, you
 
 ## After the migration
 
-1. To improve the security of the Cassandra database, follow the procedures mentioned under [Cassandra authentication](xref:Cassandra_authentication) .
+1. To improve the security of the Cassandra database, follow the procedures mentioned under [Cassandra authentication](xref:Cassandra_authentication).
+
+1. To ensure that your Cassandra database does not run out of memory under load, configure the heap size for Cassandra.
+
+   Using the default "CMS" garbage collector, the heap space should ideally be between 8 and 16 GB.
+
+   In **Windows**, you can change the heap size as follows:
+
+   1. Stop Cassandra.
+
+   1. Open Regedit  and go to the following key:
+
+      ```txt
+      HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Apache Software Foundation\Procrun 2.0\cassandra\Parameters\Java
+      ```
+
+   1. Right-click *Options* and select *Modify*.
+
+   1. Add or update the entries containing **Xms** and **Xmx** with the heap size in megabyte, e.g. **-Xms8192M** and **-Xmx8192M** for 8 GB.
+
+   1. Make these same changes in `C:\Program Files\Cassandra\conf\jvm.options`.
+
+   1. Restart Cassandra.
+
+   > [!TIP]
+   > For more information on how to tune the resources of Cassandra's Java Virtual Machine, including how to configure this on a Linux machine, see [Tuning the Java heap](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/operations/opsTuneJVM.html#opsTuneJVM__tuning-the-java-heap).
 
 1. If MySQL or MSSQL are no longer used on the DMA server, disable the relevant service:
 

--- a/user-guide/Advanced_Functionality/Databases/Configuring_dedicated_clustered_storage/Migrating_existing_systems/Migrating_the_general_database_to_Cassandra.md
+++ b/user-guide/Advanced_Functionality/Databases/Configuring_dedicated_clustered_storage/Migrating_existing_systems/Migrating_the_general_database_to_Cassandra.md
@@ -28,6 +28,22 @@ The migration procedure has the following prerequisites:
 
 - The DataMiner Agents did not restart in the last 48 hours.
 
+> [!IMPORTANT]
+> To ensure that your Cassandra does not run out of memory under load, please configure the heap size for Cassandra before attempting a migration. 
+> Using the default "CMS" garbage collector, the heap space should ideally be between 8 and 16 Gb.
+> You can change the heap size **on Windows only** by performing the following procedure:
+> 
+> - Stop Cassandra
+> - Open regedit
+> - Navigate to HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Apache Software Foundation\Procrun 2.0\cassandra\Parameters\Java.
+> - Right click the “Options” and select Modify
+> - Add or update the entries containing **Xms** and **Xmx** with the heap size in MegaBytes. e.g. **-Xms8192M** and **-Xmx8192M** for 8 Gb
+> - Make these same changes in C:\Program Files\Cassandra\conf\jvm.options
+> - Restart Cassandra
+> 
+> For more information on how to tune the resources of Cassandra's Java Virtual Machine, including how to configure this on a Linux machine please see [Tuning the Java heap](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/operations/opsTuneJVM.html#opsTuneJVM__tuning-the-java-heap) .
+>
+
 ## Before you start the migration wizard
 
 Before you start the Cassandra migration wizard, we recommend that you check the following things:


### PR DESCRIPTION
Added information on setting Heap size on Windows. Ideally a separate page should be made "Installing a Cassandra database on a DMA" which outlines that Cassandra is installed with DataMiner and mentions peculiarities about the configuration that we ship with. This would then have a better place there. However, that is tricky to do in the short term.