### PR TITLE
connector version semantics info

### DIFF
--- a/develop/devguide/Connector/Metadata.md
+++ b/develop/devguide/Connector/Metadata.md
@@ -10,7 +10,7 @@ Every connector contains the following metadata:
 |---------|---------|
 |[Name](xref:Protocol.Name)     | The name of the protocol.        |
 |[Description](xref:Protocol.Description)     |A short textual description of the protocol.         |
-|[Version](xref:Protocol.Version)     |A number or text indicating the protocol version.         |
+|[Version](xref:Protocol.Version)     |A number or text indicating the protocol version. For more information, refer to [Protocol version semantics](xref:ProtocolVersionSemantics).        |
 |[Vendor](xref:Protocol.Vendor)     |The name of the vendor of the device.         |
 |[VendorOID](xref:Protocol.VendorOID)     |The OID of the vendor of the device. Typically, this OID will start with the prefix 1.3.6.1.4.1, which identifies private enterprises.         |
 |[DeviceOID](xref:Protocol.DeviceOID)     |The OID of the device.         |

--- a/develop/devguide/Connector/Metadata.md
+++ b/develop/devguide/Connector/Metadata.md
@@ -9,16 +9,16 @@ Every connector contains the following metadata:
 |Item  |Description  |
 |---------|---------|
 |[Name](xref:Protocol.Name)     | The name of the protocol.        |
-|[Description](xref:Protocol.Description)     |A short textual description of the protocol.         |
-|[Version](xref:Protocol.Version)     |A number or text indicating the protocol version. For more information, refer to [Protocol version semantics](xref:ProtocolVersionSemantics).        |
-|[Vendor](xref:Protocol.Vendor)     |The name of the vendor of the device.         |
-|[VendorOID](xref:Protocol.VendorOID)     |The OID of the vendor of the device. Typically, this OID will start with the prefix 1.3.6.1.4.1, which identifies private enterprises.         |
-|[DeviceOID](xref:Protocol.DeviceOID)     |The OID of the device.         |
-|[Type](xref:Protocol.Type)     |The type of protocol (e.g. SNMP, SNMPv3, serial).         |
-|[ElementType](xref:Protocol.ElementType)     |A short text indicating the type of device.         |
-|[Provider](xref:Protocol.Provider)     |The name of the company or organization that created the protocol.         |
-|[IntegrationID](xref:Protocol.IntegrationID)     |The integration ID.         |
-|[VersionHistory](xref:Protocol.VersionHistory)     |The version history of the protocol. Available from DataMiner 9.5.11 onwards.         |
+|[Description](xref:Protocol.Description)     | A short textual description of the protocol.         |
+|[Version](xref:Protocol.Version)     | A number or text indicating the protocol version. For more information, refer to [Protocol version semantics](xref:ProtocolVersionSemantics).        |
+|[Vendor](xref:Protocol.Vendor)     | The name of the vendor of the device.         |
+|[VendorOID](xref:Protocol.VendorOID)     | The OID of the vendor of the device. Typically, this OID will start with the prefix 1.3.6.1.4.1, which identifies private enterprises.         |
+|[DeviceOID](xref:Protocol.DeviceOID)     | The OID of the device.         |
+|[Type](xref:Protocol.Type)     | The type of protocol (e.g. SNMP, SNMPv3, serial).         |
+|[ElementType](xref:Protocol.ElementType)     | A short text indicating the type of device.         |
+|[Provider](xref:Protocol.Provider)     | The name of the company or organization that created the protocol.         |
+|[IntegrationID](xref:Protocol.IntegrationID)     | The integration ID.         |
+|[VersionHistory](xref:Protocol.VersionHistory)     | The version history of the protocol. Available from DataMiner 9.5.11 onwards.         |
 
 ## See also
 

--- a/develop/devguide/Connector/ProtocolVersionSemantics.md
+++ b/develop/devguide/Connector/ProtocolVersionSemantics.md
@@ -31,18 +31,19 @@ It is possible that different version ranges are maintained in parallel but we s
 - Different branch ranges are maintained in parallel unless a range is explicitly marked as obsolete.
 - Range: [1 ... n]
 - Examples:
+
   - 1.0.0.1 = Initial branch.
   - 2.0.0.1 = New branch containing a subset of features.
   - Both ranges are maintained.
 
 ### System version
 
