### PR TITLE
Shortcut for opening apps in new card updated

### DIFF
--- a/user-guide/Getting_started/The_DataMiner_User_Interface/DataMiner_Cube/Cube_UI_components_X/DataMiner_Cube_sidebar.md
+++ b/user-guide/Getting_started/The_DataMiner_User_Interface/DataMiner_Cube/Cube_UI_components_X/DataMiner_Cube_sidebar.md
@@ -155,4 +155,4 @@ Depending on the configuration of your DataMiner System, the list can contain up
 
 - **WFM**: Custom DataMiner WorkFlow Manager components.
 
-Click any app in the list to open it. If you wish to open the app in a new card, hold Ctrl while clicking.
+Click any app in the list to open it. If you wish to open the app in a new card, click the app while pressing the *Ctrl* key.


### PR DESCRIPTION
Middle mouse doesn't work inside Apps pane, Ctrl + Left click can be used instead. If middle mouse not working in apps pane is not by design this change can be reverted once it's fixed. Tested on versions 10.3.0.0 and 10.2.0.0 of DataMiner Cube.