### PR TITLE
Migration from Elasticsearch to OpenSearch

### DIFF
--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Elasticsearch/Elasticsearch_database.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Elasticsearch/Elasticsearch_database.md
@@ -16,4 +16,7 @@ In a setup with **storage per DMA**, setting up an indexing database is not mand
 > - For information on how to query an Elasticsearch database, see [Querying an Elasticsearch database](xref:Querying_an_Elasticsearch_database).
 
 > [!TIP]
-> See also: [Securing the Elasticsearch database](xref:Security_Elasticsearch)
+> See also:
+>
+> - [Migrating from Elasticsearch to OpenSearch](xref:Migrating_from_Elasticsearch_to_OpenSearch)
+> - [Securing the Elasticsearch database](xref:Security_Elasticsearch)

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
@@ -33,7 +33,23 @@ Using Kibana, you can take a snapshot in the following way:
    GET /_snapshot/_all
    ```
 
-   - This request will return all registered snapshots in the cluster. In case the desired repository already exists the next step can be skipped.
+   - This will return a response containing information about all the repositories configured in Elasticsearch. In case the desired repository already exists the next step can be skipped.
+   - Example response when a repository already exists.
+
+    ```json
+    {
+      "test_tepo_1" : {
+        "type" : "fs",
+        "settings" : {
+          "location" : "/usr/share/elasticsearch/repo",
+          "maxRestoreBytesPerSec" : "40mb",
+          "readonly" : "false",
+          "compress" : "true",
+          "maxSnapshotBytesPerSec" : "40mb"
+        }
+      }
+    }
+    ```
 
 1. Create the repository by sending the following request:
 
@@ -91,7 +107,23 @@ Using Kibana, you can restore the snapshot in the following way:
    GET /_snapshot/_all
    ```
 
-   - This request will return all registered snapshots in the cluster. In case the desired repository already exists the next step can be skipped.
+   - This will return a response containing information about all the repositories configured in Elasticsearch. In case the desired repository already exists the next step can be skipped.
+   - Example response when a repository already exists.
+
+    ```json
+    {
+      "test_tepo_1" : {
+        "type" : "fs",
+        "settings" : {
+          "location" : "/usr/share/elasticsearch/repo",
+          "maxRestoreBytesPerSec" : "40mb",
+          "readonly" : "false",
+          "compress" : "true",
+          "maxSnapshotBytesPerSec" : "40mb"
+        }
+      }
+    }
+    ```
 
 1. Create the repository by sending the following request:
 
@@ -176,7 +208,23 @@ Using Kibana, you can restore the snapshot in the following way:
    GET /_snapshot/_all
    ```
 
-   - This request will return all registered snapshots in the cluster. In case the desired repository already exists the next step can be skipped.
+   - This will return a response containing information about all the repositories configured in Elasticsearch. In case the desired repository already exists the next step can be skipped.
+   - Example response when a repository already exists.
+
+    ```json
+    {
+      "test_tepo_1" : {
+        "type" : "fs",
+        "settings" : {
+          "location" : "/usr/share/elasticsearch/repo",
+          "maxRestoreBytesPerSec" : "40mb",
+          "readonly" : "false",
+          "compress" : "true",
+          "maxSnapshotBytesPerSec" : "40mb"
+        }
+      }
+    }
+    ```
 
 1. Create the repository by sending the following request:
 

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
@@ -154,7 +154,7 @@ Using Kibana, you can restore the snapshot in the following way:
 
 ## Restore the snapshot with the re-indexed data to a OpenSearch 2.11.1 cluster
 
-1. Check the *path.repo* configuration in *opensearch.yml*.
+1. Check the *path.repo* configuration in *opensearch.yml*, it should be pointing to a shared filesystem location to which each node has access.
 
 1. Check the existing repositories by sending the following request.
 

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
@@ -152,6 +152,8 @@ Using Kibana, you can restore the snapshot in the following way:
     GET /_snapshot/<repo_name>/<snapshot_name>/_status
    ```
 
+   - This request will return information about the status of the specified snapshot, the state should be "SUCCESS".
+
 ## Restore the snapshot with the re-indexed data to a OpenSearch 2.11.1 cluster
 
 1. Check the *path.repo* configuration in *opensearch.yml*, it should be pointing to a shared filesystem location to which each node has access.

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
@@ -31,6 +31,8 @@ Using Kibana, you can take a snapshot in the following way:
    GET /_snapshot/_all
    ```
 
+   - This request will return all registered snapshots in the cluster. In case the desired repository already exists the next step can be skipped.
+
 1. Create the repository by sending the following request.
 
    ```txt