-- A new system version number is used when a system dependency has increased, and it is not possible to keep the driver compatible with previous versions. For example,
-the data source with which the connector communicates has a new firmware version which is not backwards compatible.
+- A new system version number is used when a system dependency has increased, and it is not possible to keep the driver compatible with previous versions. For example, the data source with which the connector communicates has a new firmware version which is not backwards compatible.
 
 - Different data source ranges are maintained in parallel unless a range is explicitly marked as obsolete.
 - Range: [0 ... n]
 - Examples:
+
   - 1.0.0.1 = Initial version supporting device firmware 10.0.x - 10.1.x.
   - 1.1.0.1 = New range to support device firmware range 10.2.x.
   - Typically, we will always try to only maintain the last range. Exceptions are made when, for example, a hardware version is still commonly used (and supported by the vendor) and only supports up to firmware version 10.1.x not allowing us to migrate corresponding elements to the new 1.1.0.x range.
@@ -50,11 +51,14 @@ the data source with which the connector communicates has a new firmware version
 ### Major change
 
 - A new major change version number is used when the change may have an impact on the DMS platform and an action by the user might be required when a driver is upgraded to this range. For example:
+
   - Another connection is added, and the user needs to configure an IP address on existing elements.
   - Parameter descriptions have been changed, so that any Visio drawings and Automation scripts referencing these descriptions may need to be updated.
+
 - Different major change ranges are not maintained in parallel, unless this is exceptionally agreed upon.
 - Range: [0...n]
 - Examples:
+
   - 1.0.0.1 = Initial version.
   - 1.0.1.1 = New range containing an extra connection.
   - Range 1.0.0.x becomes obsolete by default and will not be maintained.
@@ -66,6 +70,7 @@ the data source with which the connector communicates has a new firmware version
 - Range:  [1 ... n]
 - If the suffix _Bx is added, where x is a number in the range [1...n], this indicates a version build that is still being developed. For example: 1.0.0.5_B1.
 - Examples:
+
   - 1.0.0.1 = Initial version.
   - 1.0.0.2 = Second iteration containing extra features.
   - Version 1.0.0.1 becomes obsolete.

--- a/develop/devguide/Connector/ProtocolVersionSemantics.md
+++ b/develop/devguide/Connector/ProtocolVersionSemantics.md
@@ -29,7 +29,7 @@ It is possible that different version ranges are maintained in parallel but we s
 
 - A new branch number is used to support multiple versions that contain distinct differences (e.g. different protocol types, subsets of a driver, etc.).
 - Different branch ranges are maintained in parallel unless a range is explicitly marked as obsolete.
-- Range: [1 … n]
+- Range: [1 ... n]
 - Examples:
   - 1.0.0.1 = Initial branch.
   - 2.0.0.1 = New branch containing a subset of features.
@@ -41,11 +41,11 @@ It is possible that different version ranges are maintained in parallel but we s
 the data source with which the connector communicates has a new firmware version which is not backwards compatible.
 
 - Different data source ranges are maintained in parallel unless a range is explicitly marked as obsolete.
-- Range: [0 … n]
+- Range: [0 ... n]
 - Examples:
-  - 1.0.0.1 = Initial version supporting device firmware 10.0.x – 10.1.x.
+  - 1.0.0.1 = Initial version supporting device firmware 10.0.x - 10.1.x.
   - 1.1.0.1 = New range to support device firmware range 10.2.x.
-  - Typically, we will always try to only maintain the last range. Exceptions are made when, for example, a hardware version is still commonly used (and supported by the vendor) and only supports up to firmware version 10.1.x not allowing us to migrate corresponding element to the new 1.1.0.x range.
+  - Typically, we will always try to only maintain the last range. Exceptions are made when, for example, a hardware version is still commonly used (and supported by the vendor) and only supports up to firmware version 10.1.x not allowing us to migrate corresponding elements to the new 1.1.0.x range.
 
 ### Major change
 
@@ -53,7 +53,7 @@ the data source with which the connector communicates has a new firmware version
   - Another connection is added, and the user needs to configure an IP address on existing elements.
   - Parameter descriptions have been changed, so that any Visio drawings and Automation scripts referencing these descriptions may need to be updated.
 - Different major change ranges are not maintained in parallel, unless this is exceptionally agreed upon.
