### PR TITLE
Small changes (Docs=Dojo)

### DIFF
--- a/dataminer-overview/DevOps/DataMiner_Devops_Professionals/DevOps_Points.md
+++ b/dataminer-overview/DevOps/DataMiner_Devops_Professionals/DevOps_Points.md
@@ -19,9 +19,9 @@ In general, the more active you are in the DataMiner Dojo community and the more
 
 - **Being active in the Q&A section on Dojo**: Asking, answering, and commenting on questions in the [Q&A section](https://community.dataminer.services/questions/) generates DevOps Points. Moreover, if your answer gets selected as the best answer by the community, you will earn extra DevOps Points. The person selecting the best answer will get something extra as well. Even voting on questions and answers will further grow your points, as does receiving votes (between 10 to 75 points).
 
-- **Completing online training courses**: The DataMiner Community offers a broad selection of [free online training](https://community.dataminer.services/learning/courses/). Enrolling in and completing any of those courses will again generate points (between 10 to 50 points). Note that the community also offers a variety of free self-tests to evaluate your knowledge. The successful completion of those [quizzes](https://community.dataminer.services/learning/quizzes/) will also result in points.
+- **Enrolling in and completing online training courses**: The DataMiner Community offers a broad selection of [free online training](https://community.dataminer.services/learning/courses/). Enrolling in and completing any of those courses will again generate points (between 10 to 50 points). Note that the community also offers a variety of free self-tests to evaluate your knowledge. The successful completion of those [quizzes](https://community.dataminer.services/learning/quizzes/) will also result in points.
 
-- **Getting your DataMiner skills certified**: Optionally, you can go for the paid [formal certification](xref:Overview_Training_certification) of some of your DataMiner skills. Upon obtaining your certification, you will be rewarded with extra points (500 to 1000 points).
+- **Formal certification**: Optionally, you can go for the paid [formal certification](xref:Overview_Training_certification) of some of your DataMiner skills. Upon obtaining your certification, you will be rewarded with extra points (500 to 1000 points).
 
 - **Contributing to the DataMiner documentation**: DataMiner Devops Professionals work with a community mindset, and sharing knowledge and information is all about empowering each other. Therefore, you are rewarded if you participate in and [contribute to the documentation](xref:contributing) of the DataMiner platform.
 
@@ -40,21 +40,21 @@ In general, the more active you are in the DataMiner Dojo community and the more
 
 - **Contributing to the DataMiner Catalog**: If you have designed a nice add-on for a DataMiner System for a specific use case, and you are willing to share this in the [DataMiner Catalog](https://catalog.dataminer.services/) to help empower the larger DataMiner community, you will be eligible for 250 up to 1000 DevOps Points. This could be a custom GQI operator, a custom Teams ChatOps operator, an Object Model, a user-definable API, etc.
 
-- **Writing a blog post**: You can opt to write and submit a [blog post](https://community.dataminer.services/blog/) for the community, and upon acceptance, this will result in 500 up to 1000 points. Blog posts can revolve around any technology or topic relevant to the community or could, for example, describe a solution that you have designed with DataMiner.
+- **Writing blog posts**: You can opt to write and submit a [blog post](https://community.dataminer.services/blog/) for the community, and upon acceptance, this will result in 500 up to 1000 points. Blog posts can revolve around any technology or topic relevant to the community or could, for example, describe a solution that you have designed with DataMiner.
 
   > [!TIP]
   > Not really sure how to get started? Take a look at our [blog post template](https://community.dataminer.services/download/blog-post-template/)!
 
-- **Creating a use case**: You can choose to submit a [use case](https://community.dataminer.services/use-cases/) for the community, and upon acceptance, this will result in 250 up to 2500 points. Use cases could focus on a new product integration that you have completed for DataMiner, or on any other type of solution that you have implemented with DataMiner.
+- **Submitting a use case**: You can choose to submit a [use case](https://community.dataminer.services/use-cases/) for the community, and upon acceptance, this will result in 250 up to 2500 points. Use cases could focus on a new product integration that you have completed for DataMiner, or on any other type of solution that you have implemented with DataMiner.
 
   > [!TIP]
   > Not really sure how to get started? Take a look at our [use case template](https://community.dataminer.services/download/use-case-template/)!
 
-- **Submitting feedback**: Your feedback is valuable. You will receive DevOps Points per submission of feedback via <https://aka.dataminer.services/Feedback/>. Each submission of the Customer Satisfaction Survey will result in 50 DevOps Points (limited to a maximum of 100 points per month).
+- **Submitting feedback**: Your feedback is valuable. You will receive DevOps Points per submission of feedback via <https://aka.dataminer.services/Feedback/>. Each submission of feedback will result in 50 DevOps Points (limited to a maximum of 100 points per month).
 
 - **Being an advocate for the DataMiner brand**: Being an advocate is also part of the culture of being a DataMiner DevOps Professional. That's why you can earn 250 points simply by adding your DataMiner DevOps level to your LinkedIn headline. Once you've updated your LinkedIn profile, you can send an email to [devops@skyline.be](mailto:devops@skyline.be) with the link to your profile page and we will get you your points! If DataMiner is mentioned in the job title in your email signature, we will hit you up with another 250 points per year. Each LinkedIn post that mentions @skyline and uses the tag #dataminerdevops will automatically result in 50 points per post.
 
-- **Reward for an outstanding DevOps mindset**: From time to time, Skyline staff members have the opportunity to nominate registered DataMiner DevOps Professionals who embody an exceptional DevOps mindset and demonstrate the effective application of associated best practices. This recognition results in the allocation of additional points, ranging from 100 up to 750, to the recipient's DataMiner DevOps Professional account.
+- **Reward for outstanding DevOps mindset**: From time to time, Skyline staff members have the opportunity to nominate registered DataMiner DevOps Professionals who exemplify an exceptional DevOps mindset and demonstrate the effective application of associated best practices. Such recognition leads to the allocation of additional points in the range of 100 up to 750 on the recipient's DataMiner DevOps Professional account.
 
 > [!IMPORTANT]
 > In addition to automatic tracking for most of the aforementioned activities to generate points, our community administrators will track certain activities to the best of their abilities to ensure that everybody is awarded all the points they are eligible for in due time. However, you are always welcome to expedite or facilitate the process by highlighting your activities via [devops@skyline.be](mailto:devops@skyline.be) if DevOps Points were not automatically attributed.


### PR DESCRIPTION
Small changes, originally included in PR #1591, so that the DevOps Points page on Docs is identical to the one on Dojo.