@@ -71,17 +73,21 @@ Using Kibana, you can take a snapshot in the following way:
     GET /_snapshot/<repo_name>/<snapshot_name>/_status
    ```
 
+   - This request returns status information for a specific snapshot within a given repository. The state should be SUCCESS and all shards should be successful.
+
 ## Restore the snapshot on an Elasticsearch 7.10.0 cluster
 
 Using Kibana, you can restore the snapshot in the following way:
 
-1. Check the *path.repo* configuration in *elasticsearch.yml*.
+1. Check the *path.repo* configuration in *elasticsearch.yml*, it should be pointing to a shared filesystem location to which each node has access.
 
 1. Check the existing repositories by sending the following request.
 
    ```txt
    GET /_snapshot/_all
    ```
+
+   - This request will return all registered snapshots in the cluster. In case the desired repository already exists the next step can be skipped.
 
 1. Create the repository by sending the following request.
 
@@ -163,6 +169,8 @@ Using Kibana, you can restore the snapshot in the following way:
    ```txt
    GET /_snapshot/_all
    ```
+
+   - This request will return all registered snapshots in the cluster. In case the desired repository already exists the next step can be skipped.
 
 1. Create the repository by sending the following request.
 

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
@@ -12,7 +12,7 @@ Follow the below-mentioned instructions to migrate data from Elasticsearch 6.8.2
 
 1. [Run the re-indexing tool and take a snapshot](#run-the-re-indexing-tool-and-take-a-snapshot).
 
-1. [Copy the reindexed snapshot to an OpenSearch 2.11.1 cluster and restore it](#restore-the-re-indexed-snapshot-to-a-opensearch-2111-cluster).
+1. [Copy the snapshot with the re-indexed data to an OpenSearch 2.11.1 cluster and restore it](#restore-the-snapshot-with-the-re-indexed-data-to-a-opensearch-2111-cluster).
 
 > [!TIP]
 > See also [Taking a snapshot of one Elasticsearch cluster and restoring it to another](xref:Taking_snapshot_Elasticsearch_cluster_and_restoring_to_different_cluster)
@@ -129,11 +129,11 @@ Using Kibana, you can restore the snapshot in the following way:
 
    | Argument | Description |
    |----------|-------------|
-   | Node or N | The name of the node to be used for re-indexing (mandatory).<br>Format: `http(s)://127.0.0.1:9200` or `http(s)://fqdn:9200` |
-   | User or U | The user name, to be provided in case Elasticsearch was hardened.<br>See [Securing the Elasticsearch database](xref:Security_Elasticsearch) |
-   | Password or P | The user password |
-   | DBPrefix or D | The database prefix, to be provided in case a custom database prefix is used instead of the default `dms-` prefix.<br>If you do not provide a prefix, the default `dms-` will be used. |
-   | TLSEnabled or T | Whether or not TLS is enabled for this ElasticSearch database.<br>Values: true or false. Default: false |
+   | -Node or -N | The name of the node to be used for re-indexing (mandatory).<br>Format: `http(s)://127.0.0.1:9200` or `http(s)://fqdn:9200` |
+   | -User or -U | The user name, to be provided in case Elasticsearch was hardened.<br>See [Securing the Elasticsearch database](xref:Security_Elasticsearch) |
+   | -Password or -P | The user password |
+   | -DBPrefix or -D | The database prefix, to be provided in case a custom database prefix is used instead of the default `dms-` prefix.<br>If you do not provide a prefix, the default `dms-` will be used. |
+   | -TLSEnabled or -T | Whether or not TLS is enabled for this ElasticSearch database.<br>Values: true or false. Default: false |
 
 1. Take a snapshot of the re-indexed data by sending the following request.
 
@@ -150,7 +150,7 @@ Using Kibana, you can restore the snapshot in the following way:
     GET /_snapshot/<repo_name>/<snapshot_name>/_status
    ```
 
-## Restore the re-indexed snapshot to a OpenSearch 2.11.1 cluster
+## Restore the snapshot with the re-indexed data to a OpenSearch 2.11.1 cluster
 
 1. Check the *path.repo* configuration in *opensearch.yml*.
 

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
@@ -45,6 +45,8 @@ Using Kibana, you can take a snapshot in the following way:
     }
    ```
 
+   Variables:
+
    - **repo_name**: A repository name of your choice.
    - **shared_repo_path**: The path to the shared folder where the snapshots will be stored.
 
@@ -56,6 +58,8 @@ Using Kibana, you can take a snapshot in the following way:
       "indices": "dms*"
     }
    ```
+
+   Variable:
 
    - **snapshot_name**: A snapshot name of your choice.
 
@@ -115,21 +119,23 @@ Using Kibana, you can restore the snapshot in the following way:
 
 ## Run the re-indexing tool and take a snapshot
 
-1. On the terminal go to the tool location:
+1. Open a terminal, and go to the folder containing the tool:
 
    ```txt
     cd <ReIndexElasticSearchIndexes.exe location>
    ```
 
-1. Execute the tool with the following arguments:
+1. Run the tool with the following arguments:
 
-   - **Node or N** Name of the node to be used for re-indexing, in format: http(s)://127.0.0.1:9200 or http(s)://fqdn:9200 (required)
-   - **User or U** UserName to be provided in case you hardened your ElasticSearch,  [Securing the Elasticsearch database](https://docs.dataminer.services/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Elasticsearch.html)
-   - **Password or P** Password of the User
-   - **DBPrefix or D** DB Prefix in case you use a custom db-prefix instead of the default dms- prefix. In case no prefix is provided, will default to dms-
-   - **TLSEnabled or T** Indicate if TLS is enabled for your ElasticSearch, can be true or false, will default to false
+   | Argument | Description |
+   |----------|-------------|
+   | Node or N | The name of the node to be used for re-indexing (mandatory).<br>Format: `http(s)://127.0.0.1:9200` or `http(s)://fqdn:9200` |
+   | User or U | The user name, to be provided in case Elasticsearch was hardened.<br>See [Securing the Elasticsearch database](xref:Security_Elasticsearch) |
+   | Password or P | The user password |
+   | DBPrefix or D | The database prefix, to be provided in case a custom database prefix is used instead of the default `dms-` prefix.<br>If you do not provide a prefix, the default `dms-` will be used. |
+   | TLSEnabled or T | Whether or not TLS is enabled for this ElasticSearch database.<br>Values: true or false. Default: false |
 
