### PR TITLE
PDF report: private dashboards

### DIFF
--- a/user-guide/Advanced_Modules/Automation_module/Automation_script_actions/Upload_report_to_FTP.md
+++ b/user-guide/Advanced_Modules/Automation_module/Automation_script_actions/Upload_report_to_FTP.md
@@ -24,7 +24,8 @@ Use this action to upload a report to an FTP server:
    >
    > - If you want to specify multiple indices for one table parameter, use a semicolon “;” as separator.
    > - If you want to specify multiple parameters for one element, service, or protocol version, assign them all within a single line.
-   > - From DataMiner 9.6.13 onwards, you can select to include a dashboard from the new Dashboards app. The dashboards are listed in the drop-down list along with the reports. The icon in front of each item in the list shows whether the item is a dashboard or a report. From DataMiner 10.0.13 onwards, a *Configure* button is available that allows you to further configure a report based on a dashboard. See [Generating a PDF report based on a dashboard using DataMiner Cube](xref:Generating_a_report_based_on_a_dashboard_Cube).
+   > - Dashboards are listed in the dropdown list along with the reports. The icon in front of each item in the list shows whether the item is a dashboard or a report. From DataMiner 10.0.13 onwards, a *Configure* button is available that allows you to further configure a report based on a dashboard. See [Generating a PDF report based on a dashboard using DataMiner Cube](xref:Generating_a_report_based_on_a_dashboard_Cube).
+   > - Private dashboards will not appear in the dropdown list, as they cannot be shared. You can edit access to dashboards in the [dashboard settings](xref:Changing_dashboard_settings).
 
 ## Example
 

--- a/user-guide/Advanced_Modules/Automation_module/Automation_script_actions/Upload_report_to_shared_folder.md
+++ b/user-guide/Advanced_Modules/Automation_module/Automation_script_actions/Upload_report_to_shared_folder.md
@@ -25,7 +25,8 @@ Use this action to upload a report to a shared network folder:
    >
    > - If you want to specify multiple indices for one table parameter, use a semicolon “;” as separator.
    > - If you want to specify multiple parameters for one element, service, or protocol version, assign them all within a single line.
-   > - From DataMiner 9.6.13 onwards, you can select to include a dashboard from the new Dashboards app. The dashboards are listed in the drop-down list along with the reports. The icon in front of each item in the list shows whether the item is a dashboard or a report. From DataMiner 10.0.13 onwards, a *Configure* button is available that allows you to further configure a report based on a dashboard. See [Generating a PDF report based on a dashboard using DataMiner Cube](xref:Generating_a_report_based_on_a_dashboard_Cube).
+   > - Dashboards are listed in the dropdown list along with the reports. The icon in front of each item in the list shows whether the item is a dashboard or a report. From DataMiner 10.0.13 onwards, a *Configure* button is available that allows you to further configure a report based on a dashboard. See [Generating a PDF report based on a dashboard using DataMiner Cube](xref:Generating_a_report_based_on_a_dashboard_Cube).
+   > - Private dashboards will not appear in the dropdown list, as they cannot be shared. You can edit access to dashboards in the [dashboard settings](xref:Changing_dashboard_settings).
 
 ## Examples
 


### PR DESCRIPTION
I've created this pull request in response to a [Dojo question](https://community.dataminer.services/question/minimum-dashboard-rigths-for-scheduler/). A private dashboard will not appear in the dropdown list of available dashboards when using the action to upload a report to FTP or a shared folder.

Is this correct and OK to merge, @SebastiaanSL?