### PR TITLE
Extend the Get Behavioral Change Events page

### DIFF
--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Query_Data_Sources/Get_behavioral_change_events.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Query_Data_Sources/Get_behavioral_change_events.md
@@ -4,31 +4,31 @@ uid: Get_behavioral_change_events
 
 # Get behavioral change events
 
-Available from DataMiner 10.3.3/10.4.0 onwards. The *Get behavioral change events* data source retrieves all behavioral change points detected in the DataMiner System. These events are detected on your trend data by *Behavioral Anomaly Detection*, see [Working with behavioral anomaly detection](xref:Working_with_behavioral_anomaly_detection). <!-- RN 35027 -->
+Available from DataMiner 10.3.3/10.4.0 onwards.<!-- RN 35027 --> The *Get behavioral change events* data source retrieves all behavioral change points detected in the DataMiner System. These events are detected in your trend data by [DataMiner Behavioral Anomaly Detection](xref:Working_with_behavioral_anomaly_detection).
 
 By default, the data contains the following columns:
 
-- **Parameter ID**: the ID of the parameter on which the change point was detected.
-- **Anomalous**: whether the change point was marked as an anomaly.
-- **Change type**: the type of change point that was detected.
-- **Increase**: whether the detected change point represents an increase (e.g. a level shift up) or a decrease (e.g. a level shift down).
-- **Start time**: the detected start time of the change point.
-- **End time**: the detected end time of the change point.
+- **Parameter ID**: The ID of the parameter for which the change point was detected.
+- **Anomalous**: Whether the change point was marked as an anomaly.
+- **Change type**: The type of change point that was detected.
+- **Increase**: Whether the detected change point represents an increase (e.g. a level shift up) or a decrease (e.g. a level shift down).
+- **Start time**: The detected start time of the change point.
+- **End time**: The detected end time of the change point.
 
-The following columns are also available after a *Select* operation:
+The following columns are also available after a [Select](xref:GQI_Select) operation:
 
-- **Element ID**: the ID of the element on which the change point was detected.
-- **Change Point ID**: the ID of the change point.
-- **Start value**: the parameter value at the start of the change point for *level shifts* and *outliers*, the slope (resp. variance) at the start of the change point for *trend changes* (resp. *variance changes*).
-- **End value**: the parameter value at the end of the change point for *level shifts* and *outliers*, the slope (resp. variance) at the end of the change point for *trend changes* (resp. *variance changes*).
-- **Significance**: a number indicating how significant the change point is relative to the historically detected change points.
-- **Severity**: a number indicating the severity of the change point relative to the historical trend data.
-- **Creation time**: when the change point was first detected.
-- **Last update**: when the change point was last updated.
+- **Element ID**: The ID of the element for which the change point was detected.
+- **Change Point ID**: The ID of the change point.
+- **Start value**: The parameter value at the start of the change point for level shifts and outliers, or the slope or variance at the start of the change point for trend changes or variance changes, respectively.
+- **End value**: The parameter value at the end of the change point for level shifts and outliers, or the slope or variance at the end of the change point for trend changes or variance changes, respectively.
+- **Significance**: A number indicating how significant the change point is compared to previously detected change points.
+- **Severity**: A number indicating the severity of the change point compared to past trend data.
+- **Creation time**: The time when the change point was first detected.
+- **Last update**: The time when the change point was last updated.
 
 When one or more table rows are selected, the following feeds are available in the *feeds* section of the data pane:
 
-- **Parameters**: the parameters on which the selected the change points were detected.
-- **Timespans**: the time ranges from the start time to the end time of the selected change points.
-- **Elements**: the elements on which the selected change points were detected.
-- **Indices**: the primary key of the table rows on which the selected change points were detected, if any.
+- **Parameters**: The parameters for which the selected change points were detected.
+- **Timespans**: The time ranges from the start time to the end time of the selected change points.
+- **Elements**: The elements for which the selected change points were detected.
+- **Indices**: The primary key of the table rows for which the selected change points were detected, if any.

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Query_Data_Sources/Get_behavioral_change_events.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Query_Data_Sources/Get_behavioral_change_events.md
@@ -12,15 +12,15 @@ By default, the data contains the following columns:
 - **Anomalous**: whether the change point was marked as an anomaly.
 - **Change type**: the type of change point that was detected.
 - **Increase**: whether the detected change point represents an increase (e.g. a level shift up) or a decrease (e.g. a level shift down).
