### PR TITLE
Add documentation about notice generated for AF when maximal cache size is reached

### DIFF
--- a/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Working_with_the_Alarm_Console/Applying_alarm_filters_in_the_Alarm_Console.md
+++ b/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Working_with_the_Alarm_Console/Applying_alarm_filters_in_the_Alarm_Console.md
@@ -186,6 +186,12 @@ Please note the following regarding the alarm focus feature:
 > [!NOTE]
 > You can enable or disable the alarm focus feature via *System Center* > *System settings* > *analytics config*. However, note that if you disable alarm focus, [automatic incident tracking](xref:Automatic_incident_tracking) is automatically also disabled, and only [manual incident tracking](xref:Automatic_incident_tracking#manually-updating-an-alarm-group) can still be used. <!-- RN 33348 -->
 
+> [!NOTE]
+> Alarm Focus internally creates a model for every parameter that had an alarm in the last two weeks up to a limit of 100 000 models. This upper limit should be plenty for most use cases, 
+but can be reached in rare cases. If this limit is reached, you will see a notice 'Alarm Focus has reached its maximum cache size' in the alarm console, and all alarms on parameters that have no model yet
+will be marked as unlikely. This notice will not have an influence on any other part of the system, and can be safely ignored. However, if you see this notice regularly, it can be a sign that your 
+parameters are not spread optimally over your DataMiner system, or that one of your protocols is generating alarms on many different rows in a table.
+
 ## Applying an alarm filter by dragging an item onto the Alarm Console
 
 Instead of manually applying a filter in a tab, you can also drag an item from the Cube UI onto the Alarm Console to create a tab filtered specifically for that item.

--- a/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Working_with_the_Alarm_Console/Applying_alarm_filters_in_the_Alarm_Console.md
+++ b/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Working_with_the_Alarm_Console/Applying_alarm_filters_in_the_Alarm_Console.md
@@ -183,14 +183,10 @@ Please note the following regarding the alarm focus feature:
 
 - In case of an alarm storm, the update of focus scores of persistent alarms is postponed until after the alarm storm ends.
 
-> [!NOTE]
-> You can enable or disable the alarm focus feature via *System Center* > *System settings* > *analytics config*. However, note that if you disable alarm focus, [automatic incident tracking](xref:Automatic_incident_tracking) is automatically also disabled, and only [manual incident tracking](xref:Automatic_incident_tracking#manually-updating-an-alarm-group) can still be used. <!-- RN 33348 -->
+- A model is created in DataMiner for every parameter that has had an alarm in the last two weeks, up to a limit of 100&thinsp;000 models. This upper limit is rarely ever reached, but when it is, the notice "Alarm Focus has reached its maximum cache size" is displayed in the Alarm Console, and all alarms on parameters that have no model yet will be marked as unlikely. This notice will not influence any other part of the system and can be safely ignored. However, if you see this notice regularly, it can be a sign that your parameters are not spread optimally over your DataMiner System, or that one of your protocols is generating alarms on many different rows in a table.
 
 > [!NOTE]
-> Alarm Focus internally creates a model for every parameter that had an alarm in the last two weeks up to a limit of 100 000 models. This upper limit should be plenty for most use cases, 
-but can be reached in rare cases. If this limit is reached, you will see a notice 'Alarm Focus has reached its maximum cache size' in the alarm console, and all alarms on parameters that have no model yet
-will be marked as unlikely. This notice will not have an influence on any other part of the system, and can be safely ignored. However, if you see this notice regularly, it can be a sign that your 
-parameters are not spread optimally over your DataMiner system, or that one of your protocols is generating alarms on many different rows in a table.
+> You can enable or disable the alarm focus feature via *System Center* > *System settings* > *analytics config*. However, note that if you disable alarm focus, [automatic incident tracking](xref:Automatic_incident_tracking) is automatically also disabled, and only [manual incident tracking](xref:Automatic_incident_tracking#manually-updating-an-alarm-group) can still be used. <!-- RN 33348 -->
 
 ## Applying an alarm filter by dragging an item onto the Alarm Console
 


### PR DESCRIPTION
Add documentation about the notice that Alarm Focus generates when it reaches its maximal cache size (cfr. RN37624)