### PR TITLE
Update Overview_of_Soft_Launch_Options.md

### DIFF
--- a/user-guide/Reference/Soft-launch_options/Overview_of_Soft_Launch_Options.md
+++ b/user-guide/Reference/Soft-launch_options/Overview_of_Soft_Launch_Options.md
@@ -373,6 +373,7 @@ Enables SLProtocol as a 32-bit process. This option is not configured in *SoftLa
 ### SnmpPollingSnmpPlusPlusOnly
 
 Configures the DataMiner System to use SNMP++ for the polling of all three SNMP versions, instead of only for SNMPv3.<!-- RN 37778 -->
+Polling IPv6 addresses is not supported. In case you poll IPv6 addresses on the agent, do not activate the feature.
 
 - **Minimum version**: 10.4.2
 - **Release version**: To be determined.

--- a/user-guide/Reference/Soft-launch_options/Overview_of_Soft_Launch_Options.md
+++ b/user-guide/Reference/Soft-launch_options/Overview_of_Soft_Launch_Options.md
@@ -373,10 +373,12 @@ Enables SLProtocol as a 32-bit process. This option is not configured in *SoftLa
 ### SnmpPollingSnmpPlusPlusOnly
 
 Configures the DataMiner System to use SNMP++ for the polling of all three SNMP versions, instead of only for SNMPv3.<!-- RN 37778 -->
-Polling IPv6 addresses is not supported. In case you poll IPv6 addresses on the agent, do not activate the feature.
 
 - **Minimum version**: 10.4.2
 - **Release version**: To be determined.
+
+> [!IMPORTANT]
+> This feature does not support polling of IPv6 addresses. In case IPv6 addresses are polled on your DMA, do not activate this feature.
 
 ### SrmOwnServices
 


### PR DESCRIPTION
added remark that SnmpPollingSnmpPlusPlusOnly does not support IPv6 addresses.