### PR TITLE
Update Protocol.Params.Param.Mediation.LinkTo.ValueMapping.md

### DIFF
--- a/develop/schemadoc/Protocol/Protocol.Params.Param.Mediation.LinkTo.ValueMapping.md
+++ b/develop/schemadoc/Protocol/Protocol.Params.Param.Mediation.LinkTo.ValueMapping.md
@@ -4,7 +4,7 @@ uid: Protocol.Params.Param.Mediation.LinkTo.ValueMapping
 
 # ValueMapping element
 
-Specifies a conversion of a value on the device protocol to a different value on the base protocol. This functionality can be used to map a discrete value on the device protocol (remoteValue) to an equivalent discrete represented by a different value on the base protocol.
+Specifies a conversion of a value on the device protocol to a different value on the base protocol. This functionality can, for instance, be used to map a discrete value on the device protocol (remoteValue) to an equivalent discrete represented by a different value on the base protocol.
 
 ## Parent
 


### PR DESCRIPTION
I noticed someone interpreting this example as the only valid purpose for the feature. Hopefully, this makes it a little clearer that the feature can also be used for other use cases.