### PR TITLE
Update Connect_to_cloud_requirements.md

### DIFF
--- a/user-guide/Cloud_Platform/Connecting_to_cloud/Connect_to_cloud_requirements.md
+++ b/user-guide/Cloud_Platform/Connecting_to_cloud/Connect_to_cloud_requirements.md
@@ -23,7 +23,7 @@ Before connecting your DataMiner System to dataminer.services, verify that the f
   > [!TIP]
   > Using SAML? See also: [Additional configuration for systems connected to dataminer.services](xref:Configuring_external_authentication_via_an_identity_provider_using_SAML#additional-configuration-for-systems-connected-to-dataminerservices)
   
-- From [DataMiner CloudGateway](xref:DataMinerExtensionModules#cloudgateway) version 2.10.0 onwards, the **internal network must allow [HTTP(S) traffic via port TCP 5100](xref:Configuring_the_IP_network_ports#overview-of-ip-ports-used-in-a-dms)**. For more information about configuring this endpoint, see [Custom dataminer.services endpoint configuration](xref:Custom_cloud_endpoint_configuration).
+- The **internal network must allow [HTTP(S) traffic via port TCP 5100](xref:Configuring_the_IP_network_ports#overview-of-ip-ports-used-in-a-dms)**. For more information about configuring this endpoint, see [Custom dataminer.services endpoint configuration](xref:Custom_cloud_endpoint_configuration).
 
   > [!NOTE]
   >


### PR DESCRIPTION
From now on CloudPack will hold a CloudGateway version higher than 2.10.0 so I removed this line to make the requirements more clear.