### PR TITLE
Document row position based calls as being unrecommended and refer to row PK based calls instead

### DIFF
--- a/src/DataMiner/QActionHelperBaseClasses/QActionTable.cs
+++ b/src/DataMiner/QActionHelperBaseClasses/QActionTable.cs
@@ -18,7 +18,8 @@ namespace Skyline.DataMiner.Scripting
 		public QActionTable(SLProtocol protocol, int tableId, string tableName) { }
 
 		/// <summary>
-		/// Gets or sets the row at the specified index (0-based).
+		/// Gets or sets the row at the specified index (0-based).<br/>
+		/// Note that this indexer should not be used. Using <see cref="this[string]"/> instead is highly recommended.
 		/// </summary>
 		/// <param name="row">The 0-based index of the row.</param>
 		/// <returns>The row data.</returns>
@@ -34,7 +35,8 @@ namespace Skyline.DataMiner.Scripting
 		public object[] this[string row] { get { return null; } set { } }
 
 		/// <summary>
-		/// Gets or sets the cell at the specified row and column index (0-based).
+		/// Gets or sets the cell at the specified row and column index (0-based).<br/>
+		/// Note that this indexer should not be used. Using <see cref="this[string, int]"/> instead is highly recommended.
 		/// </summary>
 		/// <param name="row">The 0-based index of the row.</param>
 		/// <param name="column">The 0-based index of the column.</param>

--- a/src/DataMiner/SLManagedScripting/SLProtocol.cs
+++ b/src/DataMiner/SLManagedScripting/SLProtocol.cs
@@ -1323,7 +1323,8 @@ namespace Skyline.DataMiner.Scripting
 		int SetParameterDescription(int iID, object value);
 
 		/// <summary>
-		/// Retrieves the value of a cell in the table specified by the 1-based row and column position.
+		/// Retrieves the value of a cell in the table specified by the 1-based row and column position.<br/>
+		/// Note that this method should not be used. Using <see cref="GetParameterIndexByKey(int, string, int)"/> instead is highly recommended.
 		/// </summary>
 		/// <param name="iID">The ID of the table parameter.</param>
 		/// <param name="iX">The 1-based position of the row.</param>
@@ -1350,7 +1351,8 @@ namespace Skyline.DataMiner.Scripting
 		object GetParameterIndex(int iID, int iX, int iY);
 
 		/// <summary>
-		/// Sets the value of a cell in a table, identified by its 1-based row and column position, with the specified value.
+		/// Sets the value of a cell in a table, identified by its 1-based row and column position, with the specified value.<br/>
+		/// Note that this method should not be used. Using <see cref="SetParameterIndexByKey(int, string, int, object, ValueType)"/> instead is highly recommended.
 		/// </summary>
 		/// <param name="iID">The ID of the table parameter.</param>
 		/// <param name="iX">The 1-based row position.</param>
@@ -1383,7 +1385,8 @@ namespace Skyline.DataMiner.Scripting
 		bool SetParameterIndex(int iID, int iX, int iY, object value, ValueType timeInfo);
 
 		/// <summary>
-		/// Sets the value of a cell in a table, identified by its 1-based row and column position, with the specified value.
+		/// Sets the value of a cell in a table, identified by its 1-based row and column position, with the specified value.<br/>
+		/// Note that this method should not be used. Using <see cref="SetParameterIndexByKey(int, string, int, object)"/> instead is highly recommended.
 		/// </summary>
 		/// <param name="iID">The ID of the table parameter.</param>
 		/// <param name="iX">The 1-based row position.</param>
@@ -1412,7 +1415,8 @@ namespace Skyline.DataMiner.Scripting
 		bool SetParameterIndex(int iID, int iX, int iY, object value);
 
 		/// <summary>
-		/// Sets the value of cells in tables, identified by their 1-based row and column position, with the specified values.
+		/// Sets the value of cells in tables, identified by their 1-based row and column position, with the specified values.<br/>
+		/// Note that this method should not be used. Using <see cref="SetParametersIndexByKey(int[], string[], int[], object[], DateTime[])"/> instead is highly recommended.
 		/// </summary>
 		/// <param name="ids">The IDs of the table parameters.</param>
 		/// <param name="iXs">The 1-based positions of the rows.</param>
@@ -1442,7 +1446,8 @@ namespace Skyline.DataMiner.Scripting
 		object SetParametersIndex(int[] ids, int[] iXs, int[] iYs, object[] values, DateTime[] timeInfos);
 
 		/// <summary>
-		/// Sets the value of cells in tables, identified by their 1-based row and column position, with the specified values.
+		/// Sets the value of cells in tables, identified by their 1-based row and column position, with the specified values.<br/>
+		/// Note that this method should not be used. Using <see cref="SetParametersIndexByKey(int[], string[], int[], object[])"/> instead is highly recommended.
 		/// </summary>
 		/// <param name="ids">The IDs of the table parameters.</param>
 		/// <param name="iXs">The 1-based positions of the rows.</param>
