### PR TITLE
Update Protocol.Params.Param.Information.Includes.md

### DIFF
--- a/develop/schemadoc/Protocol/Protocol.Params.Param.Information.Includes.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param.Information.Includes.md
@@ -2,7 +2,7 @@
 uid: Protocol.Params.Param.Information.Includes
 ---
 
-# Includes element
+# Includes element [Obsolete]
 
 Contains one or more Protocol.Params.Param.Information.Include tags to indicate that you want additional information to be displayed in the tooltip.
 

--- a/develop/schemadoc/Protocol/Protocol.Params.Param.Information.Includes.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param.Information.Includes.md
@@ -2,7 +2,7 @@
 uid: Protocol.Params.Param.Information.Includes
 ---
 
-# Includes element [Obsolete]
+# Includes element [obsolete]
 
 Contains one or more Protocol.Params.Param.Information.Include tags to indicate that you want additional information to be displayed in the tooltip.
 


### PR DESCRIPTION
Based on DIS Validator, the Information/Includes tag is obsolete and as such it should be updated in docs