### PR TITLE
Improved tip on linking a shape to a DataMiner dashboard

### DIFF
--- a/user-guide/Basic_Functionality/Visio/linking_shapes/Linking_a_shape_to_a_webpage.md
+++ b/user-guide/Basic_Functionality/Visio/linking_shapes/Linking_a_shape_to_a_webpage.md
@@ -32,7 +32,7 @@ Default tooltip: *Link to 'http://URL'*
 >
 > If you want to pass data [using placeholders](#special-placeholders-that-can-be-used-within-a-url), have a look at [how to specify data input in a dashboard URL](xref:Specifying_data_input_in_a_dashboard_URL).
 >
-> It can also be useful copy the URL directly from the Dashboards app. However, some of the URL parameters may be compressed. If you need the uncompressed URL parameters to insert placeholders, [retrieve the URL via the sharing option](xref:Sharing_a_dashboard#sharing-a-dashboard-url) and select *Use uncompressed URL parameters*.
+> It can also be useful to copy the URL directly from the Dashboards app. However, some of the URL parameters may be compressed. If you need the uncompressed URL parameters to insert placeholders, [retrieve the URL via the sharing option](xref:Sharing_a_dashboard#sharing-a-dashboard-url) and select *Use uncompressed URL parameters*.
 
 ## Options for shapes linked to a webpage
 

--- a/user-guide/Basic_Functionality/Visio/linking_shapes/Linking_a_shape_to_a_webpage.md
+++ b/user-guide/Basic_Functionality/Visio/linking_shapes/Linking_a_shape_to_a_webpage.md
@@ -26,13 +26,7 @@ Default tooltip: *Link to 'http://URL'*
 > - Both HTTP and HTTPS are supported.
 > - If you put a "#" sign in front of the URL, the webpage will be displayed inside the shape.
 > - Links starting with "mailto:" are not supported in the DataMiner web apps prior to DataMiner 10.2.0/10.1.8.
-
-> [!TIP]
-> You can link to a DataMiner dashboard.
->
-> If you want to pass data [using placeholders](#special-placeholders-that-can-be-used-within-a-url), have a look at [how to specify data input in a dashboard URL](xref:Specifying_data_input_in_a_dashboard_URL).
->
-> It can also be useful to copy the URL directly from the Dashboards app. However, some of the URL parameters may be compressed. If you need the uncompressed URL parameters to insert placeholders, [retrieve the URL via the sharing option](xref:Sharing_a_dashboard#sharing-a-dashboard-url) and select *Use uncompressed URL parameters*.
+> - It is also possible to link to a DataMiner dashboard this way.
 
 ## Options for shapes linked to a webpage
 
@@ -126,8 +120,13 @@ http://localhost/foo/test.php?id=123&action=save#SL_ALLOW_POPUPS#
 > [!NOTE]
 >
 > - \<ElementID>, \<ElementIP> and \<ElementName> are only to be used if the shape is also linked to an element.
-> - From DataMiner version 9.0.5 onwards, these placeholders can also be used inside another placeholder in the URL, e.g. `#http://www.skyline.be?MyParam=[param:<elementname>,1]`
+> - These placeholders can also be used inside another placeholder in the URL, e.g. `#http://www.skyline.be?MyParam=[param:<elementname>,1]`
 > - Prior to DataMiner 10.3.6/10.4.0, adding a URL fragment to a linked webpage causes the connection info to be automatically added after the fragment, rendering the URL invalid and requiring a reload of the page, which means the user may need to log in again. From DataMiner 10.3.6/10.4.0 onwards, Visual Overview can recognize if a URL fragment is added or changed and update only the necessary parts of the page, avoiding the need to recreate the browser instance. <!-- RN 36044 + 36104 -->
+
+> [!TIP]
+> If you want to pass data to a dashboard using placeholders, take a look at [how to specify data input in a dashboard URL](xref:Specifying_data_input_in_a_dashboard_URL).
+>
+> It can also be useful to copy the URL directly from the Dashboards app. However, some of the URL parameters may be compressed. If you need the uncompressed URL parameters to insert placeholders, [retrieve the URL via the sharing option](xref:Sharing_a_dashboard#sharing-a-dashboard-url) and select *Use uncompressed URL parameters*.
 
 ## Configuring a link to a DataMiner object within a webpage embedded in Visual Overview
 

--- a/user-guide/Basic_Functionality/Visio/linking_shapes/Linking_a_shape_to_a_webpage.md
+++ b/user-guide/Basic_Functionality/Visio/linking_shapes/Linking_a_shape_to_a_webpage.md
@@ -26,7 +26,13 @@ Default tooltip: *Link to 'http://URL'*
 > - Both HTTP and HTTPS are supported.
 > - If you put a "#" sign in front of the URL, the webpage will be displayed inside the shape.
 > - Links starting with "mailto:" are not supported in the DataMiner web apps prior to DataMiner 10.2.0/10.1.8.
-> - It is also possible to link to a DataMiner dashboard this way. However, note that the URL of a dashboard is by default compressed through LZ compression. If you want to [use placeholders](#special-placeholders-that-can-be-used-within-a-url), it can be useful to have the uncompressed URL instead. To get this, [retrieve the URL via the sharing option](xref:Sharing_a_dashboard#sharing-a-dashboard-url) and select *Use uncompressed URL parameters*.
+
+> [!TIP]
+> You can link to a DataMiner dashboard.
+>
+> If you want to pass data [using placeholders](#special-placeholders-that-can-be-used-within-a-url), have a look at [how to specify data input in a dashboard URL](xref:Specifying_data_input_in_a_dashboard_URL).
+>
+> It can also be useful copy the URL directly from the Dashboards app. However, some of the URL parameters may be compressed. If you need the uncompressed URL parameters to insert placeholders, [retrieve the URL via the sharing option](xref:Sharing_a_dashboard#sharing-a-dashboard-url) and select *Use uncompressed URL parameters*.
 
 ## Options for shapes linked to a webpage
 


### PR DESCRIPTION
- Move to a separate TIP and rephrased.
- Link to *Specifying data input in a dashboard URL*.
- Corrected implication that the entire URL is compressed.
- Omitted any specifics on the compression algorithm, which is internal and can change at any time.