### PR TITLE
GQI Extensions - How to add or modify links to DataMiner objects (using metadata)

### DIFF
--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GQIEditableRow.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GQIEditableRow.md
@@ -9,7 +9,7 @@ uid: GQI_GQIEditableRow
 - Namespace: `Skyline.DataMiner.Analytics.GenericInterface`
 - Assembly: `SLAnalyticsTypes.dll`
 
-Represents a row that a custom operator can manipulate.
+Represents a row that a custom operator can manipulate. Inherits from [GQIRow](xref:GQI_GQIRow).
 
 ## Methods
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GQIRow.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GQIRow.md
@@ -51,4 +51,4 @@ Creates a new row with a specified row key and the provided cells.
 | -------- | ---- | ----------- |
 | Key | `string` | Unique identifier of the row within the query result. |
 | Cells | [GQICell](xref:GQI_GQICell)[] | Cells of the row. |
-| Metadata | [GenIfRowMetadata](xref:GQI_GenIfRowMetadata) | Links to DataMiner objects. |
+| Metadata | [GenIfRowMetadata](xref:GQI_GenIfRowMetadata) | Extra information to aid clients in interpreting the row. |

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GQIRow.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GQIRow.md
@@ -51,3 +51,4 @@ Creates a new row with a specified row key and the provided cells.
 | -------- | ---- | ----------- |
 | Key | `string` | Unique identifier of the row within the query result. |
 | Cells | [GQICell](xref:GQI_GQICell)[] | Cells of the row. |
+| Metadata | [GenIfRowMetadata](xref:GQI_GenIfRowMetadata) | Links to DataMiner objects. |

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GQIRow.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GQIRow.md
@@ -51,4 +51,4 @@ Creates a new row with a specified row key and the provided cells.
 | -------- | ---- | ----------- |
 | Key | `string` | Unique identifier of the row within the query result. |
 | Cells | [GQICell](xref:GQI_GQICell)[] | Cells of the row. |
-| Metadata | [GenIfRowMetadata](xref:GQI_GenIfRowMetadata) | Extra information to aid clients in interpreting the row. Available from DataMiner 10.4.1/10.4.0 onwards. |
+| Metadata | [GenIfRowMetadata](xref:GQI_GenIfRowMetadata) | Extra information to aid clients in interpreting the row. Available from DataMiner 10.4.0/10.4.1 onwards. |

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GQIRow.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GQIRow.md
@@ -51,4 +51,4 @@ Creates a new row with a specified row key and the provided cells.
 | -------- | ---- | ----------- |
 | Key | `string` | Unique identifier of the row within the query result. |
 | Cells | [GQICell](xref:GQI_GQICell)[] | Cells of the row. |
-| Metadata | [GenIfRowMetadata](xref:GQI_GenIfRowMetadata) | Extra information to aid clients in interpreting the row. Available from DataMiner 10.4.0 onwards. |
+| Metadata | [GenIfRowMetadata](xref:GQI_GenIfRowMetadata) | Extra information to aid clients in interpreting the row. Available from DataMiner 10.4.1/10.4.0 onwards. |

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GQIRow.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GQIRow.md
@@ -51,4 +51,4 @@ Creates a new row with a specified row key and the provided cells.
 | -------- | ---- | ----------- |
 | Key | `string` | Unique identifier of the row within the query result. |
 | Cells | [GQICell](xref:GQI_GQICell)[] | Cells of the row. |
-| Metadata | [GenIfRowMetadata](xref:GQI_GenIfRowMetadata) | Extra information to aid clients in interpreting the row. |
+| Metadata | [GenIfRowMetadata](xref:GQI_GenIfRowMetadata) | Extra information to aid clients in interpreting the row. Available from DataMiner 10.4.0 onwards. |

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GenIfRowMetadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/GenIfRowMetadata.md
@@ -1,0 +1,18 @@
+---
+uid: GQI_GenIfRowMetadata
+---
+
+# GenIfRowMetadata class
+
+## Definition
+
+- Namespace: `Skyline.DataMiner.Analytics.GenericInterface`
+- Assembly: `SLAnalyticsTypes.dll`
+
+Represents all metadata linked to a specific [GQIRow](xref:GQI_GQIRow).
+
+## Properties
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| Metadata | [RowMetadataBase](xref:GQI_RowMetadataBase)[] | The collection of all linked metadata. |

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/ObjectRefMetadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/ObjectRefMetadata.md
@@ -10,13 +10,14 @@ uid: GQI_ObjectRefMetadata
 - Assembly: `SLAnalyticsTypes.dll`
 
 Represents a link to a DataMiner object for a [GQIRow](xref:GQI_GQIRow).