-- **Start time**: the time at which the change began.
-- **End time**: the time at which the change ended.
+- **Start time**: the detected start time of the change point.
+- **End time**: the detected end time of the change point.
 
 The following columns are also available after a *Select* operation:
 
 - **Element ID**: the ID of the element on which the change point was detected.
 - **Change Point ID**: the ID of the change point.
-- **Start value**: the parameter value at the start of the change point.
-- **End value**: the parameter value at the end of the change point.
+- **Start value**: the parameter value at the start of the change point for *level shifts* and *outliers*, the slope (resp. variance) at the start of the change point for *trend changes* (resp. *variance changes*).
+- **End value**: the parameter value at the end of the change point for *level shifts* and *outliers*, the slope (resp. variance) at the end of the change point for *trend changes* (resp. *variance changes*).
 - **Significance**: a number indicating how significant the change point is relative to the historically detected change points.
 - **Severity**: a number indicating the severity of the change point relative to the historical trend data.
 - **Creation time**: when the change point was first detected.

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Query_Data_Sources/Get_behavioral_change_events.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/Query_Data_Sources/Get_behavioral_change_events.md
@@ -4,4 +4,31 @@ uid: Get_behavioral_change_events
 
 # Get behavioral change events
 
-Available from DataMiner 10.3.3/10.4.0 onwards. The *Get behavioral change events* data source retrieves all behavioral anomalies detected in the DataMiner System. The data includes time range metadata on each row, with the start and end time of the event in question. When a table row is selected, the time range will be available as a feed in the *feeds* section of the data pane. <!-- RN 35027 -->
+Available from DataMiner 10.3.3/10.4.0 onwards. The *Get behavioral change events* data source retrieves all behavioral change points detected in the DataMiner System. These events are detected on your trend data by *Behavioral Anomaly Detection*, see [Working with behavioral anomaly detection](xref:Working_with_behavioral_anomaly_detection). <!-- RN 35027 -->
+
+By default, the data contains the following columns:
+
+- **Parameter ID**: the ID of the parameter on which the change point was detected.
+- **Anomalous**: whether the change point was marked as an anomaly.
+- **Change type**: the type of change point that was detected.
+- **Increase**: whether the detected change point represents an increase (e.g. a level shift up) or a decrease (e.g. a level shift down).
+- **Start time**: the time at which the change began.
+- **End time**: the time at which the change ended.
+
+The following columns are also available after a *Select* operation:
+
+- **Element ID**: the ID of the element on which the change point was detected.
+- **Change Point ID**: the ID of the change point.
+- **Start value**: the parameter value at the start of the change point.
+- **End value**: the parameter value at the end of the change point.
+- **Significance**: a number indicating how significant the change point is relative to the historically detected change points.
+- **Severity**: a number indicating the severity of the change point relative to the historical trend data.
+- **Creation time**: when the change point was first detected.
+- **Last update**: when the change point was last updated.
+
+When one or more table rows are selected, the following feeds are available in the *feeds* section of the data pane:
+
+- **Parameters**: the parameters on which the selected the change points were detected.
+- **Timespans**: the time ranges from the start time to the end time of the selected change points.
+- **Elements**: the elements on which the selected change points were detected.
+- **Indices**: the primary key of the table rows on which the selected change points were detected, if any.


### PR DESCRIPTION
Extend the page on the 'Get behavioral change events' query data source with an explanation of all the available columns and all feeds that are exported. Also include a link to more explanation on anomaly detection.