-1. Take snapshot of the reindexed data
+1. Take a snapshot of the re-indexed data by sending the following request.
 
    ```txt
    PUT /_snapshot/<repo_name>/<snapshot_name_reindexed>
@@ -138,7 +144,7 @@ Using Kibana, you can restore the snapshot in the following way:
     }
    ```
 
-1. Check Snapshot
+1. Check the snapshot by sending the following request.
 
    ```txt
     GET /_snapshot/<repo_name>/<snapshot_name>/_status
@@ -146,15 +152,15 @@ Using Kibana, you can restore the snapshot in the following way:
 
 ## Restore the re-indexed snapshot to a OpenSearch 2.11.1 cluster
 
-1. Check the "path.repo" configuration on opensearch.yml.
+1. Check the *path.repo* configuration in *opensearch.yml*.
 
-1. Check existing repositories.
+1. Check the existing repositories by sending the following request.
 
    ```txt
    GET /_snapshot/_all
    ```
 
-1. Create repository
+1. Create the repository by sending the following request.
 
    ```txt
     PUT /_snapshot/<repo_name>
@@ -170,19 +176,19 @@ Using Kibana, you can restore the snapshot in the following way:
     }
    ```
 
-1. Restore snapshot.
+1. Restore the snapshot by sending the following request.
 
    ```txt
     POST /_snapshot/<repo_name>/<snapshot_name_reindexed>/_restore 
    ```
 
-1. Check Snapshot
+1. Check the snapshot by sending the following request.
 
    ```txt
     GET /_snapshot/<repo_name>/<snapshot_name>/_status
    ```
 
-1. Check cluster health
+1. Check the cluster health by sending the following request.
 
    ```txt
     GET /_cluster/health

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
@@ -81,7 +81,9 @@ Using Kibana, you can take a snapshot in the following way:
 
 Using Kibana, you can restore the snapshot in the following way:
 
-1. Check the *path.repo* configuration in *elasticsearch.yml*, it should be pointing to a shared filesystem location to which each node has access.
+1. Check the *path.repo* configuration in *elasticsearch.yml*.
+
+   This configuration should point to a shared file system location to which each node has access.
 
 1. Check the existing repositories by sending the following request:
 

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
@@ -1,5 +1,6 @@
 ---
 uid: Migrating_from_Elasticsearch_to_OpenSearch
+keywords: re-indexer
 ---
 
 # Migrating from Elasticsearch to OpenSearch
