### PR TITLE
Extend GetParameterByPrimaryKey documentation

### DIFF
--- a/src/DataMiner/SLManagedAutomation/Element.cs
+++ b/src/DataMiner/SLManagedAutomation/Element.cs
@@ -760,7 +760,7 @@ namespace Skyline.DataMiner.Automation
 		/// </code>
 		/// </example>
 		/// <remarks>
-		/// <para>When the primary key is in a column hidden by an information template, this method will return an empty value. It is recommended to use the <see cref="GetParameter(int, string)"/> method.</para>
+		/// <para>When the primary key is in a column hidden by an information template, this method will return an empty value. We recommend using the <see cref="GetParameter(int, string)"/> method.</para>
 		/// </remarks>
 		public virtual object GetParameterByPrimaryKey(int pid, string primaryKey) { return null; }
 

--- a/src/DataMiner/SLManagedAutomation/Element.cs
+++ b/src/DataMiner/SLManagedAutomation/Element.cs
@@ -760,7 +760,7 @@ namespace Skyline.DataMiner.Automation
 		/// </code>
 		/// </example>
 		/// <remarks>
-		/// <para>When the primary key is in a column hidden by an information template, this method will return an empty value. We recommend using the <see cref="GetParameter(int, string)"/> method.</para>
+		/// <para>If a column is hidden by an information template, the value for a cell of that column can no longer be retrieved by this method (null is returned). However, the value can stilll be retrieved using the <see cref="GetParameter(int, string)"/> method. Using the GetParameter method is therefore recommended.</para>
 		/// </remarks>
 		public virtual object GetParameterByPrimaryKey(int pid, string primaryKey) { return null; }
 

--- a/src/DataMiner/SLManagedAutomation/Element.cs
+++ b/src/DataMiner/SLManagedAutomation/Element.cs
@@ -760,7 +760,7 @@ namespace Skyline.DataMiner.Automation
 		/// </code>
 		/// </example>
 		/// <remarks>
-		/// <para>If a column is hidden by an information template, the value for a cell of that column can no longer be retrieved by this method (null is returned). However, the value can stilll be retrieved using the <see cref="GetParameter(int, string)"/> method. Using the GetParameter method is therefore recommended.</para>
+		/// <para>If a column is hidden by an information template, the value for a cell of that column can no longer be retrieved by this method (null is returned). However, the value can still be retrieved using the <see cref="GetParameter(int, string)"/> method. Using the GetParameter method is therefore recommended.</para>
 		/// </remarks>
 		public virtual object GetParameterByPrimaryKey(int pid, string primaryKey) { return null; }
 

--- a/src/DataMiner/SLManagedAutomation/Element.cs
+++ b/src/DataMiner/SLManagedAutomation/Element.cs
@@ -759,6 +759,9 @@ namespace Skyline.DataMiner.Automation
 		/// var value = element.GetParameter(1002, "1");
 		/// </code>
 		/// </example>
+		/// <remarks>
+		/// <para>When the primary key is in a column hidden by an information template, this method will return an empty value. It is recommended to use the <see cref="GetParameter(int, string)"/> method.</para>
+		/// </remarks>
 		public virtual object GetParameterByPrimaryKey(int pid, string primaryKey) { return null; }
 
 		/// <summary>


### PR DESCRIPTION
Update the documentation of the GetParameterByPrimaryKey method to correctly represent the behavior of the method when information templates are present.