### PR TITLE
Update Installing_Elasticsearch_on_separate_Linux_machine.md

### DIFF
--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Elasticsearch/dedicated_clustered_storage/Installing_Elasticsearch_on_separate_Linux_machine.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Elasticsearch/dedicated_clustered_storage/Installing_Elasticsearch_on_separate_Linux_machine.md
@@ -24,9 +24,7 @@ If you use self-hosted DataMiner storage instead of the recommended [Storage as 
      `$ sudo ufw allow 22/tcp && sudo ufw enable`
 
      > [!IMPORTANT]
-     >
-     > The first part of the command above ensures the TCP port 22 used for SSH connections remains open when the firewall is enabled.
-     > Enabling the firewall without defining the rule for incoming SSH connections may result in loss of connectivity to the server.
+     > The first part of the command above ensures that the TCP port 22 used for SSH connections remains open when the firewall is enabled. Enabling the firewall without defining the rule for incoming SSH connections may result in loss of connectivity to the server.
 
    - To add the correct ports to the firewall, you can for example use the following commands:
 

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Elasticsearch/dedicated_clustered_storage/Installing_Elasticsearch_on_separate_Linux_machine.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Elasticsearch/dedicated_clustered_storage/Installing_Elasticsearch_on_separate_Linux_machine.md
@@ -21,12 +21,12 @@ If you use self-hosted DataMiner storage instead of the recommended [Storage as 
 
    - There is a default firewall on Linux, but this is disabled by default. To enable the firewall, use the following command:
 
-     `$ sudo ufw enable`
+     `$ sudo ufw allow 22/tcp && sudo ufw enable`
 
      > [!IMPORTANT]
-     > If you connect to your Linux server with SSH, you must immediately exclude port 22 or you will be locked out of the session.
      >
-     > For this, use the following command: `$ sudo ufw allow 22/tcp`
+     > The first part of the command above ensures the TCP port 22 used for SSH connections remains open when the firewall is enabled.
+     > Enabling the firewall without defining the rule for incoming SSH connections may result in loss of connectivity to the server.
 
    - To add the correct ports to the firewall, you can for example use the following commands:
 


### PR DESCRIPTION
Changed the first step of firewall configuration to reduce the risk of users locking themselves out while configuring the server.

If this change is approved, a similar change will be done to the Cassandra installation guide.