### PR TITLE
Tip about connecting to cloud added to installation landing page

### DIFF
--- a/user-guide/Getting_started/Installing_a_DataMiner_Agent.md
+++ b/user-guide/Getting_started/Installing_a_DataMiner_Agent.md
@@ -13,3 +13,6 @@ To manually install a DataMiner Agent, you will need to [use the DataMiner Insta
 
 > [!NOTE]
 > The DataMiner Installer is available on the [DataMiner software](https://community.dataminer.services/downloads/) page on DataMiner Dojo. Note that the 10.2.0 installer does not support 32-bit systems, MySQL installation, and unattended installation of a cluster.
+
+> [!TIP]
+> Do you already have a self-hosted DataMiner System that you want to connect to dataminer.services? Go to [Connecting your DataMiner System to dataminer.services](xref:Connecting_your_DataMiner_System_to_the_cloud) for more info.


### PR DESCRIPTION
With this tip on the installation landing page, we can also link to this page for users who may already have a self-hosted system and want to connect it to the cloud.