### PR TITLE
Update Advanced_analytics_features_in_the_Alarm_Console.md

### DIFF
--- a/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features_in_the_Alarm_Console.md
+++ b/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features_in_the_Alarm_Console.md
@@ -4,7 +4,7 @@ uid: Advanced_analytics_features_in_the_Alarm_Console
 
 # Advanced analytics features in the Alarm Console
 
-A number of features in the Alarm Console make use of the artificial intelligence capabilities provided by DataMiner Analytics. These features are only available on systems with a Cassandra database. They can each be activated or deactivated in System Center, via *System Center \> System settings* > *analytics config*.
+A number of features in the Alarm Console make use of the artificial intelligence capabilities provided by DataMiner Analytics. The only requirements are database related: Pattern Matching requires Elastic and the other features require Cassandra. Each feature can be activated or deactivated in System Center, via *System Center \> System settings* > *analytics config*.
 
 The following advanced analytics features **assist at identifying incidents in the alarm data**:
 

--- a/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features_in_the_Alarm_Console.md
+++ b/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features_in_the_Alarm_Console.md
@@ -4,7 +4,7 @@ uid: Advanced_analytics_features_in_the_Alarm_Console
 
 # Advanced analytics features in the Alarm Console
 
-A number of features in the Alarm Console make use of the artificial intelligence capabilities provided by DataMiner Analytics. The only requirements are database related: Pattern Matching requires Elastic and the other features require Cassandra. Each feature can be activated or deactivated in System Center, via *System Center \> System settings* > *analytics config*.
+A number of features in the Alarm Console make use of the artificial intelligence capabilities provided by DataMiner Analytics. These features are only available on systems with a Cassandra database. Pattern matching is only available on systems with an [Elasticsearch indexing database](xref:Elasticsearch_database). All features can be activated or deactivated in System Center, via *System Center \> System settings* > *analytics config*.
 
 The following advanced analytics features **assist at identifying incidents in the alarm data**:
 

--- a/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features_in_the_Alarm_Console.md
+++ b/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features_in_the_Alarm_Console.md
@@ -4,7 +4,7 @@ uid: Advanced_analytics_features_in_the_Alarm_Console
 
 # Advanced analytics features in the Alarm Console
 
-A number of features in the Alarm Console make use of the artificial intelligence capabilities provided by DataMiner Analytics. These features are only available on systems with a Cassandra database. Pattern matching is only available on systems with an [Elasticsearch indexing database](xref:Elasticsearch_database). All features can be activated or deactivated in System Center, via *System Center \> System settings* > *analytics config*.
+A number of features in the Alarm Console make use of the artificial intelligence capabilities provided by DataMiner Analytics. These features are only available on systems with a Cassandra database. Pattern matching is only available on systems with an [indexing database](xref:Indexing_Database). All features can be activated or deactivated in System Center, via *System Center \> System settings* > *analytics config*.
 
 The following advanced analytics features **assist at identifying incidents in the alarm data**:
 


### PR DESCRIPTION
We are about to add a lightbulb in the alarm console. When certain features are disabled, the lightbulb will show a link to this page to inform the user on our other functionalities. This page contained all the information we needed, except for the fact that pattern matching requires elastic. I have tried to incorporate that information here.