### PR TITLE
New maps component only supports Google Maps

### DIFF
--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/General/Maps.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/General/Maps.md
@@ -10,10 +10,9 @@ uid: DashboardMaps
 This component is used to display markers and/or lines on a map. It uses one or more GQI queries as data input.
 
 > [!NOTE]
-> To use the Maps component, the host servers for DataMiner Maps have to be configured in the file *C:\Skyline DataMiner\Maps\ServerConfig.xml*. If this file does not exist, it will be created automatically when you use a Maps component for the first time. To change the configuration, see [Configuring the DataMiner Maps host servers](xref:Configuring_the_DataMiner_Maps_host_servers).
-
-> [!NOTE]
-> This component currently only supports Google Maps ("gmaps") as [MapsProvider](xref:Configuring_the_DataMiner_Maps_host_servers).
+>
+> - To use the Maps component, the host servers for DataMiner Maps have to be configured in the file *C:\Skyline DataMiner\Maps\ServerConfig.xml*. If this file does not exist, it will be created automatically when you use a Maps component for the first time. To change the configuration, see [Configuring the DataMiner Maps host servers](xref:Configuring_the_DataMiner_Maps_host_servers).
+> - This component currently only supports **Google Maps** ("gmaps") as the [Maps provider](xref:Configuring_the_DataMiner_Maps_host_servers).
 
 ## Adding data
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/General/Maps.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/General/Maps.md
@@ -12,6 +12,9 @@ This component is used to display markers and/or lines on a map. It uses one or 
 > [!NOTE]
 > To use the Maps component, the host servers for DataMiner Maps have to be configured in the file *C:\Skyline DataMiner\Maps\ServerConfig.xml*. If this file does not exist, it will be created automatically when you use a Maps component for the first time. To change the configuration, see [Configuring the DataMiner Maps host servers](xref:Configuring_the_DataMiner_Maps_host_servers).
 
+> [!NOTE]
+> This component currently only supports Google Maps ("gmaps") as [MapsProvider](xref:Configuring_the_DataMiner_Maps_host_servers).
+
 ## Adding data
 
 Add one or multiple GQI data sources to the component. See [Applying a data feed](xref:Apply_Data_Feed).


### PR DESCRIPTION
It's not very clear that the new maps component does not work yet with OpenStreetMap (OSM).

Adding a note on top of the page that it currently only supports Google Maps.