### PR TITLE
RN 37404

### DIFF
--- a/develop/schemadoc/Protocol/Protocol.Params.Param.Type-options.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param.Type-options.md
@@ -105,7 +105,7 @@ From DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->, [smart-serial connections]
 > [!IMPORTANT]
 >
 > - Dynamic polling is only supported when the smart-serial connection acts as a client, not as a server. Assigning IP addresses like "127.0.0.1" or "any" makes the element act as a server, and it cannot switch to client mode without stopping first. Also, trying to assign a value like "127.0.0.1" to the dynamic IP parameter at runtime will cause an error.
-> - We highly recommend configuring the connection type as *smart-serial single* or *serial single*. This ensures that each connection is assigned a dedicated socket in SLPort. If multiple smart-serial or serial elements hosted on the same DMA share the same IP address and port through the element wizard, they will all use the new IP address if one of them changes the IP address dynamically.
+> - We highly recommend configuring the connection type as *smart-serial single* or *serial single*. This ensures that each connection is assigned a dedicated socket in SLPort. If multiple smart-serial or serial elements hosted on the same DMA are configured to share the same IP address and port, they will all use the new IP address if one of them changes the IP address dynamically.
 
 ### dynamic snmp get
 

--- a/develop/schemadoc/Protocol/Protocol.Params.Param.Type-options.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param.Type-options.md
@@ -100,14 +100,12 @@ If you do not specify a port, then the last port set will be used. If no port ha
 
 Only applicable for parameters of type read.
 
-From DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->, [smart-serial connections](xref:Smart_Serial_Connection) support dynamic polling, allowing you to change the IP address and IP port while the element remains active. To enable dynamic polling for a smart-serial connection, add the following parameter:
-
-`<Type options="dynamic ip">read</Type>`
+From DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->, [smart-serial connections](xref:Smart_Serial_Connection) support dynamic polling, allowing you to change the IP address and IP port while the element remains active.
 
 > [!IMPORTANT]
 >
 > - Dynamic polling is only supported when the smart-serial connection acts as a client, not as a server. Assigning IP addresses like "127.0.0.1" or "any" makes the element act as a server, and it cannot switch to a client mode without stopping it. Also, trying to assign a value like "127.0.0.1" to the dynamic IP parameter at runtime will cause an error.
-> - We highly recommend configuring the connection type as *smart-serial single*. This ensures that each connection is assigned a dedicated socket in SLPort. If multiple smart-serial elements hosted on the same DMA share the same IP address and port through the element wizard, they will all use the new IP address if one of them changes the IP address dynamically.
+> - We highly recommend configuring the connection type as *smart-serial single* or *serial single*. This ensures that each connection is assigned a dedicated socket in SLPort. If multiple smart-serial elements hosted on the same DMA share the same IP address and port through the element wizard, they will all use the new IP address if one of them changes the IP address dynamically.
 
 ### dynamic snmp get
 

--- a/develop/schemadoc/Protocol/Protocol.Params.Param.Type-options.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param.Type-options.md
@@ -105,7 +105,7 @@ From DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->, [smart-serial connections]
 > [!IMPORTANT]
 >
 > - Dynamic polling is only supported when the smart-serial connection acts as a client, not as a server. Assigning IP addresses like "127.0.0.1" or "any" makes the element act as a server, and it cannot switch to a client mode without stopping it. Also, trying to assign a value like "127.0.0.1" to the dynamic IP parameter at runtime will cause an error.
-> - We highly recommend configuring the connection type as *smart-serial single* or *serial single*. This ensures that each connection is assigned a dedicated socket in SLPort. If multiple smart-serial elements hosted on the same DMA share the same IP address and port through the element wizard, they will all use the new IP address if one of them changes the IP address dynamically.
+> - We highly recommend configuring the connection type as *smart-serial single* or *serial single*. This ensures that each connection is assigned a dedicated socket in SLPort. If multiple smart-serial or serial elements hosted on the same DMA share the same IP address and port through the element wizard, they will all use the new IP address if one of them changes the IP address dynamically.
 
 ### dynamic snmp get
 

--- a/develop/schemadoc/Protocol/Protocol.Params.Param.Type-options.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param.Type-options.md
@@ -100,6 +100,15 @@ If you do not specify a port, then the last port set will be used. If no port ha
 
 Only applicable for parameters of type read.
 
