### PR TITLE
Add timing for grouping on DVE elements to Automatic Incident Tracking benchmarks

### DIFF
--- a/user-guide/Reference/Metrics/automatic_incident_tracking_benchmarks.md
+++ b/user-guide/Reference/Metrics/automatic_incident_tracking_benchmarks.md
@@ -18,4 +18,4 @@ uid: automatic_incident_tracking_benchmarks
 | -- | ------------- | ----- | ------ | ------- | ------------- |
 | 1 | Create group with 2,000 base alarms | DMS | 13 s | Create 2,000 alarms on the same parameter (in a table) and wait until all these alarms are grouped. Alarms are only grouped after the focus score has been calculated. | No other tests running. |
 | 2 | Clear group with 2,000 base alarms | DMS | 17 s | Clear all 2,000 base alarms from a group and wait until the group itself has been cleared. | No other tests running. |
-| 3 | Create group with 100 base alarms on DVE elements | DMS | 4 s | Create one alarm on 100 DVE child elements and wait until all these alarms are grouped. Includes the time it took to set the parameters on the DVE elements. | No other tests running. |
+| 3 | Create group with 100 base alarms on DVE elements | DMS | 4 s | Create one alarm on 100 DVE child elements and wait until all these alarms are grouped. Includes the time it takes to set the parameters on the DVE elements. | No other tests running. |

--- a/user-guide/Reference/Metrics/automatic_incident_tracking_benchmarks.md
+++ b/user-guide/Reference/Metrics/automatic_incident_tracking_benchmarks.md
@@ -18,3 +18,4 @@ uid: automatic_incident_tracking_benchmarks
 | -- | ------------- | ----- | ------ | ------- | ------------- |
 | 1 | Create group with 2,000 base alarms | DMS | 13 s | Create 2,000 alarms on the same parameter (in a table) and wait until all these alarms are grouped. Alarms are only grouped after the focus score has been calculated. | No other tests running. |
 | 2 | Clear group with 2,000 base alarms | DMS | 17 s | Clear all 2,000 base alarms from a group and wait until the group itself has been cleared. | No other tests running. |
+| 3 | Create group with 100 base alarms on DVE elements | DMS | 4 s | Create one alarm on 100 DVE child elements and wait until all these alarms are grouped. Includes the time it took to set the parameters on the DVE elements. | No other tests running. |


### PR DESCRIPTION
Add timings for an extra benchmark on Automatic Incident Tracking related to grouping alarms on DVE elements, which can be slightly slower than grouping alarms on normal elements.