@@ -1649,7 +1654,8 @@ namespace Skyline.DataMiner.Scripting
 		object SetParametersIndexByKey(int[] ids, string[] keys, int[] iYs, object[] values);
 
 		/// <summary>
-		/// Gets the row data of the specified row in the specified table.
+		/// Gets the row data of the specified row in the specified table.<br/>
+		/// Note that this method should not be used. Using <see cref="GetRow(int, string)"/> instead is highly recommended.
 		/// </summary>
 		/// <param name="iPID">The ID of the table parameter.</param>
 		/// <param name="iRow">The 0-based index of the row.</param>
@@ -1701,7 +1707,8 @@ namespace Skyline.DataMiner.Scripting
 		object GetRow(int iPID, string key);
 
 		/// <summary>
-		/// Sets the data of the specified row to the specified values.
+		/// Sets the data of the specified row to the specified values.<br/>
+		/// Note that this method should not be used. Using <see cref="SetRow(int, string, object, ValueType, bool)"/> instead is highly recommended.
 		/// </summary>
 		/// <param name="iPID">The ID of the table parameter.</param>
 		/// <param name="iRow">The 0-based index of the row.</param>
@@ -1731,7 +1738,8 @@ namespace Skyline.DataMiner.Scripting
 		object SetRow(int iPID, int iRow, object row, ValueType timeInfo, [MarshalAs(UnmanagedType.U1)] bool bOverrideBehaviour);
 
 		/// <summary>
-		/// Sets the data of the specified row to the specified values.
+		/// Sets the data of the specified row to the specified values.<br/>
+		/// Note that this method should not be used. Using <see cref="SetRow(int, string, object, ValueType)"/> instead is highly recommended.
 		/// </summary>
 		/// <param name="iPID">The ID of the table parameter.</param>
 		/// <param name="iRow">The 0-based index of the row.</param>
@@ -1760,7 +1768,8 @@ namespace Skyline.DataMiner.Scripting
 		object SetRow(int iPID, int iRow, object row, ValueType timeInfo);
 
 		/// <summary>
-		/// Sets the data of the specified row to the specified values.
+		/// Sets the data of the specified row to the specified values.<br/>
+		/// Note that this method should not be used. Using <see cref="SetRow(int, string, object, bool)"/> instead is highly recommended.
 		/// </summary>
 		/// <param name="iPID">The ID of the table parameter.</param>
 		/// <param name="iRow">The 0-based index of the row.</param>
@@ -1786,7 +1795,8 @@ namespace Skyline.DataMiner.Scripting
 		object SetRow(int iPID, int iRow, object row, [MarshalAs(UnmanagedType.U1)] bool bOverrideBehaviour);
 
 		/// <summary>
-		/// Sets the data of the specified row to the specified values.
+		/// Sets the data of the specified row to the specified values.<br/>
+		/// Note that this method should not be used. Using <see cref="SetRow(int, string, object)"/> instead is highly recommended.
 		/// </summary>
 		/// <param name="iPID">The ID of the table parameter.</param>
 		/// <param name="iRow">The 0-based index of the row.</param>
@@ -2132,7 +2142,8 @@ namespace Skyline.DataMiner.Scripting
 		object Row(object theArray, int iRow);
 
 		/// <summary>
-		/// Gets the 1-based row position of the row that triggered the execution of the QAction.
+		/// Gets the 1-based row position of the row that triggered the execution of the QAction.<br/>
+		/// Note that this method should not be used. Using <see cref="RowKey()"/> instead is highly recommended.
 		/// </summary>
 		/// <returns>The position of the row.</returns>
 		/// <remarks>
@@ -2444,7 +2455,8 @@ namespace Skyline.DataMiner.Scripting
 		int CheckTrigger(int iID);
 
 		/// <summary>
-		/// Logs a message to the element log file.
+		/// Logs a message to the element log file.<br/>
+		/// Note that this method should not be used. Using <see cref="Log(string, LogType, LogLevel)"/> instead is recommended.
 		/// </summary>
 		/// <param name="iType">The logging type. Supported values: 1=Information, 2=Error, 4=DebugInfo, 8=Always.</param>
 		/// <param name="iLevel">The logging level. Supported values: -1=Development Logging, 0=No Logging, 1=Level 1 Logging, 2=Level 2 Logging, 3=Level 3 logging, 4=Level 4 Logging, 5=Log everything.</param>


### PR DESCRIPTION
xml documentation now clearly states that all row position based calls should not be used and now refers to the preferred row PK based calls.