### PR TITLE
Update ConnectionsSnmpTraps.md

### DIFF
--- a/develop/devguide/Connector/ConnectionsSnmpTraps.md
+++ b/develop/devguide/Connector/ConnectionsSnmpTraps.md
@@ -201,6 +201,11 @@ In the following example, the severity is user-definable. The severity attribute
 </Param>
 ```
 
+> [!IMPORTANT]
+> 
+> - RTDisplay must be set to `true` to generate alarms.
+> - RTDisplay can be set to `false` if you only want to receive the trap.
+
 ## Processing traps in a QAction
 
 It is possible that a QAction is required to process an incoming trap. When the setBindings attribute is set to "allBindingInfo", an object holding the trap information will be available in the QAction.

--- a/develop/devguide/Connector/ConnectionsSnmpTraps.md
+++ b/develop/devguide/Connector/ConnectionsSnmpTraps.md
@@ -203,7 +203,7 @@ In the following example, the severity is user-definable. The severity attribute
 
 > [!IMPORTANT]
 > 
-> - RTDisplay must be set to `true` to generate alarms.
+> - [RTDisplay](xref:Protocol.Params.Param.Display.RTDisplay) must be set to `true` to generate alarms.
 > - RTDisplay can be set to `false` if you only want to receive the trap.
 
 ## Processing traps in a QAction

--- a/develop/devguide/Connector/ConnectionsSnmpTraps.md
+++ b/develop/devguide/Connector/ConnectionsSnmpTraps.md
@@ -204,7 +204,7 @@ In the following example, the severity is user-definable. The severity attribute
 > [!IMPORTANT]
 > 
 > - [RTDisplay](xref:Protocol.Params.Param.Display.RTDisplay) must be set to `true` to generate alarms.
-> - RTDisplay can be set to `false` if you only want to receive the trap.
+> - [RTDisplay](xref:Protocol.Params.Param.Display.RTDisplay) can be set to `false` if you only want to receive the trap.
 
 ## Processing traps in a QAction
 


### PR DESCRIPTION
[Protocol Param - RTDisplay True](https://intranet.skyline.be/DataMiner/Lists/ToDocument/DispForm.aspx?ID=189)
[JST] Trap Receivers do NOT need to be RTDisplay True. (This is valid for both the 'allBindingInfo'-type traps and for the setBindings-type trap receivers) I'm adding this here because a lot of people are putting these parameters as RTDisplay True which is unnecessary. 
[SVD] It is indeed true that you don't need it to receive a trap, but note that you do need it if you want to use one of the options to generate a info event or to mapAlarm, etc.