### PR TITLE
RN37173

### DIFF
--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Charts/Column_and_Bar_chart.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Charts/Column_and_Bar_chart.md
@@ -37,6 +37,10 @@ To configure the component:
 
    - *Bars*: Allows you to select which data should determine the size of the bars in the chart. Multiple bars can be selected.
 
+   From DataMiner 10.3.9/10.4.0 onwards, the following setting is available:
+
+   - *Advanced* \> *Empty Result message*: Allows you to specify a custom message that is displayed when the query returns no results. <!-- RN 37173 -->
+
    > [!NOTE]
    > From DataMiner 10.3.7/10.4.0 onwards, when you add a query to the component, the label and bars will automatically be configured. <!-- RN 36229 -->
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Charts/Line_and_area_chart.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Charts/Line_and_area_chart.md
@@ -66,6 +66,10 @@ To configure the component:
 
    - *Use percentage based values*: This option is only displayed if the component displays resource capacity information. If you select this option, the chart will display percentage values instead of absolute values.
 
+   From DataMiner 10.3.9/10.4.0 onwards, the following setting is available:
+
+   - *Advanced* \> *Empty Result message*: Allows you to specify a custom message that is displayed when the query returns no results. <!-- RN 37173 -->
+
 1. Optionally, fine-tune the component layout. In the *Component* > *Layout* tab, the following options are available:
 
    - The default options available for all components. See [Customizing the component layout](xref:Configuring_dashboard_components#customizing-the-component-layout).

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Charts/Pie_and_donut_chart.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Charts/Pie_and_donut_chart.md
@@ -19,6 +19,10 @@ To configure the component:
    > [!NOTE]
    > From DataMiner 10.3.7/10.4.0 onwards, when you add a query to the component, the label and segment size will automatically be configured. <!-- RN 36229 -->
 
+   From DataMiner 10.3.9/10.4.0 onwards, the following setting is available:
+
+   - *Advanced* \> *Empty Result message*: Allows you to specify a custom message that is displayed when the query returns no results. <!-- RN 37173 -->
+
 1. Optionally, fine-tune the component layout. In the *Component* > *Layout* tab, the following options are available:
 
    - *Chart shape*: Can be set to *Pie* or *Donut*.

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/Node_edge_graph.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/Node_edge_graph.md
@@ -71,6 +71,10 @@ The component uses dynamic coloring, which can be adjusted according to preferen
 
    - *Arrows*: The direction is visualized by means of arrows drawn on the edges. If you select this option, you can also specify the exact position of the arrows on the edges.
 
+   From DataMiner 10.3.9/10.4.0 onwards, the following setting is available:
+
+   - *Advanced* \> *Empty Result message*: Allows you to specify a custom message that is displayed when the query returns no results. <!-- RN 37173 -->
+  
 ## Component actions configuration
 
 If you add a node edge graph to a custom app using the [DataMiner Low-Code Apps](xref:Application_framework), you can also configure actions for the component. This feature is not available in the Dashboards app.

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Tables/Table_component.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Tables/Table_component.md
@@ -61,6 +61,8 @@ In the *Settings* tab for this component, you can customize its behavior to suit
 
 - If you want the first row to be selected by default, in the *Settings* tab, under *Initial Selection*, set the toggle button to *On* (available from DataMiner 10.3.6/10.4.0 onwards<!-- RN 35984 -->). This way, the first row will be automatically selected whenever the component is loaded or when the data in the table is refreshed.
 
+- If you want to configure the message shown when the query returns no results, In the *Settings* tab, under *Advanced* change the setting called *Empty result message*. This setting is by default filled in with 'Nothing to show.' (Available from 10.3.9/10.4.0 onwards). <!-- RN 37173 -->
+
 ## Exporting the table
 
 From DataMiner 10.2.0/10.1.3 onwards, you can export the content of the table by clicking the ... button in the top-right corner of the component and selecting *Export to CSV*. What happens next depends on your DataMiner version:


### PR DESCRIPTION
For Table, Grid, Pie&Donut, Column&Bar, Node edge, Line&area

 A new setting has been added to all above mentioned components. This setting enables users to personalize the message thats displayed when the GQI Query returns an empty result. This setting can be found under Component settings>Advanced>Empty result message. The default message is now 'Nothing to show.' and the setting cannot be left empty.