+From DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->, [smart-serial connections](xref:Smart_Serial_Connection) support dynamic polling, allowing you to change the IP address and IP port while the element remains active. To enable dynamic polling for a smart-serial connection, add the following parameter:
+
+`<Type options="dynamic ip">read</Type>`
+
+> [!IMPORTANT]
+>
+> - Dynamic polling is only supported when the smart-serial connection acts as a client, not as a server. Assigning IP addresses like "127.0.0.1" or "any" makes the element act as a server, and it cannot switch to a client mode without stopping it. Also, trying to assign a value like "127.0.0.1" to the dynamic IP parameter at runtime will cause an error.
+> - We highly recommend configuring the connection type as *smart-serial single*. This ensures that each connection is assigned a dedicated socket in SLPort. If multiple smart-serial elements hosted on the same DMA share the same IP address and port through the element wizard, they will all use the new IP address if one of them changes the IP address dynamically.
+
 ### dynamic snmp get
 
 With this option, an SNMP Get can be triggered dynamically when a parameter value changes.

--- a/develop/schemadoc/Protocol/Protocol.Params.Param.Type-options.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param.Type-options.md
@@ -104,7 +104,7 @@ From DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->, [smart-serial connections]
 
 > [!IMPORTANT]
 >
-> - Dynamic polling is only supported when the smart-serial connection acts as a client, not as a server. Assigning IP addresses like "127.0.0.1" or "any" makes the element act as a server, and it cannot switch to a client mode without stopping it. Also, trying to assign a value like "127.0.0.1" to the dynamic IP parameter at runtime will cause an error.
+> - Dynamic polling is only supported when the smart-serial connection acts as a client, not as a server. Assigning IP addresses like "127.0.0.1" or "any" makes the element act as a server, and it cannot switch to client mode without stopping first. Also, trying to assign a value like "127.0.0.1" to the dynamic IP parameter at runtime will cause an error.
 > - We highly recommend configuring the connection type as *smart-serial single* or *serial single*. This ensures that each connection is assigned a dedicated socket in SLPort. If multiple smart-serial or serial elements hosted on the same DMA share the same IP address and port through the element wizard, they will all use the new IP address if one of them changes the IP address dynamically.
 
 ### dynamic snmp get

--- a/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/Smart_Serial_Connection.md
+++ b/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/Smart_Serial_Connection.md
@@ -13,7 +13,7 @@ For smart-serial connections, you can specify the following connection settings 
   - If you specify “any” as the host address, DataMiner listens on all IP addresses on the specified port.
 
   > [!NOTE]
