### PR TITLE
Update SAML_using_Entra_ID.md

### DIFF
--- a/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Configuring_SAML/SAML_using_Entra_ID.md
+++ b/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Configuring_SAML/SAML_using_Entra_ID.md
@@ -431,7 +431,7 @@ There are two ways to configure this setup: with or without group claims.
          <EmailClaim>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress</EmailClaim>
          <Givenname>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname</Givenname>
          <Surname>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname</Surname>
-         <Groups claims="true">[group claim name]</Groups>
+         <Groups claims="true">http://schemas.microsoft.com/ws/2008/06/identity/claims/groups</Groups>
        </AutomaticUserCreation>
      </ExternalAuthentication>
      ...


### PR DESCRIPTION
We know the default group claim name on Azure, with the different methods separated now it might help avoid confusion/make it easier to just put the default claim in there