### PR TITLE
STaaS note for DOM settings backup

### DIFF
--- a/user-guide/Advanced_Modules/DOM/DOM_ModuleSettings.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_ModuleSettings.md
@@ -71,7 +71,7 @@ The current settings structure (with regards to `DomManager`) is as follows:
 
 - Only users with the [Module Settings](xref:DataMiner_user_permissions#modules--system-configuration--object-manager--module-settings) permission can create, delete, or update module settings.
 
-- To include the module settings in a [custom backup](xref:Backing_up_a_DataMiner_Agent_in_DataMiner_Cube#configuring-the-dataminer-backups) in Cube, select *Create a backup of the database* > *Include module specific configuration data*.
+- To include the module settings in a [custom backup](xref:Backing_up_a_DataMiner_Agent_in_DataMiner_Cube#configuring-the-dataminer-backups) in Cube, select *Create a backup of the database* > *Include module specific configuration data*. However, note that this is unnecessary if your system uses [Storage as a Service](xref:STaaS).
 
 - There are no license checks when module settings are added.
 


### PR DESCRIPTION
Based on https://community.dataminer.services/question/is-there-any-need-to-back-up-dom-module-settings-if-you-use-staas.