### PR TITLE
Small tweaks to the Database docs

### DIFF
--- a/user-guide/Advanced_Functionality/Databases/Databases_about.md
+++ b/user-guide/Advanced_Functionality/Databases/Databases_about.md
@@ -15,7 +15,7 @@ Each DataMiner System requires its own system data storage. This data storage se
 | **Storage as a Service (STaaS)** | | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | **Dedicated clustered storage** | :heavy_check_mark: | | :heavy_check_mark: | :heavy_check_mark: | | | |
 | **Storage per DMA without indexing** | :heavy_check_mark: | | | | | | |
-| **Storage per DMA with Elasticsearch** | :heavy_check_mark: | | :heavy_check_mark: | | | |  |
+| **Storage per DMA with indexing (OpenSearch)** | :heavy_check_mark: | | :heavy_check_mark: | | | |  |
 
 <br/>
 

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Indexing_Database.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Indexing_Database.md
@@ -12,7 +12,9 @@ If you choose not to use the recommended [Storage as a Service (STaaS)](xref:STa
 
 - [Amazon OpenSearch Service](xref:Amazon_OpenSearch_Service): Deprecated. Supported from DataMiner 10.3.0 [CU0] up to 10.3.0 [CU8] and from DataMiner 10.3.3 up to 10.3.11.
 
-While these are not recommended, we also still support setups with storage per DMA using [an Elasticsearch database](xref:Configuring_indexing_database_per_DMS). In such setups, deploying Elasticsearch unlocks additional DataMiner features, including:
+While these are not recommended, we also still support setups with storage per DMA using [an Elasticsearch database](xref:Configuring_indexing_database_per_DMS).
+
+When DataMiner is configured to use an index database, it unlocks additional features, including:
 
 - DataMiner Advanced Analytics features such as pattern matching
 


### PR DESCRIPTION
These changes are merely suggestions. I recently read some parts of the DataMiner docs and noticed these things.

1. In one change, I updated Elasticsearch to a more general name for the indexing storage as we currently do not recommend using Elasticsearch anymore. However, I am not sure what the best choice would be here then.
2. On the 'Configuring an indexing database' page, there is a paragraph that suggests having separate Elasticsearch nodes on each DMA is not recommended. It then seems to suggest that this non-recommended installation is a way to gain access to the additional features mentioned below that paragraph. However, to the reader, it would seem that this non-recommended installation is the only way to have these features, which is not the case. Just having an indexing database configured is sufficient.

Please check these changes with the relevant parties, as I am not sure what I am saying is correct.