### PR TITLE
Add dotPeek as 3rd party tool

### DIFF
--- a/develop/TOOLS/DIS/Debugging/Debugging_a_connector.md
+++ b/develop/TOOLS/DIS/Debugging/Debugging_a_connector.md
@@ -25,3 +25,7 @@ When you have finished configuring all necessary settings, you can start debuggi
     > [!NOTE]
     > - Instead of clicking the yellow lightning bolt, you can also open DataMiner Cube, connect to the DataMiner Agent to which DIS is connected, and perform an action in the user interface that triggers the QAction you are debugging.
     > - When a QAction refers to another QAction in a DllImport attribute, then that referenced QAction will now also automatically be injected when you debug a protocol in DIS.
+
+> [!TIP]
+> - Debugging is often not possible for [third-party libraries](https://docs.dataminer.services/develop/TOOLS/NuGet/TOONuGet.html).
+> - [dotPeek](xref:dotPeek#debug-3rd-party-libraries) can serve as a handy tool to overcome this.

--- a/develop/TOOLS/DIS/Debugging/Debugging_a_connector.md
+++ b/develop/TOOLS/DIS/Debugging/Debugging_a_connector.md
@@ -27,5 +27,4 @@ When you have finished configuring all necessary settings, you can start debuggi
     > - When a QAction refers to another QAction in a DllImport attribute, then that referenced QAction will now also automatically be injected when you debug a protocol in DIS.
 
 > [!TIP]
-> - Debugging is often not possible for [third-party libraries](https://docs.dataminer.services/develop/TOOLS/NuGet/TOONuGet.html).
-> - [dotPeek](xref:dotPeek#debug-3rd-party-libraries) can serve as a handy tool to overcome this.
+> Debugging is often not possible for [third-party libraries](xref:TOONuGet). [dotPeek](xref:dotPeek) can serve as a handy tool to overcome this.

--- a/develop/TOOLS/DIS/Debugging/Debugging_an_Automation_script.md
+++ b/develop/TOOLS/DIS/Debugging/Debugging_an_Automation_script.md
@@ -28,5 +28,4 @@ When you have finished configuring all necessary settings, you can start debuggi
 > - Automation script debugging currently does not support memory files yet.
 
 > [!TIP]
-> - Debugging is often not possible for [third-party libraries](https://docs.dataminer.services/develop/TOOLS/NuGet/TOONuGet.html).
-> - [dotPeek](xref:dotPeek#debug-3rd-party-libraries) can serve as a handy tool to overcome this.
+> Debugging is often not possible for [third-party libraries](xref:TOONuGet). [dotPeek](xref:dotPeek) can serve as a handy tool to overcome this.

--- a/develop/TOOLS/DIS/Debugging/Debugging_an_Automation_script.md
+++ b/develop/TOOLS/DIS/Debugging/Debugging_an_Automation_script.md
@@ -26,3 +26,7 @@ When you have finished configuring all necessary settings, you can start debuggi
 > [!NOTE]
 > - Automation script debugging only works in conjunction with DataMiner Agents running at least DataMiner Main Release Version 10.1.0 or Feature Release Version 10.0.6.
 > - Automation script debugging currently does not support memory files yet.
+
+> [!TIP]
+> - Debugging is often not possible for [third-party libraries](https://docs.dataminer.services/develop/TOOLS/NuGet/TOONuGet.html).
+> - [dotPeek](xref:dotPeek#debug-3rd-party-libraries) can serve as a handy tool to overcome this.

--- a/develop/TOOLS/ThirdPartyTools/ThirdPartyTools.md
+++ b/develop/TOOLS/ThirdPartyTools/ThirdPartyTools.md
@@ -10,6 +10,7 @@ The following table lists some development tools that can be very useful while d
 |---------|---------|---------|
 |[DataStax DevCenter](xref:DataStax_DevCenter)     |This tool allows you to perform CQL queries or run scripts on a Cassandra database.         |Database         |
 |[dnSpy](xref:dnSpy)     |dnSpy is a debugger and .NET assembly editor.        |Debugger         |
+|[dotPeek](xref:dotPeek)     |dotPeek is a free .NET decompiler and assembly browser.     | Decompiler         |
 |[EBU LIST](xref:EBU_Live_IP_Software_Toolkit_LIST)     |EBU LIST is a freely available suite of software tools that can be used to check the state of IP-based networks and their high-bitrate media traffic.         |Network         |
 |[Fiddler](xref:Fiddler)     |Fiddler is a free web debugging tool that logs all HTTP(S) traffic between your computer and the Internet.         |Network         |
 |[ManageEngine MIB Browser](xref:ManageEngine_MIB_Browser)     |This tool allows you to monitor SNMP-enabled devices/servers.          |SNMP         |

--- a/develop/TOOLS/ThirdPartyTools/dotPeek.md
+++ b/develop/TOOLS/ThirdPartyTools/dotPeek.md
@@ -1,0 +1,54 @@
+﻿---
+uid: dotPeek
+---
+
+# dotPeek
+
+[dotPeek](https://www.jetbrains.com/decompiler/) is a freely accessible tool developed by JetBrains, 
+designed to analyze and decompile .NET assemblies. 
+It's an efficient and convenient tool that enables developers to explore and investigate the contents of compiled .NET code, 
+even when the source code isn't accessible.
+Key features include:
+
+1. High-Quality Decompilation: DotPeek effectively converts the assemblies into equivalent C# code, providing clear understanding of how the assembly functions.
+1. Built-In Viewer: It comes with a built-in viewer for .resources files, and can also decompile .exe, .dll, and .winmd files.
+1. Navigation and Search: Enables seamless navigation through the decompiled code with options to search for specific symbols, files, or types.
+1. Integrates with Visual Studio: Acts as a symbol server for Visual Studio, allowing you to step into decompiled assemblies while debugging.
+1. Export to Project: DotPeek allows you to decompile and export assemblies into Visual Studio projects for further inspection and modification.
+
+> [!IMPORTANT]
+> Remember, both binary and source code may be protected by copyright and trademark laws.
+> Ensure that the license agreement permits decompilation of the binary code. If not, obtain explicit permission from the copyright owner before proceeding with decompilation.
+
+> [!TIP]
+> For more information, see [dotPeek Introduction](https://www.jetbrains.com/help/decompiler/dotPeek_Introduction.html).
+
+## Debug 3rd party libraries
+DataMiner and DIS now support the [creation and use of NuGet libraries](xref:TOONuGet), 
+a feature tailored to boost your development process.
+Because these packages are typically shipped without debug symbols and source code, 
+the Visual Studio debugger is unable to step into the package code.
+However, dotPeek provides a seamless solution to this challenge. 
+Acting as a symbol server for Visual Studio, 
+dotPeek has the ability to automatically generate PDB files and corresponding source files.
+
+### Configuration
+
+1. Open the 3rd party libraries in dotPeek.
+   > [!TIP]
+   > dotPeek can load entire folders.
+   > In DataMiner, NuGet packages are stored under C:\Skyline DataMiner\ProtocolScripts\DllImport
+1. Click **Tools|Symbol Server** in the main menu to start the symbol server.
+   > [!NOTE]
+   > At the first start of dotPeek symbol server, you are asked to choose the assemblies you want to generate symbol files for.
+   > Select **All except .Net Framework assemblies**.
+1. In Visual Studio, click **Tools|Options...**
+1. Navigate to **Debugging** and make sure **Enable Just My Code** is unchecked.
+1. Navigate to **Debugging|Symbols** and click the plus icon to add a new location to the symbol file locations.
+1. Specify the following address: **http://localhost:33417** to link dotPeek as symbol server.
+   > [!NOTE]
+   > The port number is configurable in dotPeek
+1. Start your debugging session.
+
+> [!TIP]
+> For more information, see [Use dotPeek as a symbol server](https://www.jetbrains.com/help/decompiler/Using_product_as_a_Symbol_Server.html).

--- a/develop/TOOLS/ThirdPartyTools/dotPeek.md
+++ b/develop/TOOLS/ThirdPartyTools/dotPeek.md
@@ -4,50 +4,51 @@ uid: dotPeek
 
 # dotPeek
 
-[dotPeek](https://www.jetbrains.com/decompiler/) is a freely accessible tool developed by JetBrains, 
-designed to analyze and decompile .NET assemblies. 
-It's an efficient and convenient tool that enables developers to explore and investigate the contents of compiled .NET code, 
-even when the source code isn't accessible.
+[dotPeek](https://www.jetbrains.com/decompiler/) is a freely accessible tool developed by JetBrains, designed to analyze and decompile .NET assemblies. It is an efficient and convenient tool that enables developers to explore and investigate the contents of compiled .NET code, even when the source code is not accessible.
+
 Key features include:
 
-1. High-Quality Decompilation: DotPeek effectively converts the assemblies into equivalent C# code, providing clear understanding of how the assembly functions.
-1. Built-In Viewer: It comes with a built-in viewer for .resources files, and can also decompile .exe, .dll, and .winmd files.
-1. Navigation and Search: Enables seamless navigation through the decompiled code with options to search for specific symbols, files, or types.
-1. Integrates with Visual Studio: Acts as a symbol server for Visual Studio, allowing you to step into decompiled assemblies while debugging.
-1. Export to Project: DotPeek allows you to decompile and export assemblies into Visual Studio projects for further inspection and modification.
+- High-quality decompilation: dotPeek effectively converts the assemblies into equivalent C# code, providing clear understanding of how the assembly functions.
+- Built-in viewer: It comes with a built-in viewer for .resources files, and it can also decompile .exe, .dll, and .winmd files.
+- Navigation and search: dotPeek enables seamless navigation through the decompiled code with options to search for specific symbols, files, or types.
+- Integrates with Visual Studio: It acts as a symbol server for Visual Studio, allowing you to step into decompiled assemblies while debugging.
+- Export to project: dotPeek allows you to decompile and export assemblies into Visual Studio projects for further inspection and modification.
 
 > [!IMPORTANT]
-> Remember, both binary and source code may be protected by copyright and trademark laws.
-> Ensure that the license agreement permits decompilation of the binary code. If not, obtain explicit permission from the copyright owner before proceeding with decompilation.
+> Both binary and source code may be protected by copyright and trademark laws. Ensure that the license agreement permits decompilation of the binary code. If not, obtain explicit permission from the copyright owner before proceeding with decompilation.
 
 > [!TIP]
 > For more information, see [dotPeek Introduction](https://www.jetbrains.com/help/decompiler/dotPeek_Introduction.html).
 
-## Debug 3rd party libraries
-DataMiner and DIS now support the [creation and use of NuGet libraries](xref:TOONuGet), 
-a feature tailored to boost your development process.
-Because these packages are typically shipped without debug symbols and source code, 
-the Visual Studio debugger is unable to step into the package code.
-However, dotPeek provides a seamless solution to this challenge. 
-Acting as a symbol server for Visual Studio, 
-dotPeek has the ability to automatically generate PDB files and corresponding source files.
+## Debugging third-party libraries
+
+DataMiner and DIS support the [creation and use of NuGet libraries](xref:TOONuGet), a feature tailored to boost your development process.
+
+Because these packages are typically shipped without debug symbols and source code, the Visual Studio debugger is unable to step into the package code. However, dotPeek provides a solution to this challenge. Acting as a symbol server for Visual Studio, dotPeek can automatically generate PDB files and corresponding source files.
 
 ### Configuration
 
-1. Open the 3rd party libraries in dotPeek.
-   > [!TIP]
-   > dotPeek can load entire folders.
-   > In DataMiner, NuGet packages are stored under C:\Skyline DataMiner\ProtocolScripts\DllImport
-1. Click **Tools|Symbol Server** in the main menu to start the symbol server.
+1. Open the third-party libraries in dotPeek.
+
    > [!NOTE]
-   > At the first start of dotPeek symbol server, you are asked to choose the assemblies you want to generate symbol files for.
-   > Select **All except .Net Framework assemblies**.
-1. In Visual Studio, click **Tools|Options...**
-1. Navigate to **Debugging** and make sure **Enable Just My Code** is unchecked.
-1. Navigate to **Debugging|Symbols** and click the plus icon to add a new location to the symbol file locations.
-1. Specify the following address: **http://localhost:33417** to link dotPeek as symbol server.
+   > dotPeek can load entire folders. In DataMiner, NuGet packages are stored under `C:\Skyline DataMiner\ProtocolScripts\DllImport`.
+
+1. In the main menu, select *Tools* > *Symbol Server*  to start the symbol server.
+
    > [!NOTE]
-   > The port number is configurable in dotPeek
+   > When the dotPeek symbol server is first started, you are asked to choose the assemblies you want to generate symbol files for. Select *All except .Net Framework assemblies*.
+
+1. In Visual Studio, select *Tools* *Options*.
+
+1. Navigate to *Debugging* and make sure *Enable Just My Code* is not selected.
+
+1. Navigate to *Debugging* > *Symbols* and click the plus icon to add a new location to the symbol file locations.
+
+1. Specify the address `http://localhost:33417` to link dotPeek as symbol server.
+
+   > [!NOTE]
+   > The port number can be configured in dotPeek.
+
 1. Start your debugging session.
 
 > [!TIP]

--- a/develop/toc.yml
+++ b/develop/toc.yml
@@ -5387,6 +5387,8 @@
         topicUid: DataStax_DevCenter
       - name: dnSpy
         topicUid: dnSpy
+      - name: dotPeek
+        topicUid: dotPeek
       - name: EBU LIST
         topicUid: EBU_Live_IP_Software_Toolkit_LIST
       - name: Fiddler


### PR DESCRIPTION
Include references to dotPeek tool in the relevant debugging sections, and a new guide was created to explain its usage. This was done to provide developers with a solution for debugging third-party libraries.