-  > [Dynamic polling](#dynamic-polling) (available from DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->) is only supported when the smart-serial connection acts as a client. Assigning an IP addresses like "127.0.0.1" or "any" makes the element acts as a server, and it cannot switch to a client mode without stopping it. Also, trying to assign a value like "127.0.0.1" to the dynamic IP parameter at runtime will cause an error.
+  > [Dynamic polling](#dynamic-polling) (available from DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->) is only supported when the smart-serial connection acts as a client. Assigning IP addresses like "127.0.0.1" or "any" makes the element act as a server, and it cannot switch to a client mode without stopping it. Also, trying to assign a value like "127.0.0.1" to the dynamic IP parameter at runtime will cause an error.
 
 - **IP port**: The IP port of the destination. This is not always required.
 

--- a/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/Smart_Serial_Connection.md
+++ b/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/Smart_Serial_Connection.md
@@ -13,7 +13,7 @@ For smart-serial connections, you can specify the following connection settings 
   - If you specify “any” as the host address, DataMiner listens on all IP addresses on the specified port.
 
   > [!NOTE]
-  > [Dynamic polling](xref:Protocol.Params.Param.Type-options#dynamic-ip) (available from DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->) is only supported when the smart-serial connection acts as a client. Assigning IP addresses like "127.0.0.1" or "any" makes the element act as a server, and it cannot switch to a client mode without stopping it. Also, trying to assign a value like "127.0.0.1" to the dynamic IP parameter at runtime will cause an error.
+  > [Dynamic polling](xref:Protocol.Params.Param.Type-options#dynamic-ip) (available from DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->) is only supported when the smart-serial connection acts as a client. Assigning IP addresses like "127.0.0.1" or "any" makes the element act as a server, and it cannot switch to client mode without stopping first. Also, trying to assign a value like "127.0.0.1" to the dynamic IP parameter at runtime will cause an error.
 
 - **IP port**: The IP port of the destination. This is not always required.
 

--- a/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/Smart_Serial_Connection.md
+++ b/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/Smart_Serial_Connection.md
@@ -13,7 +13,7 @@ For smart-serial connections, you can specify the following connection settings 
   - If you specify “any” as the host address, DataMiner listens on all IP addresses on the specified port.
 
   > [!NOTE]
-  > [Dynamic polling](#dynamic-polling) (available from DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->) is only supported when the smart-serial connection acts as a client. Assigning IP addresses like "127.0.0.1" or "any" makes the element act as a server, and it cannot switch to a client mode without stopping it. Also, trying to assign a value like "127.0.0.1" to the dynamic IP parameter at runtime will cause an error.
+  > [Dynamic polling](xref:Protocol.Params.Param.Type-options#dynamic-ip) (available from DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->) is only supported when the smart-serial connection acts as a client. Assigning IP addresses like "127.0.0.1" or "any" makes the element act as a server, and it cannot switch to a client mode without stopping it. Also, trying to assign a value like "127.0.0.1" to the dynamic IP parameter at runtime will cause an error.
 
 - **IP port**: The IP port of the destination. This is not always required.
 
@@ -27,16 +27,3 @@ For smart-serial connections, you can specify the following connection settings 
 - **Bus address**: The bus address of the device. This is not always required.
 
 - **Network**: The network interface (NIC). If only one network interface is available on the DMA, it is automatically selected.
-
-## Dynamic polling
-
-From DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->, the smart-serial connection supports dynamic polling, allowing you to change the IP address and IP port while the element remains active.
-s
-To enable dynamic polling for a smart-serial connection, add the following parameter:
-
-`<Type options="dynamic ip">read</Type>`
-
-> [!IMPORTANT]
->
-> - Dynamic polling is only supported when the smart-serial connection acts as a client, not as a server.
-> - We highly recommend configuring the connection type as *smart-serial single*. This ensures that each connection is assigned a dedicated socket in SLPort. If multiple smart-serial elements hosted on the same DMA share the same IP address and port through the element wizard, they will all use the new IP address if one of them changes the IP address dynamically.

--- a/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/Smart_Serial_Connection.md
+++ b/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/Smart_Serial_Connection.md
@@ -12,6 +12,9 @@ For smart-serial connections, you can specify the following connection settings 
 
   - If you specify “any” as the host address, DataMiner listens on all IP addresses on the specified port.
 
+  > [!NOTE]
+  > [Dynamic polling](#dynamic-polling) (available from DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->) is only supported when the smart-serial connection acts as a client. Assigning an IP addresses like "127.0.0.1" or "any" makes the element acts as a server, and it cannot switch to a client mode without stopping it. Also, trying to assign a value like "127.0.0.1" to the dynamic IP parameter at runtime will cause an error.
+
 - **IP port**: The IP port of the destination. This is not always required.
 
 - **Accepted IP address**: Available if a smart-serial server port of type TCP is used. Allows you to specify one or more allowed IP addresses for the connection. The element will then only communicate with those IP addresses. This configuration makes it possible for several elements to listen on the same port but communicate exclusively with a different set of IPs.
@@ -24,3 +27,16 @@ For smart-serial connections, you can specify the following connection settings 
 - **Bus address**: The bus address of the device. This is not always required.
 
 - **Network**: The network interface (NIC). If only one network interface is available on the DMA, it is automatically selected.
+
+## Dynamic polling
+
+From DataMiner 10.3.11/10.4.0 onwards<!--RN 37404-->, the smart-serial connection supports dynamic polling, allowing you to change the IP address and IP port while the element remains active.
+s
+To enable dynamic polling for a smart-serial connection, add the following parameter:
+
+`<Type options="dynamic ip">read</Type>`
+
+> [!IMPORTANT]
+>
+> - Dynamic polling is only supported when the smart-serial connection acts as a client, not as a server.
+> - We highly recommend configuring the connection type as *smart-serial single*. This ensures that each connection is assigned a dedicated socket in SLPort. If multiple smart-serial elements hosted on the same DMA share the same IP address and port through the element wizard, they will all use the new IP address if one of them changes the IP address dynamically.


### PR DESCRIPTION
Hi @LaurensMT, could you please review this pull request to confirm the accurate inclusion of release note 37404 in the user guide?

In release note 37404, you wrote the following: _"Similar like for serial connection, dynamic polling can be configured by adding a parameter that contains this: `<Type options="dynamic ip">read</Type>`."_

However, in the user guide, I cannot find any mention of serial connections supporting dynamic polling. When was this introduced (DataMiner version and release note)?