### PR TITLE
Add bitRateTracking to MaintenanceSettings documentation

### DIFF
--- a/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/MaintenanceSettings_xml.md
+++ b/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/MaintenanceSettings_xml.md
@@ -359,9 +359,19 @@ In this *MaxSize* tag, you can specify the maximum log file size.
 
 Default: 10 MB
 
-### Network
+### Network.bitRateTracking
 
-Using the attribute *bitRateTracking*, which is *true* by default, the bitrate calculations performed by SLProtocol can be disabled. Disabling bitrate tracking means the [Communication Info] table on the General Parameters page will not be updated. This also means the bitrate related notifies such as [NT_GET_BITRATE_DELTA](xref:NT_GET_BITRATE_DELTA) can also no longer be used by connectors.
+With the *bitRateTracking* tag, you can enable or disable the bitrate calculations performed by SLProtocol.
+
+|Value | Description |
+|--|--|
+| true | SLProtocol's bitrate calculations are enabled. (Default setting.) |
+| false | SLProtocol's bitrate calculations are disabled. |
+
+> [!NOTE]
+> Disabling this setting will halt updates to the *Communication Info* table on the *General parameters* page. Bitrate-related notifies such as [NT_GET_BITRATE_DELTA](xref:NT_GET_BITRATE_DELTA) will not be usable by connectors.
+
+For example:
 
 ```xml
 <Network bitRateTracking="true"/>

--- a/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/MaintenanceSettings_xml.md
+++ b/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/MaintenanceSettings_xml.md
@@ -75,6 +75,7 @@ This is an example of a *MaintenanceSettings.xml* file:
       <SkipRTE process="SLDataMiner.exe" thread="Database cleaning" />
     </FailoverOnRTE>
   </WatchDog>
+  <Network bitRateTracking="true">
 </MaintenanceSettings>
 ```
 
@@ -357,6 +358,14 @@ See [Configuring HTTPS settings in DataMiner](xref:Setting_up_HTTPS_on_a_DMA#con
 In this *MaxSize* tag, you can specify the maximum log file size.
 
 Default: 10 MB
+
+### Network
+
+Using the attribute *bitRateTracking*, which is *true* by default, the bitrate calculations performed by SLProtocol can be disabled. Disabling bitrate tracking means the [Communication Info] table on the General Parameters page will not be updated. This also means the bitrate related notifies such as [NT_GET_BITRATE_DELTA](xref:NT_GET_BITRATE_DELTA) can also no longer be used by connectors.
+
+```xml
+<Network bitRateTracking="true"/>
+```
 
 ### ProtocolSettings.DCF.CalculateAlarmState
 

--- a/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/MaintenanceSettings_xml.md
+++ b/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/MaintenanceSettings_xml.md
@@ -75,7 +75,7 @@ This is an example of a *MaintenanceSettings.xml* file:
       <SkipRTE process="SLDataMiner.exe" thread="Database cleaning" />
     </FailoverOnRTE>
   </WatchDog>
-  <Network bitRateTracking="true">
+  <Network bitRateTracking="true"/>
 </MaintenanceSettings>
 ```
 

--- a/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/MaintenanceSettings_xml.md
+++ b/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/MaintenanceSettings_xml.md
@@ -363,7 +363,7 @@ Default: 10 MB
 
 With the *bitRateTracking* tag, you can enable or disable the bitrate calculations performed by SLProtocol.
 
-|Value | Description |
+| Value | Description |
 |--|--|
 | true | SLProtocol's bitrate calculations are enabled. (Default setting.) |
 | false | SLProtocol's bitrate calculations are disabled. |


### PR DESCRIPTION
Don't know when this option was introduced, but it has been mentioned in TBD item 155, which was created in 2014.