### PR TITLE
RN 37233

### DIFF
--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/General/Stepper.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/General/Stepper.md
@@ -23,7 +23,7 @@ To configure the component:
 
      > [!NOTE]
      >
-     > - If the DOM history saving behavior of a module has been set to *Disabled* in [the `DomInstanceHistorySettings` object](xref:DOM_DomInstanceHistorySettings), the stepper component will not show a history of traversed states for any DOM instances. From DataMiner 10.3.11/10.4.0 onwards<!--RN 37233-->, instances without a history calculate the happy path from the initial state to the current state and then to the final state. In DataMiner 10.3.10, instances without a history calculate the happy path from the current state to the final state.
+     > - If the DOM history saving behavior of a module has been set to *Disabled* in [the `DomInstanceHistorySettings` object](xref:DOM_DomInstanceHistorySettings), the stepper component will not show the actual history of traversed states for any DOM instances. Instead, from DataMiner 10.3.11/10.4.0 onwards<!--RN 37233-->, instances without a history calculate the happy path from the initial state to the current state and then to the final state. In DataMiner 10.3.10, instances without a history only calculate the happy path from the current state to the final state.
      > - The DOM instance history objects are by default stored asynchronously, which enhances performance but may result in an outdated history when retrieved. In such cases, the path between the incomplete history and the current state is also completed according to the standard flow.
 
 1. Fine-tune the component layout. In the *Component > Layout* tab, the following options are available:

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/General/Stepper.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/General/Stepper.md
@@ -23,7 +23,7 @@ To configure the component:
 
      > [!NOTE]
      >
-     > - If the DOM history saving behavior of a module has been set to *Disabled* in [the `DomInstanceHistorySettings` object](xref:DOM_DomInstanceHistorySettings), the stepper component will not show a history of traversed states for any DOM instances. Instances without a history calculate the path from the initial state to the current state as if they followed the standard flow, similar to a happy path.
+     > - If the DOM history saving behavior of a module has been set to *Disabled* in [the `DomInstanceHistorySettings` object](xref:DOM_DomInstanceHistorySettings), the stepper component will not show a history of traversed states for any DOM instances. From DataMiner 10.3.11/10.4.0 onwards<!--RN 37233-->, instances without a history display the happy path from the initial state to the current state. In DataMiner 10.3.10, instances without a history calculate the path from the initial state to the current state as if they followed the standard flow, similar to a happy path.
      > - The DOM instance history objects are by default stored asynchronously, which enhances performance but may result in an outdated history when retrieved. In such cases, the path between the incomplete history and the current state is also completed according to the standard flow.
 
 1. Fine-tune the component layout. In the *Component > Layout* tab, the following options are available:

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/General/Stepper.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/General/Stepper.md
@@ -23,7 +23,7 @@ To configure the component:
 
      > [!NOTE]
      >
-     > - If the DOM history saving behavior of a module has been set to *Disabled* in [the `DomInstanceHistorySettings` object](xref:DOM_DomInstanceHistorySettings), the stepper component will not show a history of traversed states for any DOM instances. From DataMiner 10.3.11/10.4.0 onwards<!--RN 37233-->, instances without a history display the happy path from the initial state to the current state. In DataMiner 10.3.10, instances without a history calculate the path from the initial state to the current state as if they followed the standard flow, similar to a happy path.
+     > - If the DOM history saving behavior of a module has been set to *Disabled* in [the `DomInstanceHistorySettings` object](xref:DOM_DomInstanceHistorySettings), the stepper component will not show a history of traversed states for any DOM instances. From DataMiner 10.3.11/10.4.0 onwards<!--RN 37233-->, instances without a history calculate the happy path from the initial state to the current state and then to the final state. In DataMiner 10.3.10, instances without a history calculate the happy path from the current state to the final state.
      > - The DOM instance history objects are by default stored asynchronously, which enhances performance but may result in an outdated history when retrieved. In such cases, the path between the incomplete history and the current state is also completed according to the standard flow.
 
 1. Fine-tune the component layout. In the *Component > Layout* tab, the following options are available:


### PR DESCRIPTION
Hi @TVincke98, could you please review this pull request to confirm the accurate inclusion of release note 37233 in the user guide?

I am a bit unsure whether this release note introduces a noticeable change for users. In DataMiner 10.3.10, a path was calculated similar to a happy path, and now, from DataMiner 10.3.11/10.4.0 onwards, it is an actual happy path. If this isn't something users will notice as a difference between 10.3.10 and 10.3.11, it may be better to replace the text by one standard line: _"Instances without a history display the happy path from the initial state to the current state as if they followed the standard flow."_