-- Range: [0…n]
+- Range: [0...n]
 - Examples:
   - 1.0.0.1 = Initial version.
   - 1.0.1.1 = New range containing an extra connection.
@@ -63,8 +63,8 @@ the data source with which the connector communicates has a new firmware version
 
 - A new minor change version number indicates an iteration in the driver range consisting of new features, fixes and/or changes.
 - This number is not included in the driver version range as previous iterations are never maintained in parallel.
-- Range:  [1 … n]
-- If the suffix _Bx is added, where x is a number in the range [1…n], this indicates a version build that is still being developed. For example: 1.0.0.5_B1.
+- Range:  [1 ... n]
+- If the suffix _Bx is added, where x is a number in the range [1...n], this indicates a version build that is still being developed. For example: 1.0.0.5_B1.
 - Examples:
   - 1.0.0.1 = Initial version.
   - 1.0.0.2 = Second iteration containing extra features.

--- a/develop/devguide/Connector/ProtocolVersionSemantics.md
+++ b/develop/devguide/Connector/ProtocolVersionSemantics.md
@@ -45,7 +45,7 @@ the data source with which the connector communicates has a new firmware version
 - Examples:
   - 1.0.0.1 = Initial version supporting device firmware 10.0.x – 10.1.x.
   - 1.1.0.1 = New range to support device firmware range 10.2.x.
-  - Both ranges are maintained in parallel.
+  - Typically, we will always try to only maintain the last range. Exceptions are made when, for example, a hardware version is still commonly used (and supported by the vendor) and only supports up to firmware version 10.1.x not allowing us to migrate corresponding element to the new 1.1.0.x range.
 
 ### Major change
 

--- a/develop/devguide/Connector/ProtocolVersionSemantics.md
+++ b/develop/devguide/Connector/ProtocolVersionSemantics.md
@@ -49,7 +49,7 @@ the data source with which the connector communicates has a new firmware version
 
 ### Major change
 
-- A new major change version number is used when the change may have an impact on the DMS platform and an action by the user is required when a driver is upgraded to this range. For example:
+- A new major change version number is used when the change may have an impact on the DMS platform and an action by the user might be required when a driver is upgraded to this range. For example:
   - Another connection is added, and the user needs to configure an IP address on existing elements.
   - Parameter descriptions have been changed, so that any Visio drawings and Automation scripts referencing these descriptions may need to be updated.
 - Different major change ranges are not maintained in parallel, unless this is exceptionally agreed upon.

