### PR TITLE
Internet Explorer info

### DIFF
--- a/user-guide/Getting_started/Accessing_DataMiner/Accessing_DataMiner_Cube/Installing_DataMiner_Cube/Configuring_Microsoft_edge_to_run_Cube.md
+++ b/user-guide/Getting_started/Accessing_DataMiner/Accessing_DataMiner_Cube/Installing_DataMiner_Cube/Configuring_Microsoft_edge_to_run_Cube.md
@@ -48,4 +48,4 @@ Before you can run the DataMiner Cube browser application in Microsoft Edge, a n
 > - It is possible that your Edge policies are in fact managed by your company. In that case, you may not be able to configure this yourself, and you will need to contact your IT administrator for this. You can verify if this is the case by browsing to <edge://policy/> in Microsoft Edge. If this page contains an item "InternetExplorerIntegrationSiteList", IE compatibility is configured at company level.
 
 > [!TIP]
-> See also: [Internet Explorer Support](https://community.dataminer.services/documentation/internet-explorer-support/)
+> See also: [Can I still use the DataMiner Cube browser app in Internet Explorer?](xref:DataMiner_client_applications#can-i-still-use-the-dataminer-cube-browser-app-in-internet-explorer)

--- a/user-guide/Reference/DataMiner_Client_Requirements.md
+++ b/user-guide/Reference/DataMiner_Client_Requirements.md
@@ -57,17 +57,6 @@ To install the Skyline certificates:
 > - When the installation is complete, a message "Certificates have been installed (current user)" or "Certificates have been installed (all users)" will be displayed.
 > - This tool (SLRegCerts.exe) also supports a "/silent" option that suppresses any message box output, so that it can be used in automatic installations.
 
-### Web browser
-
-If DataMiner Cube will be run as a web application instead of a desktop application, you will need one of the following browsers:
-
-- Microsoft Internet Explorer (v9.0 or above)
-
-- Microsoft Edge (using IE compatibility mode)
-
-> [!TIP]
-> For more information, see [Internet Explorer Support](https://community.dataminer.services/documentation/internet-explorer-support/).
-
 ### Optional software
 
 **Microsoft Visio (Standard or Professional, version 2013 or later)**:

--- a/user-guide/Reference/faq/DataMiner_client_applications.md
+++ b/user-guide/Reference/faq/DataMiner_client_applications.md
@@ -10,6 +10,8 @@ uid: DataMiner_client_applications
 
 - [What should I do if I cannot connect to a DMA using the DataMiner Cube browser app?](#what-should-i-do-if-i-cannot-connect-to-a-dma-using-the-dataminer-cube-browser-app)
 
+- [Can I still use the DataMiner Cube browser app in Internet Explorer?](#can-i-still-use-the-dataminer-cube-browser-app-in-internet-explorer)
+
 ## How do I send info about my DataMiner client to Technical Support?
 
 In case of problems, Skyline Technical Support may ask you to provide version information and/or debug information. Below, you can find how you can gather the requested information.
@@ -83,3 +85,11 @@ To reinstall the browser app, you need to clean the XBAP cache:
    1. Click *Run*.
 
 1. If the problem persists, contact DataMiner Technical Support.
+
+## Can I still use the DataMiner Cube browser app in Internet Explorer?
+
+Support for the DataMiner Cube browser app has ended as of DataMiner 10.3 (see [Third-party software support life cycle](xref:Software_support_life_cycles#third-party-software-support-life-cycle)).
+
+For earlier DataMiner versions, we also recommend using the desktop application. See [Installing the DataMiner Cube desktop application](xref:Installing_the_DataMiner_Cube_desktop_application).
+
+Though the browser app is still supported in older DataMiner versions, it should no longer be used in Internet Explorer, as Microsoft support for Internet Explorer ended in 2022 (see [Lifecycle FAQ - Internet Explorer and Microsoft Edge](https://docs.microsoft.com/en-us/lifecycle/faq/internet-explorer-microsoft-edge)). You can instead open the DataMiner Cube browser app in Microsoft Edge instead. See [Configuring Microsoft Edge to run DataMiner Cube](xref:Configuring_Microsoft_edge_to_run_Cube).


### PR DESCRIPTION
I propose to add this new FAQ item to replace https://community.dataminer.services/documentation/internet-explorer-support/, so that this Dojo page can be removed. Any existing links to the Dojo page can then be updated to go to the FAQ item instead.