### PR TITLE
Clarification for shared static parameter behavior

### DIFF
--- a/develop/devguide/Connector/LogicQActions.md
+++ b/develop/devguide/Connector/LogicQActions.md
@@ -117,7 +117,10 @@ The entry point method must be a public method of a public class.
 
 In the example above, the Run method of the QAction class is defined as a static method.
 
-It is also possible to define static fields in the QAction class. As only one copy of a static member exists, regardless of how many instances of the class are created, static fields are also shared between all the elements executing this protocol (and the same version) and persist as long as the SLScripting process is running.
+It is also possible to define static fields in the QAction class. As only one copy of a static member exists, regardless of how many instances of the class are created, static fields are also shared between all the elements executing this protocol and persist as long as the SLScripting process is running.
+
+> [!NOTE]
+> Static fields are only shared between elements with the same DataMiner version.
 
 Consider the following example of a protocol that defines a button (with parameter ID 100) triggering a QAction. The QAction defines a static field executionCount and a static method Run:
 

--- a/develop/devguide/Connector/LogicQActions.md
+++ b/develop/devguide/Connector/LogicQActions.md
@@ -117,7 +117,7 @@ The entry point method must be a public method of a public class.
 
 In the example above, the Run method of the QAction class is defined as a static method.
 
-It is also possible to define static fields in the QAction class. As only one copy of a static member exists, regardless of how many instances of the class are created, static fields are also shared between all the elements executing this protocol and persist as long as the SLScripting process is running.
+It is also possible to define static fields in the QAction class. As only one copy of a static member exists, regardless of how many instances of the class are created, static fields are also shared between all the elements executing this protocol (and the same version) and persist as long as the SLScripting process is running.
 
 Consider the following example of a protocol that defines a button (with parameter ID 100) triggering a QAction. The QAction defines a static field executionCount and a static method Run:
 

--- a/develop/devguide/Connector/LogicQActions.md
+++ b/develop/devguide/Connector/LogicQActions.md
@@ -120,7 +120,7 @@ In the example above, the Run method of the QAction class is defined as a static
 It is also possible to define static fields in the QAction class. As only one copy of a static member exists, regardless of how many instances of the class are created, static fields are also shared between all the elements executing this protocol and persist as long as the SLScripting process is running.
 
 > [!NOTE]
-> Static fields are only shared between elements with the same DataMiner version.
+> Static fields are only shared between elements with the same protocol version.
 
 Consider the following example of a protocol that defines a button (with parameter ID 100) triggering a QAction. The QAction defines a static field executionCount and a static method Run:
 


### PR DESCRIPTION
Added clarification for shared static parameter behavior. Version needs to be the same as well. (Could be added as a note if that would be better)