@@ -14,7 +15,7 @@ To use this tool, follow the instructions below:
 
 1. [Run the re-indexing tool and take a snapshot](#run-the-re-indexing-tool-and-take-a-snapshot).
 
-1. [Copy the snapshot with the re-indexed data to an OpenSearch 2.11.1 cluster and restore it](#restore-the-snapshot-with-the-re-indexed-data-to-a-opensearch-2111-cluster).
+1. [Copy the snapshot with the re-indexed data to an OpenSearch 2.11.1 cluster and restore it](#restore-the-snapshot-with-the-re-indexed-data-to-an-opensearch-2111-cluster).
 
 > [!TIP]
 > See also: [Taking a snapshot of one Elasticsearch cluster and restoring it to another](xref:Taking_snapshot_Elasticsearch_cluster_and_restoring_to_different_cluster)
@@ -33,28 +34,28 @@ Using Kibana, you can take a snapshot in the following way:
    GET /_snapshot/_all
    ```
 
-   - This will return a response containing information about all the repositories configured in Elasticsearch. In case the desired repository already exists the next step can be skipped.
-   - Example response when a repository already exists.
+   - This will return a response containing information about all the repositories configured in Elasticsearch. In case the desired repository already exists, you can skip the next step.
+   - Example response when a repository already exists:
 
-    ```json
-    {
-      "test_tepo_1" : {
-        "type" : "fs",
-        "settings" : {
-          "location" : "/usr/share/elasticsearch/repo",
-          "maxRestoreBytesPerSec" : "40mb",
-          "readonly" : "false",
-          "compress" : "true",
-          "maxSnapshotBytesPerSec" : "40mb"
-        }
-      }
-    }
-    ```
+     ```json
+     {
+       "test_tepo_1" : {
+         "type" : "fs",
+         "settings" : {
+           "location" : "/usr/share/elasticsearch/repo",
+           "maxRestoreBytesPerSec" : "40mb",
+           "readonly" : "false",
+           "compress" : "true",
+           "maxSnapshotBytesPerSec" : "40mb"
+         }
+       }
+     }
+     ```
 
 1. Create the repository by sending the following request:
 
    ```txt
-    PUT /_snapshot/<repo_name>
+   PUT /_snapshot/<repo_name>
     {
         "type": "fs",
         "settings": {
@@ -88,10 +89,10 @@ Using Kibana, you can take a snapshot in the following way:
 1. Check the snapshot by sending the following request:
 
    ```txt
-    GET /_snapshot/<repo_name>/<snapshot_name>/_status
+   GET /_snapshot/<repo_name>/<snapshot_name>/_status
    ```
 
-   - This request returns status information for a specific snapshot within a given repository. The state should be SUCCESS and all shards should be successful.
+   This request returns status information for a specific snapshot within a given repository. The state should be SUCCESS and all shards should be successful.
 
 ## Restore the snapshot on an Elasticsearch 7.10.0 cluster
 
@@ -107,28 +108,28 @@ Using Kibana, you can restore the snapshot in the following way:
    GET /_snapshot/_all
    ```
 
-   - This will return a response containing information about all the repositories configured in Elasticsearch. In case the desired repository already exists the next step can be skipped.
-   - Example response when a repository already exists.
+   - This will return a response containing information about all the repositories configured in Elasticsearch. In case the desired repository already exists, you can skip the next step.
+   - Example response when a repository already exists:
 
-    ```json
-    {
-      "test_tepo_1" : {
-        "type" : "fs",
-        "settings" : {
-          "location" : "/usr/share/elasticsearch/repo",
-          "maxRestoreBytesPerSec" : "40mb",
-          "readonly" : "false",
-          "compress" : "true",
-          "maxSnapshotBytesPerSec" : "40mb"
-        }
-      }
-    }
-    ```
+     ```json
+     {
+       "test_tepo_1" : {
+         "type" : "fs",
+         "settings" : {
+           "location" : "/usr/share/elasticsearch/repo",
+           "maxRestoreBytesPerSec" : "40mb",
+           "readonly" : "false",
+           "compress" : "true",
+           "maxSnapshotBytesPerSec" : "40mb"
+         }
+       }
+     }
+     ```
 
 1. Create the repository by sending the following request:
 
    ```txt
-    PUT /_snapshot/<repo_name>
+   PUT /_snapshot/<repo_name>
     {
         "type": "fs",
         "settings": {
@@ -144,19 +145,21 @@ Using Kibana, you can restore the snapshot in the following way:
 1. Restore the snapshot by sending the following request:
 
    ```txt
-    POST /_snapshot/<repo_name>/<snapshot_name>/_restore 
+   POST /_snapshot/<repo_name>/<snapshot_name>/_restore 
    ```
 
 1. Check the snapshot by sending the following request:
 
    ```txt
-    GET /_snapshot/<repo_name>/<snapshot_name>/_status
+   GET /_snapshot/<repo_name>/<snapshot_name>/_status
    ```
+
+   This request will return information about the status of the specified snapshot. The status should be "SUCCESS".
 
 1. Check the cluster health by sending the following request:
 
    ```txt
-    GET /_cluster/health
+   GET /_cluster/health
    ```
 
    The status of the cluster should turn green after the restore.
@@ -166,7 +169,7 @@ Using Kibana, you can restore the snapshot in the following way:
 1. Open a terminal, and go to the folder containing the tool. By default, this is the folder `C:\Skyline DataMiner\Tools\ReIndexElasticSearchIndexes`:
 
    ```txt
-    cd C:\Skyline DataMiner\Tools\ReIndexElasticSearchIndexes
+   cd C:\Skyline DataMiner\Tools\ReIndexElasticSearchIndexes
    ```
 
 1. Run the tool with the following arguments:
@@ -191,12 +194,12 @@ Using Kibana, you can restore the snapshot in the following way:
 1. Check the snapshot by sending the following request:
 
    ```txt
-    GET /_snapshot/<repo_name>/<snapshot_name>/_status
+   GET /_snapshot/<repo_name>/<snapshot_name>/_status
    ```
 
    This request will return information about the status of the specified snapshot. The status should be "SUCCESS".
 
-## Restore the snapshot with the re-indexed data to a OpenSearch 2.11.1 cluster
+## Restore the snapshot with the re-indexed data to an OpenSearch 2.11.1 cluster
 
 1. Check the *path.repo* configuration in *opensearch.yml*.
 
@@ -208,28 +211,28 @@ Using Kibana, you can restore the snapshot in the following way:
    GET /_snapshot/_all
    ```
 
-   - This will return a response containing information about all the repositories configured in Elasticsearch. In case the desired repository already exists the next step can be skipped.
-   - Example response when a repository already exists.
+   - This will return a response containing information about all the repositories configured in Elasticsearch. In case the desired repository already exists, you can skip the next step.
+   - Example response when a repository already exists:
 
-    ```json
-    {
-      "test_tepo_1" : {
-        "type" : "fs",
-        "settings" : {
-          "location" : "/usr/share/elasticsearch/repo",
-          "maxRestoreBytesPerSec" : "40mb",
-          "readonly" : "false",
-          "compress" : "true",
-          "maxSnapshotBytesPerSec" : "40mb"
-        }
-      }
-    }
-    ```
+     ```json
+     {
+       "test_tepo_1" : {
+         "type" : "fs",
+         "settings" : {
+           "location" : "/usr/share/elasticsearch/repo",
+           "maxRestoreBytesPerSec" : "40mb",
+           "readonly" : "false",
+           "compress" : "true",
+           "maxSnapshotBytesPerSec" : "40mb"
+         }
+       }
+     }
+     ```
 
 1. Create the repository by sending the following request:
 
    ```txt
-    PUT /_snapshot/<repo_name>
+   PUT /_snapshot/<repo_name>
     {
         "type": "fs",
         "settings": {
@@ -245,19 +248,21 @@ Using Kibana, you can restore the snapshot in the following way:
 1. Restore the snapshot by sending the following request:
 
    ```txt
-    POST /_snapshot/<repo_name>/<snapshot_name_reindexed>/_restore 
+   POST /_snapshot/<repo_name>/<snapshot_name_reindexed>/_restore 
    ```
 
 1. Check the snapshot by sending the following request:
 
    ```txt
-    GET /_snapshot/<repo_name>/<snapshot_name>/_status
+   GET /_snapshot/<repo_name>/<snapshot_name>/_status
    ```
+
+   This request will return information about the status of the specified snapshot. The status should be "SUCCESS".
 
 1. Check the cluster health by sending the following request:
 
    ```txt
-    GET /_cluster/health
+   GET /_cluster/health
    ```
 
    The status of the cluster should turn green after the restore.

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
@@ -23,7 +23,7 @@ To use this tool, follow the instructions below:
 
 Using Kibana, you can take a snapshot in the following way:
 
-1. Check the *path.repo* configuration in *elasticsearch.yml*.
+1. Check the *path.repo* configuration in *elasticsearch.yml*, it should be pointing to a shared filesystem location to which each node has access.
 
 1. Check the existing repositories by sending the following request.
 
@@ -117,14 +117,14 @@ Using Kibana, you can restore the snapshot in the following way:
     GET /_cluster/health
    ```
 
-   - Wait until the cluster health status turns green.
+   - Check the cluster health to ensure that the status turns green after the restore.
 
 ## Run the re-indexing tool and take a snapshot
 
 1. Open a terminal, and go to the folder containing the tool:
 
    ```txt
-    cd <ReIndexElasticSearchIndexes.exe location>
+    cd C:\Skyline DataMiner\Tools\ReIndexElasticSearchIndexes
    ```
 
 1. Run the tool with the following arguments:
@@ -195,3 +195,5 @@ Using Kibana, you can restore the snapshot in the following way:
    ```txt
     GET /_cluster/health
    ```
+
+   - Check the cluster health to ensure that the status turns green after the restore.

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Migrating_from_Elasticsearch_to_Opensearch.md
@@ -4,7 +4,9 @@ uid: Migrating_from_Elasticsearch_to_OpenSearch
 
 # Migrating from Elasticsearch to OpenSearch
 
-Follow the below-mentioned instructions to migrate data from Elasticsearch 6.8.22 to OpenSearch 2.11.1.
+From DataMiner 10.4.4/10.5.0 onwards<!-- RN 37994 -->, a tool is available that allows you to migrate from Elasticsearch 6.8.22 to OpenSearch 2.11.1.
+
+To use this tool, follow the instructions below:
 
 1. [Take a snapshot of the Elasticsearch 6.8.22 cluster](#take-a-snapshot-of-the-elasticsearch-6822-cluster).
 
@@ -15,7 +17,7 @@ Follow the below-mentioned instructions to migrate data from Elasticsearch 6.8.2
 1. [Copy the snapshot with the re-indexed data to an OpenSearch 2.11.1 cluster and restore it](#restore-the-snapshot-with-the-re-indexed-data-to-a-opensearch-2111-cluster).
 
 > [!TIP]
-> See also [Taking a snapshot of one Elasticsearch cluster and restoring it to another](xref:Taking_snapshot_Elasticsearch_cluster_and_restoring_to_different_cluster)
+> See also: [Taking a snapshot of one Elasticsearch cluster and restoring it to another](xref:Taking_snapshot_Elasticsearch_cluster_and_restoring_to_different_cluster)
 
 ## Take a snapshot of the Elasticsearch 6.8.22 cluster
 

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Migration_from_Elasticsearch_to_Opensearch.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Migration_from_Elasticsearch_to_Opensearch.md
@@ -1,8 +1,8 @@
 ---
-uid: Migration_from_Elasticsearch_to_Opensearch
+uid: Migration_from_Elasticsearch_to_OpenSearch
 ---
 
-# Migration from Elasticsearch to Opensearch
+# Migration from Elasticsearch to OpenSearch
 
 This guide describes the steps to migrate from Elasticsearch 6.8.22 to OpenSearch 2.11.1
 

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Migration_from_Elasticsearch_to_Opensearch.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Migration_from_Elasticsearch_to_Opensearch.md
@@ -1,34 +1,35 @@
 ---
-uid: Migration_from_Elasticsearch_to_OpenSearch
+uid: Migrating_from_Elasticsearch_to_OpenSearch
 ---
 
-# Migration from Elasticsearch to OpenSearch
+# Migrating from Elasticsearch to OpenSearch
 
-This guide describes the steps to migrate from Elasticsearch 6.8.22 to OpenSearch 2.11.1
+Follow the below-mentioned instructions to migrate data from Elasticsearch 6.8.22 to OpenSearch 2.11.1.
 
-1. Take a snapshot in the Elasticsearch 6.8.22 cluster.
+1. [Take a snapshot of the Elasticsearch 6.8.22 cluster](#take-a-snapshot-of-the-elasticsearch-6822-cluster).
 
-2. Copy the snapshot to a Elasticsearch 7.10.0 cluster and restore it there.
+1. [Copy the snapshot to an Elasticsearch 7.10.0 cluster and restore it](#restore-the-snapshot-on-an-elasticsearch-7100-cluster).
 
-3. Run the Reindexing tool on the restored data and take a snapshot.
+1. [Run the re-indexing tool and take a snapshot](#run-the-re-indexing-tool-and-take-a-snapshot).
 
-4. Copy the reindexed snapshot to a OpenSearch 2.11.1 cluster and restore it there.
+1. [Copy the reindexed snapshot to an OpenSearch 2.11.1 cluster and restore it](#restore-the-re-indexed-snapshot-to-a-opensearch-2111-cluster).
 
-Reference [Taking a snapshot of one Elasticsearch cluster and restoring it to another](xref:Taking_snapshot_Elasticsearch_cluster_and_restoring_to_different_cluster)
+> [!TIP]
+> See also [Taking a snapshot of one Elasticsearch cluster and restoring it to another](xref:Taking_snapshot_Elasticsearch_cluster_and_restoring_to_different_cluster)
 
-## Take Snapshot on Elasticsearch 6.8.22
+## Take a snapshot of the Elasticsearch 6.8.22 cluster
 
-### Sample Steps to take snapshot on Kibana
+Using Kibana, you can take a snapshot in the following way:
 
-1. Check the "path.repo" configuration on elasticsearch.yml.
+1. Check the *path.repo* configuration in *elasticsearch.yml*.
 
-2. Check existing repositories.
+1. Check the existing repositories by sending the following request.
 
    ```txt
    GET /_snapshot/_all
    ```
 
-3. Create repository
+1. Create the repository by sending the following request.
 
    ```txt
     PUT /_snapshot/<repo_name>
@@ -44,10 +45,10 @@ Reference [Taking a snapshot of one Elasticsearch cluster and restoring it to an
     }
    ```
 
-    - **shared_repo_path**: The path of the shared folder for storing the snapshots.
-    - **repo_name**: A repository name of your choice.
+   - **repo_name**: A repository name of your choice.
+   - **shared_repo_path**: The path to the shared folder where the snapshots will be stored.
 
-4. Take snapshot
+1. Take the snapshot by sending the following request.
 
    ```txt
    PUT /_snapshot/<repo_name>/<snapshot_name>
@@ -56,27 +57,27 @@ Reference [Taking a snapshot of one Elasticsearch cluster and restoring it to an
     }
    ```
 
-    - **snapshot_name**: A snapshot name of your choice.
+   - **snapshot_name**: A snapshot name of your choice.
 
-5. Check Snapshot
+1. Check the snapshot by sending the following request.
 
    ```txt
     GET /_snapshot/<repo_name>/<snapshot_name>/_status
    ```
 
-## Restore Snapshot on Elasticsearch 7.10.0
+## Restore the snapshot on an Elasticsearch 7.10.0 cluster
 
-### Sample Steps to restore snapshot on Kibana
+Using Kibana, you can restore the snapshot in the following way:
 
-1. Check the "path.repo" configuration on elasticsearch.yml.
+1. Check the *path.repo* configuration in *elasticsearch.yml*.
 
-2. Check existing repositories.
+1. Check the existing repositories by sending the following request.
 
    ```txt
    GET /_snapshot/_all
    ```
 
-3. Create repository
+1. Create the repository by sending the following request.
 
    ```txt
     PUT /_snapshot/<repo_name>
@@ -92,27 +93,27 @@ Reference [Taking a snapshot of one Elasticsearch cluster and restoring it to an
     }
    ```
 
-4. Restore snapshot.
+1. Restore the snapshot by sending the following request.
 
    ```txt
     POST /_snapshot/<repo_name>/<snapshot_name>/_restore 
    ```
 
-5. Check Snapshot
+1. Check the snapshot by sending the following request.
 
    ```txt
     GET /_snapshot/<repo_name>/<snapshot_name>/_status
    ```
 
-6. Check cluster health
+1. Check the cluster health by sending the following request.
 
    ```txt
     GET /_cluster/health
    ```
 
-    - Wait for green status of cluster health.
+   - Wait until the cluster health status turns green.
 
-## Run Reindexing Tool
+## Run the re-indexing tool and take a snapshot
 
 1. On the terminal go to the tool location:
 
@@ -120,7 +121,7 @@ Reference [Taking a snapshot of one Elasticsearch cluster and restoring it to an
     cd <ReIndexElasticSearchIndexes.exe location>
    ```
 
-2. Execute the tool whith the following arguments:
+1. Execute the tool with the following arguments:
 
    - **Node or N** Name of the node to be used for re-indexing, in format: http(s)://127.0.0.1:9200 or http(s)://fqdn:9200 (required)
    - **User or U** UserName to be provided in case you hardened your ElasticSearch,  [Securing the Elasticsearch database](https://docs.dataminer.services/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Elasticsearch.html)
@@ -128,7 +129,7 @@ Reference [Taking a snapshot of one Elasticsearch cluster and restoring it to an
    - **DBPrefix or D** DB Prefix in case you use a custom db-prefix instead of the default dms- prefix. In case no prefix is provided, will default to dms-
    - **TLSEnabled or T** Indicate if TLS is enabled for your ElasticSearch, can be true or false, will default to false
 
-3. Take snapshot of the reindexed data
+1. Take snapshot of the reindexed data
 
    ```txt
    PUT /_snapshot/<repo_name>/<snapshot_name_reindexed>
@@ -137,23 +138,23 @@ Reference [Taking a snapshot of one Elasticsearch cluster and restoring it to an
     }
    ```
 
-4. Check Snapshot
+1. Check Snapshot
 
    ```txt
     GET /_snapshot/<repo_name>/<snapshot_name>/_status
    ```
 
-## Restore reindexed snapshot in OpenSearch
+## Restore the re-indexed snapshot to a OpenSearch 2.11.1 cluster
 
 1. Check the "path.repo" configuration on opensearch.yml.
 
-2. Check existing repositories.
+1. Check existing repositories.
 
    ```txt
    GET /_snapshot/_all
    ```
 
-3. Create repository
+1. Create repository
 
    ```txt
     PUT /_snapshot/<repo_name>
@@ -169,19 +170,19 @@ Reference [Taking a snapshot of one Elasticsearch cluster and restoring it to an
     }
    ```
 
-4. Restore snapshot.
+1. Restore snapshot.
 
    ```txt
     POST /_snapshot/<repo_name>/<snapshot_name_reindexed>/_restore 
    ```
 
-5. Check Snapshot
+1. Check Snapshot
 
    ```txt
     GET /_snapshot/<repo_name>/<snapshot_name>/_status
    ```
 
-6. Check cluster health
+1. Check cluster health
 
    ```txt
     GET /_cluster/health

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Migration_from_Elasticsearch_to_Opensearch.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Migration_from_Elasticsearch_to_Opensearch.md
@@ -1,0 +1,188 @@
+---
+uid: Migration_from_Elasticsearch_to_Opensearch
+---
+
+# Migration from Elasticsearch to Opensearch
+
+This guide describes the steps to migrate from Elasticsearch 6.8.22 to OpenSearch 2.11.1
+
+1. Take a snapshot in the Elasticsearch 6.8.22 cluster.
+
+2. Copy the snapshot to a Elasticsearch 7.10.0 cluster and restore it there.
+
+3. Run the Reindexing tool on the restored data and take a snapshot.
+
+4. Copy the reindexed snapshot to a OpenSearch 2.11.1 cluster and restore it there.
+
+Reference [Taking a snapshot of one Elasticsearch cluster and restoring it to another](xref:Taking_snapshot_Elasticsearch_cluster_and_restoring_to_different_cluster)
+
+## Take Snapshot on Elasticsearch 6.8.22
+
+### Sample Steps to take snapshot on Kibana
+
+1. Check the "path.repo" configuration on elasticsearch.yml.
+
+2. Check existing repositories.
+
+   ```txt
+   GET /_snapshot/_all
+   ```
+
+3. Create repository
+
+   ```txt
+    PUT /_snapshot/<repo_name>
+    {
+        "type": "fs",
+        "settings": {
+        "location" : "<shared_repo_path>",
+            "maxRestoreBytesPerSec" : "40mb",
+            "readonly" : "false",
+            "compress" : "true",
+            "maxSnapshotBytesPerSec" : "40mb"
+        }
+    }
+   ```
+
+    - **shared_repo_path**: The path of the shared folder for storing the snapshots.
+    - **repo_name**: A repository name of your choice.
+
+4. Take snapshot
+
+   ```txt
+   PUT /_snapshot/<repo_name>/<snapshot_name>
+    {
+      "indices": "dms*"
+    }
+   ```
+
+    - **snapshot_name**: A snapshot name of your choice.
+
+5. Check Snapshot
+
+   ```txt
+    GET /_snapshot/<repo_name>/<snapshot_name>/_status
+   ```
+
+## Restore Snapshot on Elasticsearch 7.10.0
+
+### Sample Steps to restore snapshot on Kibana
+
+1. Check the "path.repo" configuration on elasticsearch.yml.
+
+2. Check existing repositories.
+
+   ```txt
+   GET /_snapshot/_all
+   ```
+
+3. Create repository
+
+   ```txt
+    PUT /_snapshot/<repo_name>
+    {
+        "type": "fs",
+        "settings": {
+        "location" : "<shared_repo_path>",
+            "maxRestoreBytesPerSec" : "40mb",
+            "readonly" : "false",
+            "compress" : "true",
+            "maxSnapshotBytesPerSec" : "40mb"
+        }
+    }
+   ```
+
+4. Restore snapshot.
+
+   ```txt
+    POST /_snapshot/<repo_name>/<snapshot_name>/_restore 
+   ```
+
+5. Check Snapshot
+
+   ```txt
+    GET /_snapshot/<repo_name>/<snapshot_name>/_status
+   ```
+
+6. Check cluster health
+
+   ```txt
+    GET /_cluster/health
+   ```
+
+    - Wait for green status of cluster health.
+
+## Run Reindexing Tool
+
+1. On the terminal go to the tool location:
+
+   ```txt
+    cd <ReIndexElasticSearchIndexes.exe location>
+   ```
+
+2. Execute the tool whith the following arguments:
+
+   - **Node or N** Name of the node to be used for re-indexing, in format: http(s)://127.0.0.1:9200 or http(s)://fqdn:9200 (required)
+   - **User or U** UserName to be provided in case you hardened your ElasticSearch,  [Securing the Elasticsearch database](https://docs.dataminer.services/user-guide/Advanced_Functionality/Security/Advanced_security_configuration/Database_security/Security_Elasticsearch.html)
+   - **Password or P** Password of the User
+   - **DBPrefix or D** DB Prefix in case you use a custom db-prefix instead of the default dms- prefix. In case no prefix is provided, will default to dms-
+   - **TLSEnabled or T** Indicate if TLS is enabled for your ElasticSearch, can be true or false, will default to false
+
+3. Take snapshot of the reindexed data
+
+   ```txt
+   PUT /_snapshot/<repo_name>/<snapshot_name_reindexed>
+    {
+      "indices": "dms*"
+    }
+   ```
+
+4. Check Snapshot
+
+   ```txt
+    GET /_snapshot/<repo_name>/<snapshot_name>/_status
+   ```
+
+## Restore reindexed snapshot in OpenSearch
+
+1. Check the "path.repo" configuration on opensearch.yml.
+
+2. Check existing repositories.
+
+   ```txt
+   GET /_snapshot/_all
+   ```
+
+3. Create repository
+
+   ```txt
+    PUT /_snapshot/<repo_name>
+    {
+        "type": "fs",
+        "settings": {
+        "location" : "<shared_repo_path>",
+            "maxRestoreBytesPerSec" : "40mb",
+            "readonly" : "false",
+            "compress" : "true",
+            "maxSnapshotBytesPerSec" : "40mb"
+        }
+    }
+   ```
+
+4. Restore snapshot.
+
+   ```txt
+    POST /_snapshot/<repo_name>/<snapshot_name_reindexed>/_restore 
+   ```
+
+5. Check Snapshot
+
+   ```txt
+    GET /_snapshot/<repo_name>/<snapshot_name>/_status
+   ```
+
+6. Check cluster health
+
+   ```txt
+    GET /_cluster/health
+   ```

--- a/user-guide/Advanced_Functionality/toc.yml
+++ b/user-guide/Advanced_Functionality/toc.yml
@@ -375,6 +375,8 @@ items:
                 topicUid: Resources_migration_to_elastic
               - name: Migrating SRM profiles to the indexing database
                 topicUid: Profile_migration_to_elastic
+              - name: Migration from Elasticsearch to OpenSearch
+                topicUid: Migration_from_Elasticsearch_to_OpenSearch
           - name: Common database settings
             topicUid: Specifying_TTL_overrides
             items:

--- a/user-guide/Advanced_Functionality/toc.yml
+++ b/user-guide/Advanced_Functionality/toc.yml
@@ -375,8 +375,8 @@ items:
                 topicUid: Resources_migration_to_elastic
               - name: Migrating SRM profiles to the indexing database
                 topicUid: Profile_migration_to_elastic
-              - name: Migration from Elasticsearch to OpenSearch
-                topicUid: Migration_from_Elasticsearch_to_OpenSearch
+              - name: Migrating from Elasticsearch to OpenSearch
+                topicUid: Migrating_from_Elasticsearch_to_OpenSearch
           - name: Common database settings
             topicUid: Specifying_TTL_overrides
             items:


### PR DESCRIPTION
Describes the steps to perform the migration from Elasticsearch to OpenSearch with the use of the Reindexing tool.