+
 Inherits from [RowMetadataBase](xref:GQI_RowMetadataBase).
 
 ## Properties
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| Object | [DMAObjectRef](#dmaobjectref) | A type specific reference to the DataMiner object. |
+| Object | [DMAObjectRef](#dmaobjectref) | A type-specific reference to the DataMiner object. |
 
 ## DMAObjectRef
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/ObjectRefMetadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/ObjectRefMetadata.md
@@ -1,0 +1,44 @@
+---
+uid: GQI_ObjectRefMetadata
+---
+
+# ObjectRefMetadata class
+
+## Definition
+
+- Namespace: `Skyline.DataMiner.Analytics.GenericInterface`
+- Assembly: `SLAnalyticsTypes.dll`
+
+Represents a link to a DataMiner object for a [GQIRow](xref:GQI_GQIRow).
+Inherits from [RowMetadataBase](xref:GQI_RowMetadataBase).
+
+## Properties
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| Object | [DMAObjectRef](#dmaobjectref) | A type specific reference to the DataMiner object. |
+
+## DMAObjectRef
+
+`DMAObjectRef` is an abstract base class for all types representing a reference to a specific DataMiner object.
+
+> [!IMPORTANT]
+> `DMAObjectRef` and its derived classes are part of a different namespace and assembly.
+>
+> - Namespace: `Skyline.DataMiner.Net`
+> - Assembly: `SLNetTypes.dll`
+
+The following derived classes are currently supported:
+
+- AlarmID
+- DomInstanceId
+- ElementID
+- PaProcessObjectRef
+- ParamID
+- PaTokenObjectRef
+- ProfileInstanceID
+- ReservationInstanceID
+- ResourceID
+- ResourcePoolID
+- ServiceID
+- ViewID

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/RowMetadataBase.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/RowMetadataBase.md
@@ -1,0 +1,16 @@
+---
+uid: GQI_RowMetadataBase
+---
+
+# RowMetadataBase class
+
+## Definition
+
+- Namespace: `Skyline.DataMiner.Analytics.GenericInterface`
+- Assembly: `SLAnalyticsTypes.dll`
+
+This is an abstract class that serves as a base class for all possible types of row metadata.
+
+## Derived types
+
+- [ObjectRefMetadata](xref:GQI_ObjectRefMetadata): A link to a DataMiner object.

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/RowMetadataBase.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/RowMetadataBase.md
@@ -13,4 +13,5 @@ This is an abstract class that serves as a base class for all possible types of 
 
 ## Derived types
 
-- [ObjectRefMetadata](xref:GQI_ObjectRefMetadata): A link to a DataMiner object.
+- [ObjectRefMetadata](xref:GQI_ObjectRefMetadata): Link to a DataMiner object.
+- [TimeRangeMetadata](xref:GQI_TimeRangeMetadata): Link to a time range.

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/TimeRangeMetadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/TimeRangeMetadata.md
@@ -10,6 +10,7 @@ uid: GQI_TimeRangeMetadata
 - Assembly: `SLAnalyticsTypes.dll`
 
 Represents a link to a specific time range for a [GQIRow](xref:GQI_GQIRow).
+
 Inherits from [RowMetadataBase](xref:GQI_RowMetadataBase).
 
 ## Properties

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/TimeRangeMetadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/API_Reference/TimeRangeMetadata.md
@@ -1,0 +1,20 @@
+---
+uid: GQI_TimeRangeMetadata
+---
+
+# TimeRangeMetadata class
+
+## Definition
+
+- Namespace: `Skyline.DataMiner.Analytics.GenericInterface`
+- Assembly: `SLAnalyticsTypes.dll`
+
+Represents a link to a specific time range for a [GQIRow](xref:GQI_GQIRow).
+Inherits from [RowMetadataBase](xref:GQI_RowMetadataBase).
+
+## Properties
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| StartTime | `DateTime` | Timestamp that marks the start of the time range. |
+| EndTime | `DateTime` | Timestamp that marks the end of the time range. |

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
@@ -6,7 +6,7 @@ uid: Ad_hoc_Metadata
 
 GQI allows query rows to be linked to certain DataMiner objects. This is achieved via metadata that informs the Dashboards and Low-Code Apps of what a row represents. The metadata can then be used to feed these DataMiner objects from one component to another.
 
-From DataMiner 10.4.1/10.4.0 onwards, you can also add this metadata to the rows of your ad hoc data source, just like the rows from built-in data sources.
+From DataMiner 10.4.0/10.4.1 onwards, you can also add this metadata to the rows of your ad hoc data source, just like the rows from built-in data sources.
 
 To link a GQI row to a DataMiner object, add a reference to the object in the [Metadata property](xref:GQI_GQIRow#properties) of the row.
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
@@ -1,0 +1,22 @@
+---
+uid: Ad_hoc_Metadata
+---
+
+# Linking rows to DataMiner objects
+
+Just like the built-in data sources, you can link the rows of your ad hoc data source to specific DataMiner objects. This will allow you to feed these objects in the Dashboards and Low-Code Apps to other components.
+
+To link a GQI row to a DataMiner object, add a reference to the object in the [Metadata property](xref:GQI_GQIRow#properties) of the row.
+
+## Example
+
+The following ad hoc data source exposes a table of elements contained within a specific view.
+
+:::code language="csharp" source="./SLC-GQIDS-ViewElements.cs":::
+
+## See also
+
+- [Supported references to DataMiner objects](xref:GQI_ObjectRefMetadata#dmaobjectref)
+- [ObjectRefMetadata](xref:GQI_ObjectRefMetadata)
+- [GenIfRowMetadata](xref:GQI_GenIfRowMetadata)
+- [GQIRow](xref:GQI_GQIRow)

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
@@ -6,7 +6,7 @@ uid: Ad_hoc_Metadata
 
 GQI allows query rows to be linked to certain DataMiner objects. This is achieved via metadata that informs the Dashboards and Low-Code Apps of what a row represents. The metadata can then be used to feed these DataMiner objects from one component to another.
 
-Just like the rows from built-in data sources, you can now also add this metadata to the rows of your ad hoc data source.
+From DataMiner 10.4.0 onwards, you can also add this metadata to the rows of your ad hoc data source, just like the rows from built-in data sources.
 
 To link a GQI row to a DataMiner object, add a reference to the object in the [Metadata property](xref:GQI_GQIRow#properties) of the row.
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
@@ -6,7 +6,7 @@ uid: Ad_hoc_Metadata
 
 GQI allows query rows to be linked to certain DataMiner objects. This is achieved via metadata that informs the Dashboards and Low-Code Apps of what a row represents. The metadata can then be used to feed these DataMiner objects from one component to another.
 
-From DataMiner 10.4.0 onwards, you can also add this metadata to the rows of your ad hoc data source, just like the rows from built-in data sources.
+From DataMiner 10.4.1/10.4.0 onwards, you can also add this metadata to the rows of your ad hoc data source, just like the rows from built-in data sources.
 
 To link a GQI row to a DataMiner object, add a reference to the object in the [Metadata property](xref:GQI_GQIRow#properties) of the row.
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
@@ -4,7 +4,7 @@ uid: Ad_hoc_Metadata
 
 # Linking rows to DataMiner objects
 
-Just like the built-in data sources, you can link the rows of your ad hoc data source to specific DataMiner objects. This will allow you to feed these objects in the Dashboards and Low-Code Apps to other components.
+Just like the rows from built-in data sources can contain metadata that allow you to feed certain DataMiner objects in your Dashboards and Low-Code Apps, so too can you link the rows of your ad hoc data source to these DataMiner objects.
 
 To link a GQI row to a DataMiner object, add a reference to the object in the [Metadata property](xref:GQI_GQIRow#properties) of the row.
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
@@ -4,7 +4,8 @@ uid: Ad_hoc_Metadata
 
 # Linking rows to DataMiner objects
 
-Just like the rows from built-in data sources can contain metadata that allow you to feed certain DataMiner objects in your Dashboards and Low-Code Apps, so too can you link the rows of your ad hoc data source to these DataMiner objects.
+GQI allows query rows to be linked to certain DataMiner objects. This is achieved via metadata that informs the Dashboards and the Low-Code apps what a row represents. The metadata can then be used to feed these DataMiner objects from one component to another.
+Just like the rows from built-in data sources, you can now also add this metadata to the rows of your ad hoc data source.
 
 To link a GQI row to a DataMiner object, add a reference to the object in the [Metadata property](xref:GQI_GQIRow#properties) of the row.
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/Ad_hoc_Metadata.md
@@ -4,7 +4,8 @@ uid: Ad_hoc_Metadata
 
 # Linking rows to DataMiner objects
 
-GQI allows query rows to be linked to certain DataMiner objects. This is achieved via metadata that informs the Dashboards and the Low-Code apps what a row represents. The metadata can then be used to feed these DataMiner objects from one component to another.
+GQI allows query rows to be linked to certain DataMiner objects. This is achieved via metadata that informs the Dashboards and Low-Code Apps of what a row represents. The metadata can then be used to feed these DataMiner objects from one component to another.
+
 Just like the rows from built-in data sources, you can now also add this metadata to the rows of your ad hoc data source.
 
 To link a GQI row to a DataMiner object, add a reference to the object in the [Metadata property](xref:GQI_GQIRow#properties) of the row.

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/SLC-GQIDS-ViewElements.cs
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Ad_hoc_data/SLC-GQIDS-ViewElements.cs
@@ -1,0 +1,65 @@
+using Skyline.DataMiner.Analytics.GenericInterface;
+using Skyline.DataMiner.Net;
+using Skyline.DataMiner.Net.Messages;
+using System.Collections.Generic;
+using System.Linq;
+
+[GQIMetaData(Name = "Get elements in view")]
+public sealed class ViewElementsDataSource : IGQIDataSource, IGQIOnInit, IGQIInputArguments
+{
+    private readonly GQIIntArgument _viewArgument = new GQIIntArgument("View id") { IsRequired = true };
+    private readonly GQIStringColumn _nameColumn = new GQIStringColumn("Name");
+
+    private GQIDMS _dms;
+    private int _viewID;
+
+    public OnInitOutputArgs OnInit(OnInitInputArgs args)
+    {
+        _dms = args.DMS;
+        return default;
+    }
+
+    public GQIArgument[] GetInputArguments() => new[] { _viewArgument };
+
+    public OnArgumentsProcessedOutputArgs OnArgumentsProcessed(OnArgumentsProcessedInputArgs args)
+    {
+        _viewID = args.GetArgumentValue(_viewArgument);
+        return default;
+    }
+
+    public GQIColumn[] GetColumns() => new[] { _nameColumn };
+
+    public GQIPage GetNextPage(GetNextPageInputArgs args)
+    {
+        var rows = GetElements()
+            .Select(CreateElementRow)
+            .ToArray();
+        return new GQIPage(rows);
+    }
+
+    private IEnumerable<LiteElementInfoEvent> GetElements()
+    {
+        var requestMsg = new GetLiteElementInfo { ViewID = _viewID };
+        var responseMsg = _dms.SendMessages(requestMsg);
+        return responseMsg.OfType<LiteElementInfoEvent>();
+    }
+
+    private GQIRow CreateElementRow(LiteElementInfoEvent element)
+    {
+        // Create a new row with:
+
+        // 1. A unique key
+        var elementID = new ElementID(element.DataMinerID, element.ElementID);
+        var key = elementID.GetKey();
+
+        // 2. Cells containing element data
+        var nameCell = new GQICell { Value = element.Name };
+        var cells = new[] { nameCell };
+
+        // 3. Metadata to link the row to the element
+        var elementMetadata = new ObjectRefMetadata { Object = elementID };
+        var rowMetadata = new GenIfRowMetadata(new[] { elementMetadata });
+
+        return new GQIRow(key, cells) { Metadata = rowMetadata };
+    }
+}

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Custom_Operator/CO_Metadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Custom_Operator/CO_Metadata.md
@@ -1,0 +1,28 @@
+---
+uid: CO_Metadata
+---
+
+# Modifying links to DataMiner objects
+
+In a custom operator, you can link row or modify any existing links to DataMiner objects.
+These metadata links allow you to feed the objects in the Dashboards and Low-Code Apps to other components.
+
+To add, remove or modify a DataMiner object link, use the [Metadata property](xref:GQI_GQIRow#properties) of the editable row.
+
+## Example
+
+The following custom operator links GQI rows to DataMiner views based on a column that contains the view id.
+
+:::code language="csharp" source="./SLC-GQIO-LinkToView.cs":::
+
+> [!CAUTION]
+> Although it is technically possible to modify the existing metadata instances, this can in some cases lead to undefined behavior and is therefore strongly discouraged.
+>
+> If you need to modify existing links, it's better to **create new instances and treat the existing instance as immutable**.
+
+## See also
+
+- [Supported references to DataMiner objects](xref:GQI_ObjectRefMetadata#dmaobjectref)
+- [ObjectRefMetadata](xref:GQI_ObjectRefMetadata)
+- [GenIfRowMetadata](xref:GQI_GenIfRowMetadata)
+- [GQIEditableRow](xref:GQI_GQIEditableRow)

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Custom_Operator/CO_Metadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Custom_Operator/CO_Metadata.md
@@ -4,8 +4,8 @@ uid: CO_Metadata
 
 # Modifying links to DataMiner objects
 
-In a custom operator, you can link row or modify any existing links to DataMiner objects.
-These metadata links allow you to feed the objects in the Dashboards and Low-Code Apps to other components.
+In a custom operator, you can modify the metadata that links DataMiner objects to a row.
+This metadata allows you to feed the objects in Dashboards and Low-Code Apps to other components.
 
 To add, remove or modify a DataMiner object link, use the [Metadata property](xref:GQI_GQIRow#properties) of the editable row.
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Custom_Operator/CO_Metadata.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Custom_Operator/CO_Metadata.md
@@ -4,21 +4,20 @@ uid: CO_Metadata
 
 # Modifying links to DataMiner objects
 
-In a custom operator, you can modify the metadata that links DataMiner objects to a row.
-This metadata allows you to feed the objects in Dashboards and Low-Code Apps to other components.
+In a custom operator, you can modify the metadata that links DataMiner objects to a row. This metadata allows you to feed the objects in Dashboards and Low-Code Apps to other components.
 
-To add, remove or modify a DataMiner object link, use the [Metadata property](xref:GQI_GQIRow#properties) of the editable row.
+To add, remove, or modify a DataMiner object link, use the [Metadata property](xref:GQI_GQIRow#properties) of the editable row.
 
 ## Example
 
-The following custom operator links GQI rows to DataMiner views based on a column that contains the view id.
+The following custom operator links GQI rows to DataMiner views based on a column that contains the view ID.
 
 :::code language="csharp" source="./SLC-GQIO-LinkToView.cs":::
 
 > [!CAUTION]
 > Although it is technically possible to modify the existing metadata instances, this can in some cases lead to undefined behavior and is therefore strongly discouraged.
 >
-> If you need to modify existing links, it's better to **create new instances and treat the existing instance as immutable**.
+> If you need to modify existing links, you should **create new instances and treat the existing instance as immutable**.
 
 ## See also
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Custom_Operator/SLC-GQIO-LinkToView.cs
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Extensions/Custom_Operator/SLC-GQIO-LinkToView.cs
@@ -1,0 +1,43 @@
+using Skyline.DataMiner.Analytics.GenericInterface;
+using Skyline.DataMiner.Net;
+
+[GQIMetaData(Name = "Link to view")]
+public sealed class LinkToViewOperator : IGQIRowOperator, IGQIInputArguments
+{
+    private readonly GQIColumnDropdownArgument _viewIDColumnArgument;
+
+    private GQIColumn<int> _viewIDColumn;
+
+    public LinkToViewOperator()
+    {
+        _viewIDColumnArgument = new GQIColumnDropdownArgument("View id column")
+        {
+            IsRequired = true,
+            Types = new[] { GQIColumnType.Int },
+        };
+    }
+
+    public GQIArgument[] GetInputArguments() => new[] { _viewIDColumnArgument };
+
+    public OnArgumentsProcessedOutputArgs OnArgumentsProcessed(OnArgumentsProcessedInputArgs args)
+    {
+        _viewIDColumn = (GQIColumn<int>)args.GetArgumentValue(_viewIDColumnArgument);
+        return default;
+    }
+
+    public void HandleRow(GQIEditableRow row)
+    {
+        // Retrieve the view id from this row
+        if (!row.TryGetValue(_viewIDColumn, out int viewID))
+            return;
+
+        // Wrap it in a ViewID object ref
+        var objectRef = new ViewID(viewID);
+
+        // Create a new metadata instance for the object
+        var objectRefMetadata = new ObjectRefMetadata { Object = objectRef };
+
+        // Link it to the row
+        row.Metadata = new GenIfRowMetadata(new[] { objectRefMetadata });
+    }
+}

--- a/user-guide/Advanced_Modules/User-Defined_APIs/UD_APIs_Triggering_an_API.md
+++ b/user-guide/Advanced_Modules/User-Defined_APIs/UD_APIs_Triggering_an_API.md
@@ -66,7 +66,7 @@ The Content-Length header is calculated and filled in automatically depending on
 >
 > - DataMiner 10.3.6: 30 MB
 > - DataMiner 10.3.8: 16.7 MB
-> - DataMiner 10.4.1/10.4.0: 29 MB
+> - DataMiner 10.4.0/10.4.1: 29 MB
 
 ### Body
 

--- a/user-guide/Advanced_Modules/toc.yml
+++ b/user-guide/Advanced_Modules/toc.yml
@@ -549,6 +549,8 @@ items:
                     topicUid: Ad_hoc_Building_blocks
                   - name: Life cycle of queries with ad hoc data
                     topicUid: Ad_hoc_Life_cycle
+                  - name: Linking rows to DataMiner objects
+                    topicUid: Ad_hoc_Metadata
                   - name: Tutorials
                     topicUid: Ad_hoc_Tutorials
                     items:
@@ -563,6 +565,8 @@ items:
                     topicUid: CO_Building_blocks
                   - name: Life cycle of a custom operator
                     topicUid: CO_Life_cycle
+                  - name: Modifying links to DataMiner objects
+                    topicUid: CO_Metadata
                   - name: Tutorials
                     topicUid: Creating_Minus_Operator
                     items:
@@ -575,6 +579,8 @@ items:
               - name: API reference
                 topicUid: GQI_GQIArgument
                 items:
+                  - name: GenIfRowMetadata
+                    topicUid: GQI_GenIfRowMetadata
                   - name: GQIArgument
                     topicUid: GQI_GQIArgument
                   - name: GQICell
@@ -619,10 +625,14 @@ items:
                     topicUid: GQI_IGQIQueryNode
                   - name: IGQIRowOperator
                     topicUid: GQI_IGQIRowOperator
+                  - name: ObjectRefMetadata
+                    topicUid: GQI_ObjectRefMetadata
                   - name: OnArgumentsProcessedInputArgs
                     topicUid: GQI_OnArgumentsProcessedInputArgs
                   - name: OnInitInputArgs
                     topicUid: GQI_OnInitInputArgs
+                  - name: RowMetadataBase
+                    topicUid: GQI_RowMetadataBase
           - name: Query updates
             topicUid: Query_updates
           - name: Importing a query

--- a/user-guide/Advanced_Modules/toc.yml
+++ b/user-guide/Advanced_Modules/toc.yml
@@ -633,6 +633,8 @@ items:
                     topicUid: GQI_OnInitInputArgs
                   - name: RowMetadataBase
                     topicUid: GQI_RowMetadataBase
+                  - name: TimeRangeMetadata
+                    topicUid: GQI_TimeRangeMetadata
           - name: Query updates
             topicUid: Query_updates
           - name: Importing a query


### PR DESCRIPTION
Includes:

- How to link DataMiner objects to a GQI row using metadata in ad hoc data sources (+ example)
- How to modify links to DataMiner objects using metadata in custom operators (+example)
- Added API reference for GenIfRowMetadata, RowMetadataBase, ObjectRefMetadata
- Extended API reference for GQIRow/GQIEditableRow