### PR TITLE
Update Protocol.HTTP.Session-timeout.md

### DIFF
--- a/develop/schemadoc/Protocol/Protocol.HTTP.Session-timeout.md
+++ b/develop/schemadoc/Protocol/Protocol.HTTP.Session-timeout.md
@@ -4,7 +4,7 @@ uid: Protocol.HTTP.Session-timeout
 
 # timeout attribute
 
-Specifies that DataMiner must use this timeout value instead of the default one (or the one specified in the Session tag) when executing this connection of this session.
+Specifies that DataMiner must use this timeout value instead of the default one (or the one specified in the Connection tag) when executing this connection of this session.
 
 ## Content Type
 

--- a/develop/schemadoc/Protocol/Protocol.HTTP.Session-timeout.md
+++ b/develop/schemadoc/Protocol/Protocol.HTTP.Session-timeout.md
@@ -4,7 +4,10 @@ uid: Protocol.HTTP.Session-timeout
 
 # timeout attribute
 
-Specifies that DataMiner must use this timeout value instead of the default one (or the one specified in the Connection tag) when executing this connection of this session.
+Specifies that DataMiner must use this timeout value instead of the default one.
+
+> [!NOTE]
+> For a [Connection](xref:Protocol.HTTP.Session.Connection) in this Session, you can override the timeout to be used via the [Connection@timeout](xref:Protocol.HTTP.Session.Connection-timeout) attribute.
 
 ## Content Type
 

--- a/develop/schemadoc/Protocol/Protocol.HTTP.Session.Connection-timeout.md
+++ b/develop/schemadoc/Protocol/Protocol.HTTP.Session.Connection-timeout.md
@@ -4,7 +4,7 @@ uid: Protocol.HTTP.Session.Connection-timeout
 
 # timeout attribute
 
-Specifies that DataMiner must use this timeout value instead of the default one (or the one specified in the Session tag) when executing this connection of this session.
+Specifies that DataMiner must use this timeout value instead of the default one (or the one specified in the [timeout](xref:Protocol.HTTP.Session-timeout) attribute of the [Session](xref:Protocol.HTTP.Session) tag) when executing this connection of this session.
 
 ## Content Type
 


### PR DESCRIPTION
Is this a mistake? DataMiner will use this value instead of one specified in Session tag, but this value is the value in Session tag. Maybe it will overrule some other timeout setting and not the one in Connection tag?