### PR TITLE
update of naming convention rules

### DIFF
--- a/develop/CICD/Skyline Communications/Github/Use_Github_Guidelines.md
+++ b/develop/CICD/Skyline Communications/Github/Use_Github_Guidelines.md
@@ -40,11 +40,10 @@ For a script, the correct license is **MIT**.
 
 ## Repository naming convention
 
-If the repository is private the name should look like this (using "-" as separator): **{customerAcronym}-{itemType}-{itemName}**
+If the repository is private, the name should look like this (using "-" as separator): **{customerAcronym}-{itemType}-{itemName}**
 
 > [!IMPORTANT]
-> IF the repository is PUBLIC then DO NOT USE customer acronym on the repository name, USE Skyline acronym 'SLC' instead.
-
+> If the repository is **public**, **do not use a customer acronym** in the repository name. Instead, use the **Skyline acronym "SLC"**.
 
 - For a list of **customer acronyms**, refer to [DCP](https://dcp.skyline.be/Lists/Customers/AllItems.aspx). For generic repositories, use the Skyline Communications acronym (SLC).
 

--- a/develop/CICD/Skyline Communications/Github/Use_Github_Guidelines.md
+++ b/develop/CICD/Skyline Communications/Github/Use_Github_Guidelines.md
@@ -40,7 +40,11 @@ For a script, the correct license is **MIT**.
 
 ## Repository naming convention
 
-The repository name should look like this (using "-" as separator): **{customerAcronym}-{itemType}-{itemName}**
+If the repository is private the name should look like this (using "-" as separator): **{customerAcronym}-{itemType}-{itemName}**
+
+> [!IMPORTANT]
+> IF the repository is PUBLIC then DO NOT USE customer acronym on the repository name, USE Skyline acronym 'SLC' instead.
+
 
 - For a list of **customer acronyms**, refer to [DCP](https://dcp.skyline.be/Lists/Customers/AllItems.aspx). For generic repositories, use the Skyline Communications acronym (SLC).
 


### PR DESCRIPTION
is a repo is public we can't use customer acronyms on naming