### PR TITLE
EPM 6.1.9 CU1 update

### DIFF
--- a/release-notes/EPM/I-DOCSIS/EPM_6.1.9_I-DOCSIS.md
+++ b/release-notes/EPM/I-DOCSIS/EPM_6.1.9_I-DOCSIS.md
@@ -13,6 +13,30 @@ uid: EPM_6.1.9_I-DOCSIS
 - QAM US Channels: US QAM Ch Bitrate
 - QAM DS Channels: DS QAM Ch Bitrate
 
+#### DOCSIS topology KPIs reorganized [ID_37169]
+
+The KPIs on the *DOCSIS Network*, *DOCSIS market*, *DOCSIS Hub*, *CCAP Core*, *DS Linecard*, *US Linecard*, *DS Port*, *US Port*, *Node Segment*, *Service Group [Fiber Node]*, *DS Service Group*, *US Service Group*, and *CM* pages have been reorganized to improve the information displayed on these pages:
+
+- The KPIs are now grouped in boxes.
+
+- Irrelevant KPIs are no longer displayed:
+
+  - On all levels: *Entity ID*, *Entity Name*, *Number Ping OK*, and *Percentage Ping OK*.
+
+  - On CCAP Core level: *System Name*.
+
+  - On US/DS Linecard and US/DS Port level: *Number CM Online* and *Percentage CM Online*.
+
+  - On Service Group level: *System ID*, *System Name*, and *Fiber Node Name*.
+
+  - On CM level: *Percentage US/DS QAM Utilization* and *US/DS Average SNR*.
+
+- KPIs have been added:
+
+  - On all levels: *Number DOCSIS 1.x* and *Number DOCSIS Unknown*
+
+  - On Service Group and CM level: *US Service Group Name*, *Number US OFDMA Channels*, and *Percentage US OFDMA Utilization* in the US OFDMA section, and *DS Service Group Name*, *Number DS OFDMA Channels*, and *Percentage DS OFDMA Utilization* in the DS OFDM section.
+
 #### New OFDM/OFDMA information available [ID_37202]
 
 In the CISCO CBR-8 CCAP Platform connector, a new *OFDM/OFDMA* page has been added containing parameters related to OFDM/OFDMA channels from the device. Currently this information is only available at node segment level. These channels are also linked to the associated node segments and service groups. When you view either of those entities in the topology, new KPIs are displayed with the total number of OFDM and OFDMA channels and the average utilization. There is also a link to a dashboard displaying all channels associated with the entity.

--- a/release-notes/EPM/I-DOCSIS/EPM_6.1.9_I-DOCSIS_CU1.md
+++ b/release-notes/EPM/I-DOCSIS/EPM_6.1.9_I-DOCSIS_CU1.md
@@ -6,9 +6,9 @@ uid: EPM_6.1.9_I-DOCSIS_CU1
 
 ## Enhancements
 
-#### #CM Ping OK renamed and CH Utilization updated to show filtered dashboard [ID_36751]
+#### Network layer KPIs adjusted and CH Utilization updated to show filtered dashboard [ID_36751]
 
-​On the network layer, the *#CM Ping OK* KPI has been changed to *#CM Ping Unreachable*. On the service group layer, the CH Utilization has been updated so it shows the dashboard with preselected filters for the respective service group.
+​On the network layer, the *#CM Ping OK* KPI is now no longer displayed, as it does not provide meaningful information. Instead, the KPI *#CM Ping Unreachable* is now displayed. On the service group layer, the CH Utilization has been updated so it shows the dashboard with preselected filters for the respective service group.
 
 #### Generic DOCSIS CM Collector: Interval adjusted for KPI calculation [ID_37356]
 

--- a/release-notes/EPM/I-DOCSIS/EPM_6.1.9_I-DOCSIS_CU1.md
+++ b/release-notes/EPM/I-DOCSIS/EPM_6.1.9_I-DOCSIS_CU1.md
@@ -20,6 +20,15 @@ To streamline the way DOCSIS version information is displayed, a number of chang
 
 In the dashboard *05. CM OFDM Channels*, the Start and Stop Frequency parameters are now displayed in the table *OFDM Channels*. These are retrieved from the CCAP. Previously, these parameters were not available in this dashboard.
 
+#### EPM_I_DOCSIS_AddNewCcapCmPair script updated [ID_38326]
+
+The script *EPM_I_DOCSIS_AddNewCcapCmPair*, which is used to create a new CCAP/CM pair, has been updated as follows:
+
+- Users can now create elements by selecting the host instead of the back-end elements.
+- The path of the CCAP is now the same as the selected host, instead of the name of the element pointing to the EPM SOLUTION folder.
+- Custom properties are now updated through the script and take the values of the views in which the element was created.
+- The script now supports the set and get community string for the collector and the CCAP, instead of only the set community string.
+
 ## Fixes
 
 #### CISCO CBR-8 CCAP Platform: DS port not found for some QAM Channels [ID_38044]

--- a/release-notes/EPM/I-DOCSIS/EPM_6.1.9_I-DOCSIS_CU1.md
+++ b/release-notes/EPM/I-DOCSIS/EPM_6.1.9_I-DOCSIS_CU1.md
@@ -6,6 +6,14 @@ uid: EPM_6.1.9_I-DOCSIS_CU1
 
 ## Enhancements
 
+#### #CM Ping OK renamed and CH Utilization updated to show filtered dashboard [ID_36751]
+
+​On the network layer, the *#CM Ping OK* KPI has been changed to *#CM Ping Unreachable*. On the service group layer, the CH Utilization has been updated so it shows the dashboard with preselected filters for the respective service group.
+
+#### Generic DOCSIS CM Collector: Interval adjusted for KPI calculation [ID_37356]
+
+To make sure the same data are shown at the same time, the logic that updates KPIs in the CM QAM Channels, Cable Modem Overview, and QAM Channels tables now uses the same interval parameter, i.e. the Threshold Execution Interval.
+
 #### DOCSIS version information streamlined [ID_38078]
 
 To streamline the way DOCSIS version information is displayed, a number of changes have been implemented:
@@ -30,6 +38,14 @@ The script *EPM_I_DOCSIS_AddNewCcapCmPair*, which is used to create a new CCAP/C
 - The script now supports the set and get community string for the collector and the CCAP, instead of only the set community string.
 
 ## Fixes
+
+#### Generic CM Collector: Empty rows in QAM Channels and Cable Modem Overview tables [ID_36626]
+
+Up to now, it could occur that the QAM Channels and Cable Modem Overview tables contained rows that were almost completely empty. To prevent this, the methods to calculate and obtain the status for the QAM channel KPIs have been modified to only consider active QAM channels.
+
+#### CM count on CCAP Core level not matching cumulative count across associated linecards [ID_37399]
+
+It could occur that the total count of CMs at the CCAP Core level did not match the cumulative count of CMs across the linecards associated with that CCAP. This was caused by the CMs being associated with linecards using a logical value (Service Group ID) instead of a physical one (MAC Domain). This has now been changed so that CMs are linked to a linecard using the MAC Domain of each CM.
 
 #### CISCO CBR-8 CCAP Platform: DS port not found for some QAM Channels [ID_38044]
 


### PR DESCRIPTION
The page https://docs.dataminer.services/user-guide/Standard_Apps/EPM/EPM_I-DOCSIS/I-DOCSIS_Create_CCAP_CM_pair.html will also need to be updated with these changes. @EstebanSkyline, could you create a pull request for this?  
Also, note that on that page only the get community string is mentioned, while in the release note it says that up to now only the set community string was supported. Is this a mistake in the release note?