--- a/develop/devguide/Connector/ProtocolVersionSemantics.md
+++ b/develop/devguide/Connector/ProtocolVersionSemantics.md
@@ -1,0 +1,80 @@
+---
+uid: ProtocolVersionSemantics
+---
+
+# Protocol version semantics
+
+Versioning of a DataMiner protocol provides users with visibility on changes, fixes, new features, the possible impact of changes, and compatibility requirements. Versioning also allows users to identify which version ranges are maintained in parallel.
+
+The version of a protocol is indicated using a specific format, as explained below.
+
+## Composition of a protocol version number
+
+A protocol version number consists of 4 numbers separated by periods. Each of the numbers has a distinct purpose.
+
+A.B.C.D
+
+- A = Branch
+- B = System version
+- C = Major change
+- D = Minor change
+
+For example: 1.0.0.1
+
+The combination of the first 3 numbers identifies the protocol version range.
+
+It is possible that different version ranges are maintained in parallel.
+
+### Branch
+
+- A new branch number is used to support multiple versions that contain distinct differences (e.g. different protocol types, subsets of a driver, etc.).
+- Different branch ranges are maintained in parallel unless a range is explicitly marked as obsolete.
+- Range: [1 … n]
+- Examples:
+  - 1.0.0.1 = Initial branch.
+  - 2.0.0.1 = New branch containing a subset of features.
+  - Both ranges are maintained.
+
+### System version
+
+- A new system version number is used when a system dependency has increased, and it is not possible to keep the driver compatible with previous versions. For example,
+the data source with which the connector communicates has a new firmware version which is not backwards compatible.
+
+- Different data source ranges are maintained in parallel unless a range is explicitly marked as obsolete.
+- Range: [0 … n]
+- Examples:
+  - 1.0.0.1 = Initial version supporting device firmware 10.0.x – 10.1.x.
+  - 1.1.0.1 = New range to support device firmware range 10.2.x.
+  - Both ranges are maintained in parallel.
+
+### Major change
+
+- A new major change version number is used when the change may have an impact on the DMS platform and an action by the user is required when a driver is upgraded to this range. For example:
+  - Another connection is added, and the user needs to configure an IP address on existing elements.
+  - Parameter descriptions have been changed, so that any Visio drawings and Automation scripts referencing these descriptions may need to be updated.
+- Different major change ranges are not maintained in parallel, unless this is exceptionally agreed upon.
+- Range: [0…n]
+- Examples:
+  - 1.0.0.1 = Initial version.
+  - 1.0.1.1 = New range containing an extra connection.
+  - Range 1.0.0.x becomes obsolete by default and will not be maintained.
+
+### Minor change
+
+- A new minor change version number indicates an iteration in the driver range consisting of new features, fixes and/or changes.
+- This number is not included in the driver version range as previous iterations are never maintained in parallel.
+- Range:  [1 … n]
+- If the suffix _Bx is added, where x is a number in the range [1…n], this indicates a version build that is still being developed. For example: 1.0.0.5_B1.
+- Examples:
+  - 1.0.0.1 = Initial version.
+  - 1.0.0.2 = Second iteration containing extra features.
+  - Version 1.0.0.1 becomes obsolete.
+
+## Update Center
+
+When a connector is installed in a DMS, you can retrieve new versions from the same branch through Update Center. For more detailed information, refer to [Updating protocols with the Update Center](xref:Adding_a_protocol_or_protocol_version_to_your_DataMiner_System#updating-protocols-with-the-update-center).
+
+In Update Center, detailed information is included in the version history overview, including:
+
+- What has been implemented in a version.
+- What the reason is for a possible range change and which possible actions need to be taken.

--- a/develop/devguide/Connector/ProtocolVersionSemantics.md
+++ b/develop/devguide/Connector/ProtocolVersionSemantics.md
@@ -23,7 +23,7 @@ For example: 1.0.0.1
 
 The combination of the first 3 numbers identifies the protocol version range.
 
-It is possible that different version ranges are maintained in parallel.
+It is possible that different version ranges are maintained in parallel but we should always try to keep this to a minimum.
 
 ### Branch
 

--- a/develop/schemadoc/Protocol/Protocol.Version.md
+++ b/develop/schemadoc/Protocol/Protocol.Version.md
@@ -19,6 +19,7 @@ Specifies the protocol version.
 Within a DataMiner System, you can maintain different versions of the same protocol and assign them to different elements. If you have to make modifications to a protocol, do not create a completely new protocol. Instead, make a new version of that same protocol.
 
 The content of the Version element can be a structured string specifying the branch, firmware, major and minor version (e.g. "1.0.0.3") or a string (e.g. "high power").
+
 For more information about the version semantics, refer to [Protocol version semantics](xref:ProtocolVersionSemantics).
 
 > [!NOTE]

--- a/develop/schemadoc/Protocol/Protocol.Version.md
+++ b/develop/schemadoc/Protocol/Protocol.Version.md
@@ -19,6 +19,7 @@ Specifies the protocol version.
 Within a DataMiner System, you can maintain different versions of the same protocol and assign them to different elements. If you have to make modifications to a protocol, do not create a completely new protocol. Instead, make a new version of that same protocol.
 
 The content of the Version element can be a structured string specifying the branch, firmware, major and minor version (e.g. "1.0.0.3") or a string (e.g. "high power").
+For more information about the version semantics, refer to [Protocol version semantics](xref:ProtocolVersionSemantics).
 
 > [!NOTE]
 > When you have two types of elements that are very similar (e.g. an optical transmitter: one with a high output power and another with a low output power), you can use the same protocol and create two versions (e.g. version "high power" and version "low power" for the protocol "optical transmitter". The only difference between the two versions would then be e.g. the range settings for the "Output Power" parameter).

--- a/develop/toc.yml
+++ b/develop/toc.yml
@@ -11,6 +11,9 @@
       items:
       - name: Metadata
         topicUid: Metadata
+        items:
+        - name: Protocol version semantics
+          topicUid: ProtocolVersionSemantics
       - name: Logic
         topicUid: Logic
         items:


### PR DESCRIPTION
Info about connector version semantics, which is taken from https://community.dataminer.services/documentation/protocol-version-numbering-explained/ is now included in docs.