### PR TITLE
Update Advanced_analytics_features_in_the_Alarm_Console.md

### DIFF
--- a/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features_in_the_Alarm_Console.md
+++ b/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features_in_the_Alarm_Console.md
@@ -1,5 +1,6 @@
 ---
 uid: Advanced_analytics_features_in_the_Alarm_Console
+keywords: alarm focus, AI
 ---
 
 # Advanced analytics features in the Alarm Console


### PR DESCRIPTION
made this change because I noticed few times before that it was impossible to search and find "alarm focus" in the documentation