### PR TITLE
Update ActionReplace.md

### DIFF
--- a/develop/devguide/Connector/Actions/ActionReplace.md
+++ b/develop/devguide/Connector/Actions/ActionReplace.md
@@ -43,6 +43,8 @@ The 0-based position of the parameter in the command/response.
 
 ## Examples
 
+In the following example, the fifth parameter (as Type@nr is 0-based) mentioned in the definition of response 324 will be replaced with the parameter of which the ID is set in parameter 10396. So, for example, if parameter 10396 contains 100, the fifth parameter in the response will be replaced with parameter 100:
+
 ```xml
 <Action id="1999">
   <On id="324">response</On>


### PR DESCRIPTION
Fixes #1892
Added example text for more clarity. The implementation in DataMiner is currently as described. I.e., type@id should hold an integer value which is the ID of the parameter to be used as the replacement parameter.