### PR TITLE
Added detailed documentation for all DOM FieldDescriptors

### DIFF
--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_AutoIncrementFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_AutoIncrementFieldDescriptor.md
@@ -1,0 +1,44 @@
+---
+uid: DOM_AutoIncrementFieldDescriptor
+---
+
+# AutoIncrementFieldDescriptor
+
+- **FieldValue type**: string
+- **FieldValue example**: "MY_ID_154687"
+- **Multiple values supported**: :heavy_multiplication_x:
+- **Available since**: DataMiner 10.1.2/10.2.0
+
+| Type of Descriptor | FieldType | FieldValue type |
+|--------------------|-----------|-----------------|
+| Generates a unique incrementing integer with formatting options | string | string |
+
+Defines a DOM field that will automatically get an incremented value assigned. When a `DomInstance` does not have a value for this field yet, one will be assigned the next time the instance is updated. The `IDFormat` property is used to define a string format for the number value. In this string, "{0}" gets replaced by that number value. If the `IDFormat` property is empty, its value will not be formatted. When the field is marked as soft-deleted, no values will get assigned when a `DomInstance` gets saved.
+
+Some examples, assuming the next value is 10:
+
+| Description | Format | Result |
+|---|---|---|
+| Add a prefix and postfix | Pre-{0}-Post | Pre-10-Post |
+| Prefix with "REF-" and [format](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-numeric-format-strings) the value | REF-{0:000000} | REF-000010 |
+| When no format is set, the value is stored | | 10 |
+
+## Defining the FieldDescriptor
+
+```csharp
+var incrementHelper = new IncrementManagerHelper(_engine.SendSLNetMessages);
+var incrementer = incrementHelper.AutoIncrementers.Create(new AutoIncrementer());
+
+var descriptor = new AutoIncrementFieldDescriptor()
+{
+    ID = new FieldDescriptorID(Guid.NewGuid()),
+    Name = "My ID field",
+    FieldType = typeof(string),
+    AutoIncrementerID = incrementer.ID,
+    IDFormat = "Prefix_{0}_Suffix", // Optional
+};
+```
+
+## Adding a value for the FieldDescriptor
+
+No value needs to be provided. A value will automatically be added to the each section.

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_AutoIncrementFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_AutoIncrementFieldDescriptor.md
@@ -41,4 +41,4 @@ var descriptor = new AutoIncrementFieldDescriptor()
 
 ## Adding a value for the FieldDescriptor
 
-No value needs to be provided. A value will automatically be added to the each section.
+No value needs to be provided. A value will automatically be added to each section.

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_DomInstanceFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_DomInstanceFieldDescriptor.md
@@ -1,0 +1,50 @@
+---
+uid: DOM_DomInstanceFieldDescriptor
+---
+
+# DomInstanceFieldDescriptor
+
+- **FieldValue type**: Guid
+- **FieldValue example**: 9ba9aa93-8208-4404-9778-6a9343ba8483 (ID of a `DomInstance`)
+- **Multiple values supported**: :heavy_check_mark:
+- **Available since**: DataMiner 10.1.10/10.2.0
+
+| Type of Descriptor | FieldType | FieldValue type |
+|--------------------|-----------|-----------------|
+| References a single `DomInstance` | Guid | Guid |
+| References one or more `DomInstances` | List\<Guid\> | Guid (ListValueWrapper) |
+
+Defines a DOM field that references a `DomInstance` by storing the ID of that instance in the form of a `Guid`. This `DomInstance` can exist in a different DOM module if you set the `ModuleID` property to the ID of that module. There is also a `DomDefinitionIds` list property that can be used to define whether `DomInstances` should be linked to the defined definitions. Both properties are intended for UIs, and their validity and existence is not checked server-side. The configuration is similar to the [`DomInstanceValueFieldDescriptor`](xref:DOM_DomInstanceValueFieldDescriptor).
+
+## Defining the FieldDescriptor
+
+To enable multiple values, set the `FieldType` to `List<Guid>`.
+
+```csharp
+var descriptor = new DomInstanceFieldDescriptor("my_referenced_module")
+{
+    ID = new FieldDescriptorID(Guid.NewGuid()),
+    Name = "My DOM reference field",
+    FieldType = typeof(Guid), 
+    DomDefinitionIds = { domDefinitionId } // Optional
+};
+```
+
+## Adding a value for the FieldDescriptor
+
+```csharp
+var instance = new DomInstance
+{
+    ID = new DomInstanceId(Guid.NewGuid()),
+    DomDefinitionId = domDefinitionId
+};
+
+// Single value
+var instanceId = Guid.Parse("8000971e-982a-2151-10a2-1803aa100359");
+instance.AddOrUpdateFieldValue(sectionDefinitionId, fieldDescriptorId, instanceId);
+
+// Multiple values
+var firstInstanceId = Guid.Parse("755a424e-783f-466d-981e-8359fd0ca426");
+var secondInstanceId = Guid.Parse("16da2b5d-6b43-4267-96ba-4abd5c16ee2b");
+instance.AddOrUpdateListFieldValue(sectionDefinitionId, fieldDescriptorId, new List<Guid> { firstInstanceId, secondInstanceId });
+```

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_DomInstanceValueFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_DomInstanceValueFieldDescriptor.md
@@ -6,7 +6,7 @@ uid: DOM_DomInstanceValueFieldDescriptor
 
 - **FieldValue type**: Guid
 - **FieldValue example**: 9ba9aa93-8208-4404-9778-6a9343ba8483 (ID of a `DomInstance`)
-- **Multiple values supported**: :heavy_check_mark: (Since 10.2.5/10.3.0 - Server only)<!-- RN 32904 -->
+- **Multiple values supported**: :heavy_check_mark: (since DataMiner 10.2.5/10.3.0 - server only)<!-- RN 32904 -->
 - **Available since**: DataMiner 10.2.3/10.3.0
 
 | Type of Descriptor | FieldType | FieldValue type |

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_DomInstanceValueFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_DomInstanceValueFieldDescriptor.md
@@ -13,7 +13,7 @@ uid: DOM_DomInstanceValueFieldDescriptor
 |--------------------|-----------|-----------------|
 | References a single `DomInstance` value | Guid | Guid |
 
-Defines a DOM field that references a `DomInstance` by storing the ID of that instance in the form of a `Guid`. Compared to the [`DomInstanceFieldDescriptor`](xref:DOM_DomInstanceFieldDescriptor), this descriptor also references a specific value of that `DomInstance`. The configuration is the same as the [`DomInstanceFieldDescriptor`](xref:DOM_DomInstanceFieldDescriptor), but it adds the `FieldDescriptorId` property that references a specific `FieldValue`. This way, the DOM LCA form will show the specified value of the `DomInstance` alongside the name in the dropdown.
+Defines a DOM field that references a `DomInstance` by storing the ID of that instance in the form of a `Guid`. Compared to the [`DomInstanceFieldDescriptor`](xref:DOM_DomInstanceFieldDescriptor), this descriptor also references a specific value of that `DomInstance`. The configuration is the same as that of the [`DomInstanceFieldDescriptor`](xref:DOM_DomInstanceFieldDescriptor), but it adds the `FieldDescriptorId` property that references a specific `FieldValue`. This way, the DOM low-code app form will show the specified value of the `DomInstance` alongside the name in the dropdown.
 
 ## Defining the FieldDescriptor
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_DomInstanceValueFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_DomInstanceValueFieldDescriptor.md
@@ -1,0 +1,41 @@
+---
+uid: DOM_DomInstanceValueFieldDescriptor
+---
+
+# DomInstanceValueFieldDescriptor
+
+- **FieldValue type**: Guid
+- **FieldValue example**: 9ba9aa93-8208-4404-9778-6a9343ba8483 (ID of a `DomInstance`)
+- **Multiple values supported**: :heavy_check_mark: (Since 10.2.5/10.3.0 - Server only)<!-- RN 32904 -->
+- **Available since**: DataMiner 10.2.3/10.3.0
+
+| Type of Descriptor | FieldType | FieldValue type |
+|--------------------|-----------|-----------------|
+| References a single `DomInstance` value | Guid | Guid |
+
+Defines a DOM field that references a `DomInstance` by storing the ID of that instance in the form of a `Guid`. Compared to the [`DomInstanceFieldDescriptor`](xref:DOM_DomInstanceFieldDescriptor), this descriptor also references a specific value of that `DomInstance`. The configuration is the same as the [`DomInstanceFieldDescriptor`](xref:DOM_DomInstanceFieldDescriptor), but it adds the `FieldDescriptorId` property that references a specific `FieldValue`. This way, the DOM LCA form will show the specified value of the `DomInstance` alongside the name in the dropdown.
+
+## Defining the FieldDescriptor
+
+```csharp
+var descriptor = new DomInstanceValueFieldDescriptor("my_referenced_module", fieldDescriptorId)
+{
+    ID = new FieldDescriptorID(Guid.NewGuid()),
+    Name = "My DOM value reference field",
+    FieldType = typeof(Guid),
+    DomDefinitionIds = { domDefinitionId } // Optional
+};
+```
+
+## Adding a value for the FieldDescriptor
+
+```csharp
+var instance = new DomInstance 
+{        
+    ID = new DomInstanceId(Guid.NewGuid()),
+    DomDefinitionId = domDefinitionId
+};
+
+var instanceId = Guid.Parse("8000971e-982a-2151-10a2-1803aa100359");
+instance.AddOrUpdateFieldValue(sectionDefinitionId, fieldDescriptorId, instanceId);
+```

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ElementFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ElementFieldDescriptor.md
@@ -6,7 +6,7 @@ uid: DOM_ElementFieldDescriptor
 
 - **FieldValue type**: string
 - **FieldValue example**: "21569/987" (\<DMA ID\>/\<Element ID\>)
-- **Multiple values supported**: :heavy_check_mark: (Since 10.2.3/10.3.0)
+- **Multiple values supported**: :heavy_check_mark: (since DataMiner 10.2.3/10.3.0)
 - **Available since**: DataMiner 10.1.10/10.2.0
 
 | Type of Descriptor | FieldType | FieldValue type |

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ElementFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ElementFieldDescriptor.md
@@ -14,7 +14,7 @@ uid: DOM_ElementFieldDescriptor
 | References a single DataMiner element | string | string |
 | References one or more DataMiner elements | List\<string\> | string (ListValueWrapper) |
 
-Defines a DOM field that references a DataMiner element by storing the ID of that element in the form of a `string`. The ID must be saved in the `<DMA ID>/<Element ID>` format (e.g. "21569/987"). The `ViewIds` property can be used to define whether the elements should be in any of the defined views. The validity and existence of these views are not checked server-side. These will only be used in the DOM LCA form to determine the elements that will be shown in the dropdown.
+Defines a DOM field that references a DataMiner element by storing the ID of that element in the form of a `string`. The ID must be saved in the `<DMA ID>/<Element ID>` format (e.g. "21569/987"). The `ViewIds` property can be used to define whether the elements should be in any of the defined views. The validity and existence of these views are not checked server-side. These will only be used in the DOM low-code app form to determine the elements that will be shown in the dropdown.
 
 ## Defining the FieldDescriptor
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ElementFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ElementFieldDescriptor.md
@@ -1,0 +1,50 @@
+---
+uid: DOM_ElementFieldDescriptor
+---
+
+# ElementFieldDescriptor
+
+- **FieldValue type**: string
+- **FieldValue example**: "21569/987" (\<DMA ID\>/\<Element ID\>)
+- **Multiple values supported**: :heavy_check_mark: (Since 10.2.3/10.3.0)
+- **Available since**: DataMiner 10.1.10/10.2.0
+
+| Type of Descriptor | FieldType | FieldValue type |
+|--------------------|-----------|-----------------|
+| References a single DataMiner element | string | string |
+| References one or more DataMiner elements | List\<string\> | string (ListValueWrapper) |
+
+Defines a DOM field that references a DataMiner element by storing the ID of that element in the form of a `string`. The ID must be saved in the `<DMA ID>/<Element ID>` format (e.g. "21569/987"). The `ViewIds` property can be used to define whether the elements should be in any of the defined views. The validity and existence of these views are not checked server-side. These will only be used in the DOM LCA form to determine the elements that will be shown in the dropdown.
+
+## Defining the FieldDescriptor
+
+To enable multiple values, set the `FieldType` to `List<string>`.
+
+```csharp
+var descriptor = new ElementFieldDescriptor
+{
+    ID = new FieldDescriptorID(Guid.NewGuid()),
+    Name = "My element reference field",
+    FieldType = typeof(string),
+    ViewIds = { 5405, 6401 } // Optional
+};
+```
+
+## Adding a value for the FieldDescriptor
+
+```csharp
+var instance = new DomInstance
+{
+    ID = new DomInstanceId(Guid.NewGuid()),
+    DomDefinitionId = domDefinitionId
+};
+
+// Single value
+var elementId = "21569/987";
+instance.AddOrUpdateFieldValue(sectionDefinitionId, fieldDescriptorId, elementId);
+
+// Multiple values
+var firstElementId = "21569/1205";
+var secondElementId = "21569/1680";
+instance.AddOrUpdateListFieldValue(sectionDefinitionId, fieldDescriptorId, new List<string> { firstElementId, secondElementId });
+```

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_GenericEnumFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_GenericEnumFieldDescriptor.md
@@ -6,7 +6,7 @@ uid: DOM_GenericEnumFieldDescriptor
 
 - **FieldValue type**: int / string
 - **FieldValue example**: 5 / "very_high"
-- **Multiple values supported**: :heavy_check_mark: (Since 10.4.0/10.4.1)<!-- RN 37482 -->
+- **Multiple values supported**: :heavy_check_mark: (since DataMiner 10.4.0/10.4.1)<!-- RN 37482 -->
 - **Available since**: DataMiner 10.1.2/10.2.0
 
 | Type of Descriptor | FieldType | FieldValue type |

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_GenericEnumFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_GenericEnumFieldDescriptor.md
@@ -16,7 +16,7 @@ uid: DOM_GenericEnumFieldDescriptor
 | References a single string enum entry | GenericEnum\<string\> | string |
 | References one or more string enum entries | List<GenericEnum\<string\>> | string (ListValueWrapper) |
 
-Defines a DOM field that stores one or more options from a list of pre-determined discrete values. These possible values are defined by the `GenericEnum` object that is defined on the descriptor. The `GenericEnum` contains `GenericEnumEntry` objects that map a display value to a value, which is either of type int or string.
+Defines a DOM field that stores one or more options from a list of pre-determined discrete values. These possible values are defined by the `GenericEnum` object that is defined on the descriptor. The `GenericEnum` contains `GenericEnumEntry` objects that map a display value to a value, which is either of type `int` or `string`.
 
 It is possible to add additional discrete options after the descriptor was created, but it is not possible to remove or update options that are already in use. If a situation like this would occur, see [Removing an enum entry from a GenericEnumFieldDescriptor](xref:DOM_Remove_Enum_Entry).
 
@@ -24,7 +24,7 @@ It is possible to add additional discrete options after the descriptor was creat
 
 To enable multiple values, set the `FieldType` to `List<GenericEnum<int>>`.
 
-*Int enum:*
+### Int enum
 
 ```csharp
 var genericEnum = new GenericEnum<int>();
@@ -41,7 +41,7 @@ var descriptor = new GenericEnumFieldDescriptor
 };
 ```
 
-*String enum:*
+### String enum
 
 ```csharp
 var genericEnum = new GenericEnum<string>();
@@ -63,7 +63,7 @@ var descriptor = new GenericEnumFieldDescriptor
 
 ## Adding a value for the FieldDescriptor
 
-*Int enum:*
+### Int enum
 
 ```csharp
 var instance = new DomInstance
@@ -81,7 +81,7 @@ var secondEnumValue = 2;
 instance.AddOrUpdateListFieldValue(sectionDefinitionId, fieldDescriptorId, new List<int> { firstEnumValue, secondEnumValue });
 ```
 
-*String enum:*
+### String enum
 
 ```csharp
 var instance = new DomInstance

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_GenericEnumFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_GenericEnumFieldDescriptor.md
@@ -1,0 +1,100 @@
+---
+uid: DOM_GenericEnumFieldDescriptor
+---
+
+# GenericEnumFieldDescriptor
+
+- **FieldValue type**: int / string
+- **FieldValue example**: 5 / "very_high"
+- **Multiple values supported**: :heavy_check_mark: (Since 10.4.0/10.4.1)<!-- RN 37482 -->
+- **Available since**: DataMiner 10.1.2/10.2.0
+
+| Type of Descriptor | FieldType | FieldValue type |
+|--------------------|-----------|-----------------|
+| References a single int enum entry | GenericEnum\<int\> | int |
+| References one or more int enum entries | List<GenericEnum\<int\>> | int (ListValueWrapper) |
+| References a single string enum entry | GenericEnum\<string\> | string |
+| References one or more string enum entries | List<GenericEnum\<string\>> | string (ListValueWrapper) |
+
+Defines a DOM field that stores one or more options from a list of pre-determined discrete values. These possible values are defined by the `GenericEnum` object that is defined on the descriptor. The `GenericEnum` contains `GenericEnumEntry` objects that map a display value to a value, which is either of type int or string.
+
+It is possible to add additional discrete options after the descriptor was created, but it is not possible to remove or update options that are already in use. If a situation like this would occur, see [Removing an enum entry from a GenericEnumFieldDescriptor](xref:DOM_Remove_Enum_Entry).
+
+## Defining the FieldDescriptor
+
+To enable multiple values, set the `FieldType` to `List<GenericEnum<int>>`.
+
+*Int enum:*
+
+```csharp
+var genericEnum = new GenericEnum<int>();
+genericEnum.AddEntry("High", 1);
+genericEnum.AddEntry("Medium", 2);
+genericEnum.AddEntry("Low", 3, true); // true = entry is set to hidden
+
+var descriptor = new GenericEnumFieldDescriptor
+{
+    ID = new FieldDescriptorID(Guid.NewGuid()),
+    Name = "My int enum field",
+    FieldType = typeof(GenericEnum<int>),
+    GenericEnumInstance = genericEnum
+};
+```
+
+*String enum:*
+
+```csharp
+var genericEnum = new GenericEnum<string>();
+genericEnum.AddEntry("High", "sv_h");
+genericEnum.AddEntry("Medium", "sv_m");
+genericEnum.AddEntry("Low", "sv_l", true); // true = entry is set to hidden
+
+var descriptor = new GenericEnumFieldDescriptor
+{
+    ID = new FieldDescriptorID(Guid.NewGuid()),
+    Name = "My string enum field",
+    FieldType = typeof(GenericEnum<string>),
+    GenericEnumInstance = genericEnum
+};
+```
+
+> [!NOTE]
+> Requires the `using Skyline.DataMiner.Net.GenericEnums;` using directive.
+
+## Adding a value for the FieldDescriptor
+
+*Int enum:*
+
+```csharp
+var instance = new DomInstance
+{
+    ID = new DomInstanceId(Guid.NewGuid()),
+    DomDefinitionId = domDefinitionId
+};
+
+// Single value
+instance.AddOrUpdateFieldValue(sectionDefinitionId, fieldDescriptorId, 2); // 2 is the value of the entry with displayValue "Medium"
+
+// Multiple values
+var firstEnumValue = 1;
+var secondEnumValue = 2;
+instance.AddOrUpdateListFieldValue(sectionDefinitionId, fieldDescriptorId, new List<int> { firstEnumValue, secondEnumValue });
+```
+
+*String enum:*
+
+```csharp
+var instance = new DomInstance
+{
+    ID = new DomInstanceId(Guid.NewGuid()),
+    DomDefinitionId = domDefinitionId
+};
+
+// Single value
+instance.AddOrUpdateFieldValue(sectionDefinitionId, fieldDescriptorId, "sv_h"); // "sv_m" is the value of entry with displayValue "High"
+
+// Multiple values
+var firstEnumValue = "sv_m";
+var secondEnumValue = "sv_l";
+instance.AddOrUpdateListFieldValue(sectionDefinitionId, fieldDescriptorId, new List<string> { firstEnumValue, secondEnumValue });
+```

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_GroupFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_GroupFieldDescriptor.md
@@ -13,7 +13,7 @@ uid: DOM_GroupFieldDescriptor
 |--------------------|-----------|-----------------|
 | References a single DataMiner group | string | string |
 
-Defines a DOM field that stores the name of a DataMiner user group in the form of a `string`. The validity and existence of the group is not checked server-side. However, when displayed in the DOM LCA form, a value will be marked invalid when the group does not exist in the DMS.
+Defines a DOM field that stores the name of a DataMiner user group in the form of a `string`. The validity and existence of the group is not checked server-side. However, when displayed in the DOM low-code app form, a value will be marked invalid when the group does not exist in the DMS.
 
 ## Defining the FieldDescriptor
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_GroupFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_GroupFieldDescriptor.md
@@ -13,7 +13,7 @@ uid: DOM_GroupFieldDescriptor
 |--------------------|-----------|-----------------|
 | References a single DataMiner group | string | string |
 
-Defines a DOM field that stores the name of a DataMiner user group in the form of a `string`. The validity and existence of the group is not checked server-side. However, when displayed in the DOM low-code app form, a value will be marked invalid when the group does not exist in the DMS.
+Defines a DOM field that stores the name of a DataMiner user group in the form of a `string`. The validity and existence of the group is not checked server-side. However, when a value is displayed in the DOM low-code app form, it will be marked invalid when the group does not exist in the DMS.
 
 ## Defining the FieldDescriptor
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_GroupFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_GroupFieldDescriptor.md
@@ -1,0 +1,39 @@
+---
+uid: DOM_GroupFieldDescriptor
+---
+
+# GroupFieldDescriptor
+
+- **FieldValue type**: string
+- **FieldValue example**: "NOC Administrators"
+- **Multiple values supported**: :heavy_multiplication_x:
+- **Available since**: DataMiner 10.3.3/10.4.0
+
+| Type of Descriptor | FieldType | FieldValue type |
+|--------------------|-----------|-----------------|
+| References a single DataMiner group | string | string |
+
+Defines a DOM field that stores the name of a DataMiner user group in the form of a `string`. The validity and existence of the group is not checked server-side. However, when displayed in the DOM LCA form, a value will be marked invalid when the group does not exist in the DMS.
+
+## Defining the FieldDescriptor
+
+```csharp
+var descriptor = new GroupFieldDescriptor
+{
+    ID = new FieldDescriptorID(Guid.NewGuid()),
+    Name = "My group reference field",
+    FieldType = typeof(string)
+};
+```
+
+## Adding a value for the FieldDescriptor
+
+```csharp
+var instance = new DomInstance
+{
+    ID = new DomInstanceId(Guid.NewGuid()),
+    DomDefinitionId = domDefinitionId
+};
+
+instance.AddOrUpdateFieldValue(sectionDefinitionId, fieldDescriptorId, "NOC Operators");
+```

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ReservationFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ReservationFieldDescriptor.md
@@ -6,7 +6,7 @@ uid: DOM_ReservationFieldDescriptor
 
 - **FieldValue type**: Guid
 - **FieldValue example**: 0d911285-0232-4610-8bd8-ebbebc9cdc29 (ID of an [SRM booking](xref:srm_instantiations#booking))
-- **Multiple values supported**: :heavy_check_mark: (Since 10.2.3/10.3.0)
+- **Multiple values supported**: :heavy_check_mark: (since DataMiner 10.2.3/10.3.0)
 - **Available since**: DataMiner 10.1.2/10.2.0
 
 | Type of Descriptor | FieldType | FieldValue type |
@@ -14,7 +14,7 @@ uid: DOM_ReservationFieldDescriptor
 | References a single SRM booking | Guid | Guid |
 | References one or more SRM bookings | List\<Guid\> | Guid (ListValueWrapper) |
 
-Defines a DOM field that references an SRM booking (`ReservationInstance`) by storing the ID of that booking in the form of a `Guid`. The validity and existence of the booking is not checked server-side. However, when displayed in the DOM low-code app form, a value will be marked invalid when the booking does not exist in the DMS.
+Defines a DOM field that references an SRM booking (`ReservationInstance`) by storing the ID of that booking in the form of a `Guid`. The validity and existence of the booking is not checked server-side. However, when a value is displayed in the DOM low-code app form, it will be marked invalid when the booking does not exist in the DMS.
 
 ## Defining the FieldDescriptor
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ReservationFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ReservationFieldDescriptor.md
@@ -1,0 +1,49 @@
+---
+uid: DOM_ReservationFieldDescriptor
+---
+
+# ReservationFieldDescriptor
+
+- **FieldValue type**: Guid
+- **FieldValue example**: 0d911285-0232-4610-8bd8-ebbebc9cdc29 (ID of an [SRM booking](xref:srm_instantiations#booking))
+- **Multiple values supported**: :heavy_check_mark: (Since 10.2.3/10.3.0)
+- **Available since**: DataMiner 10.1.2/10.2.0
+
+| Type of Descriptor | FieldType | FieldValue type |
+|--------------------|-----------|-----------------|
+| References a single SRM booking | Guid | Guid |
+| References one or more SRM bookings | List\<Guid\> | Guid (ListValueWrapper) |
+
+Defines a DOM field that references an SRM booking (`ReservationInstance`) by storing the ID of that booking in the form of a `Guid`. The validity and existence of the booking is not checked server-side. However, when displayed in the DOM LCA form, a value will be marked invalid when the booking does not exist in the DMS.
+
+## Defining the FieldDescriptor
+
+To enable multiple values, set the FieldType to `List<Guid>`.
+
+```csharp
+var descriptor = new ReservationFieldDescriptor
+{
+    ID = new FieldDescriptorID(Guid.NewGuid()),
+    Name = "My reservation reference field",
+    FieldType = typeof(Guid)
+};
+```
+
+## Adding a value for the FieldDescriptor
+
+```csharp
+var instance = new DomInstance
+{
+    ID = new DomInstanceId(Guid.NewGuid()),
+    DomDefinitionId = domDefinitionId
+};
+
+// Single value
+var reservationId = Guid.Parse("8000971e-982a-2151-10a2-1803aa100359");
+instance.AddOrUpdateFieldValue(sectionDefinitionId, fieldDescriptorId, reservationId);
+
+// Multiple values
+var firstReservationId = Guid.Parse("755a424e-783f-466d-981e-8359fd0ca426");
+var secondReservationId = Guid.Parse("16da2b5d-6b43-4267-96ba-4abd5c16ee2b");
+instance.AddOrUpdateListFieldValue(sectionDefinitionId, fieldDescriptorId, new List<Guid> { firstReservationId, secondReservationId });
+```

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ReservationFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ReservationFieldDescriptor.md
@@ -14,7 +14,7 @@ uid: DOM_ReservationFieldDescriptor
 | References a single SRM booking | Guid | Guid |
 | References one or more SRM bookings | List\<Guid\> | Guid (ListValueWrapper) |
 
-Defines a DOM field that references an SRM booking (`ReservationInstance`) by storing the ID of that booking in the form of a `Guid`. The validity and existence of the booking is not checked server-side. However, when displayed in the DOM LCA form, a value will be marked invalid when the booking does not exist in the DMS.
+Defines a DOM field that references an SRM booking (`ReservationInstance`) by storing the ID of that booking in the form of a `Guid`. The validity and existence of the booking is not checked server-side. However, when displayed in the DOM low-code app form, a value will be marked invalid when the booking does not exist in the DMS.
 
 ## Defining the FieldDescriptor
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ResourceFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ResourceFieldDescriptor.md
@@ -14,7 +14,7 @@ uid: DOM_ResourceFieldDescriptor
 | References a single SRM resource | Guid | Guid |
 | References one or more SRM resources | List\<Guid\> | Guid (ListValueWrapper) |
 
-Defines a DOM field that references an SRM resource by storing the ID of that resource in the form of a `Guid`. Using the `ResourcePoolIds` property, it is possible to define to which resource pools the resource should belong. If this list is left empty, the dropdown of a DOM LCA form will display and accept any resource in the DMS. The validity and existence of the resource is not checked server-side. However, when displayed in the DOM LCA form, a value will be marked invalid when the resource does not exist in the DMS or when it is not part of the defined pools.
+Defines a DOM field that references an SRM resource by storing the ID of that resource in the form of a `Guid`. Using the `ResourcePoolIds` property, it is possible to define to which resource pools the resource should belong. If this list is left empty, the dropdown of a DOM low-code app form will display and accept any resource in the DMS. The validity and existence of the resource is not checked server-side. However, when displayed in the DOM low-code app form, a value will be marked invalid when the resource does not exist in the DMS or when it is not part of the defined pools.
 
 ## Defining the FieldDescriptor
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ResourceFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ResourceFieldDescriptor.md
@@ -1,0 +1,53 @@
+---
+uid: DOM_ResourceFieldDescriptor
+---
+
+# ResourceFieldDescriptor
+
+- **FieldValue type**: Guid
+- **FieldValue example**: a0623201-c157-478c-a880-d40422c40f1c (ID of an [SRM resource](xref:The_Resources_module))
+- **Multiple values supported**: :heavy_check_mark: (Since 10.2.3/10.3.0)
+- **Available since**: DataMiner 10.1.2/10.2.0
+
+| Type of Descriptor | FieldType | FieldValue type |
+|--------------------|-----------|-----------------|
+| References a single SRM resource | Guid | Guid |
+| References one or more SRM resources | List\<Guid\> | Guid (ListValueWrapper) |
+
+Defines a DOM field that references an SRM resource by storing the ID of that resource in the form of a `Guid`. Using the `ResourcePoolIds` property, it is possible to define to which resource pools the resource should belong. If this list is left empty, the dropdown of a DOM LCA form will display and accept any resource in the DMS. The validity and existence of the resource is not checked server-side. However, when displayed in the DOM LCA form, a value will be marked invalid when the resource does not exist in the DMS or when it is not part of the defined pools.
+
+## Defining the FieldDescriptor
+
+To enable multiple values, set the `FieldType` to `List<Guid>`.
+
+```csharp
+var poolIdOne = Guid.Parse("755a424e-783f-466d-981e-8359fd0ca426");
+var poolIdTwo = Guid.Parse("16da2b5d-6b43-4267-96ba-4abd5c16ee2b");
+
+var descriptor = new ResourceFieldDescriptor
+{
+    ID = new FieldDescriptorID(Guid.NewGuid()),
+    Name = "My resource reference field",
+    FieldType = typeof(Guid),
+    ResourcePoolIds = { poolIdOne, poolIdTwo } // Optional
+};
+```
+
+## Adding a value for the FieldDescriptor
+
+```csharp
+var instance = new DomInstance
+{
+    ID = new DomInstanceId(Guid.NewGuid()),
+    DomDefinitionId = domDefinitionId
+};
+
+// Single value
+var resourceId = Guid.Parse("8000971e-982a-2151-10a2-1803aa100359");
+instance.AddOrUpdateFieldValue(sectionDefinitionId, fieldDescriptorId, resourceId);
+
+// Multiple values
+var firstResourceId = Guid.Parse("755a424e-783f-466d-981e-8359fd0ca426");
+var secondResourceId = Guid.Parse("16da2b5d-6b43-4267-96ba-4abd5c16ee2b");
+instance.AddOrUpdateListFieldValue(sectionDefinitionId, fieldDescriptorId, new List<Guid> { firstResourceId, secondResourceId });
+```

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ResourceFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ResourceFieldDescriptor.md
@@ -5,8 +5,8 @@ uid: DOM_ResourceFieldDescriptor
 # ResourceFieldDescriptor
 
 - **FieldValue type**: Guid
-- **FieldValue example**: a0623201-c157-478c-a880-d40422c40f1c (ID of an [SRM resource](xref:The_Resources_module))
-- **Multiple values supported**: :heavy_check_mark: (Since 10.2.3/10.3.0)
+- **FieldValue example**: a0623201-c157-478c-a880-d40422c40f1c (ID of an [SRM resource](xref:Concepts1))
+- **Multiple values supported**: :heavy_check_mark: (since DataMiner 10.2.3/10.3.0)
 - **Available since**: DataMiner 10.1.2/10.2.0
 
 | Type of Descriptor | FieldType | FieldValue type |
@@ -14,7 +14,7 @@ uid: DOM_ResourceFieldDescriptor
 | References a single SRM resource | Guid | Guid |
 | References one or more SRM resources | List\<Guid\> | Guid (ListValueWrapper) |
 
-Defines a DOM field that references an SRM resource by storing the ID of that resource in the form of a `Guid`. Using the `ResourcePoolIds` property, it is possible to define to which resource pools the resource should belong. If this list is left empty, the dropdown of a DOM low-code app form will display and accept any resource in the DMS. The validity and existence of the resource is not checked server-side. However, when displayed in the DOM low-code app form, a value will be marked invalid when the resource does not exist in the DMS or when it is not part of the defined pools.
+Defines a DOM field that references an SRM resource by storing the ID of that resource in the form of a `Guid`. Using the `ResourcePoolIds` property, it is possible to define to which resource pools the resource should belong. If this list is left empty, the dropdown of a DOM low-code app form will display and accept any resource in the DMS. The validity and existence of the resource is not checked server-side. However, when a value is displayed in the DOM low-code app form, it will be marked invalid when the resource does not exist in the DMS or when it is not part of the defined pools.
 
 ## Defining the FieldDescriptor
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ServiceDefinitionFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ServiceDefinitionFieldDescriptor.md
@@ -6,7 +6,7 @@ uid: DOM_ServiceDefinitionFieldDescriptor
 
 - **FieldValue type**: Guid
 - **FieldValue example**: 1bf36345-89df-4ba2-906c-e82bb9ba01cd (ID of an [SRM service definition](xref:srm_definitions#service-definition))
-- **Multiple values supported**: :heavy_check_mark: (Since 10.2.3/10.3.0)
+- **Multiple values supported**: :heavy_check_mark: (since DataMiner 10.2.3/10.3.0)
 - **Available since**: DataMiner 10.1.2/10.2.0
 
 | Type of Descriptor | FieldType | FieldValue type |
@@ -14,7 +14,7 @@ uid: DOM_ServiceDefinitionFieldDescriptor
 | References a single SRM service definition | Guid | Guid |
 | References one or more SRM service definitions | List\<Guid\> | Guid (ListValueWrapper) |
 
-Defines a DOM field that references an SRM service definition by storing the ID of that definition in the form of a `Guid`. Using the `ServiceDefinitionFilter` property, it is possible to define which definitions are allowed. If this filter is left empty, the dropdown of a DOM low-code app form will display and accept any definition in the DMS. The validity and existence of the service definition is not checked server-side. However, when displayed in the DOM low-code app form, a value will be marked invalid when the definition does not exist in the DMS or is not part of the filtered set of definitions.
+Defines a DOM field that references an SRM service definition by storing the ID of that definition in the form of a `Guid`. Using the `ServiceDefinitionFilter` property, it is possible to define which definitions are allowed. If this filter is left empty, the dropdown of a DOM low-code app form will display and accept any definition in the DMS. The validity and existence of the service definition is not checked server-side. However, when a value is displayed in the DOM low-code app form, it will be marked invalid when the definition does not exist in the DMS or is not part of the filtered set of definitions.
 
 ## Defining the FieldDescriptor
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ServiceDefinitionFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ServiceDefinitionFieldDescriptor.md
@@ -14,7 +14,7 @@ uid: DOM_ServiceDefinitionFieldDescriptor
 | References a single SRM service definition | Guid | Guid |
 | References one or more SRM service definitions | List\<Guid\> | Guid (ListValueWrapper) |
 
-Defines a DOM field that references an SRM service definition by storing the ID of that definition in the form of a `Guid`. Using the `ServiceDefinitionFilter` property, it is possible to define which definitions are allowed. If this filter is left empty, the dropdown of a DOM LCA form will display and accept any definition in the DMS. The validity and existence of the service definition is not checked server-side. However, when displayed in the DOM LCA form, a value will be marked invalid when the definition does not exist in the DMS or is not part of the filtered set of definitions.
+Defines a DOM field that references an SRM service definition by storing the ID of that definition in the form of a `Guid`. Using the `ServiceDefinitionFilter` property, it is possible to define which definitions are allowed. If this filter is left empty, the dropdown of a DOM low-code app form will display and accept any definition in the DMS. The validity and existence of the service definition is not checked server-side. However, when displayed in the DOM low-code app form, a value will be marked invalid when the definition does not exist in the DMS or is not part of the filtered set of definitions.
 
 ## Defining the FieldDescriptor
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ServiceDefinitionFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_ServiceDefinitionFieldDescriptor.md
@@ -1,0 +1,53 @@
+---
+uid: DOM_ServiceDefinitionFieldDescriptor
+---
+
+# ServiceDefinitionFieldDescriptor
+
+- **FieldValue type**: Guid
+- **FieldValue example**: 1bf36345-89df-4ba2-906c-e82bb9ba01cd (ID of an [SRM service definition](xref:srm_definitions#service-definition))
+- **Multiple values supported**: :heavy_check_mark: (Since 10.2.3/10.3.0)
+- **Available since**: DataMiner 10.1.2/10.2.0
+
+| Type of Descriptor | FieldType | FieldValue type |
+|--------------------|-----------|-----------------|
+| References a single SRM service definition | Guid | Guid |
+| References one or more SRM service definitions | List\<Guid\> | Guid (ListValueWrapper) |
+
+Defines a DOM field that references an SRM service definition by storing the ID of that definition in the form of a `Guid`. Using the `ServiceDefinitionFilter` property, it is possible to define which definitions are allowed. If this filter is left empty, the dropdown of a DOM LCA form will display and accept any definition in the DMS. The validity and existence of the service definition is not checked server-side. However, when displayed in the DOM LCA form, a value will be marked invalid when the definition does not exist in the DMS or is not part of the filtered set of definitions.
+
+## Defining the FieldDescriptor
+
+To enable multiple values, set the `FieldType` to `List<Guid>`.
+
+```csharp
+var descriptor = new ServiceDefinitionFieldDescriptor
+{
+    ID = new FieldDescriptorID(Guid.NewGuid()),
+    Name = "My service definition reference field",
+    FieldType = typeof(Guid),
+    ServiceDefinitionFilter = ServiceDefinitionExposers.Name.Contains("example") // Optional
+};
+```
+
+> [!NOTE]
+> Requires the `using Skyline.DataMiner.Net.Messages.SLDataGateway;` using directive.
+
+## Adding a value for the FieldDescriptor
+
+```csharp
+var instance = new DomInstance
+{
+    ID = new DomInstanceId(Guid.NewGuid()),
+    DomDefinitionId = domDefinitionId
+};
+
+// Single value
+var serviceDefinitionId = Guid.Parse("8000971e-982a-2151-10a2-1803aa100359");
+instance.AddOrUpdateFieldValue(sectionDefinitionId, fieldDescriptorId, serviceDefinitionId);
+
+// Multiple values
+var firstDefinitionId = Guid.Parse("755a424e-783f-466d-981e-8359fd0ca426");
+var secondDefinitionId = Guid.Parse("16da2b5d-6b43-4267-96ba-4abd5c16ee2b");
+instance.AddOrUpdateListFieldValue(sectionDefinitionId, fieldDescriptorId, new List<Guid> { firstDefinitionId, secondDefinitionId });
+```

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_StaticTextFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_StaticTextFieldDescriptor.md
@@ -1,0 +1,28 @@
+---
+uid: DOM_StaticTextFieldDescriptor
+---
+
+# StaticTextFieldDescriptor
+
+- **FieldValue type**: string
+- **FieldValue example**: N/A
+- **Multiple values supported**: :heavy_multiplication_x:
+- **Available since**: DataMiner 10.1.2/10.2.0
+
+Defines a DOM field that should always have a static value, defined by the `StaticText` property. This field is read-only and cannot be edited using the form component. Changing the text can only be done by changing the value of the `StaticText` property on the descriptor. No value will be stored on the `DomInstance`.
+
+## Defining the FieldDescriptor
+
+```csharp
+var descriptor = new StaticTextFieldDescriptor
+{
+    ID = new FieldDescriptorID(Guid.NewGuid()),
+    Name = "My static text field",
+    FieldType = typeof(string),
+    StaticText = "Some Static Text"
+};
+```
+
+## Adding a value for the FieldDescriptor
+
+No value needs to be provided. None is stored for this descriptor type.

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_UserFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_UserFieldDescriptor.md
@@ -13,7 +13,7 @@ uid: DOM_UserFieldDescriptor
 |--------------------|-----------|-----------------|
 | References a single DataMiner user | string | string |
 
-Defines a DOM field that stores the name of a DataMiner user in the form of a `string`. The 'Name' field of a DataMiner is saved, while the 'Full Name' field is used as the display value in an LCA form. The `GroupNames` property can be used to define which groups the user should be part of. The validity and existence of the user is not checked server-side. However, when displayed in the DOM LCA form, a value will be marked invalid when the user does not exist in the DMS or is not part of the defined groups.
+Defines a DOM field that stores the name of a DataMiner user in the form of a `string`. The 'Name' field of a DataMiner user is saved, while the 'Full Name' field is used as the display value in an LCA form. The `GroupNames` property can be used to define which groups the user should be part of. The validity and existence of the user is not checked server-side. However, when displayed in the DOM LCA form, a value will be marked invalid when the user does not exist in the DMS or is not part of the defined groups.
 
 ## Defining the FieldDescriptor
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_UserFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_UserFieldDescriptor.md
@@ -1,0 +1,41 @@
+---
+uid: DOM_UserFieldDescriptor
+---
+
+# UserFieldDescriptor
+
+- **FieldValue type**: string
+- **FieldValue example**: "COMPANY\JohnDO" ('Name' of a DataMiner user)
+- **Multiple values supported**: :heavy_multiplication_x:
+- **Available since**: DataMiner 10.3.3/10.4.0
+
+| Type of Descriptor | FieldType | FieldValue type |
+|--------------------|-----------|-----------------|
+| References a single DataMiner user | string | string |
+
+Defines a DOM field that stores the name of a DataMiner user in the form of a `string`. The 'Name' field of a DataMiner is saved, while the 'Full Name' field is used as the display value in an LCA form. The `GroupNames` property can be used to define which groups the user should be part of. The validity and existence of the user is not checked server-side. However, when displayed in the DOM LCA form, a value will be marked invalid when the user does not exist in the DMS or is not part of the defined groups.
+
+## Defining the FieldDescriptor
+
+```csharp
+var descriptor = new UserFieldDescriptor
+{
+    ID = new FieldDescriptorID(Guid.NewGuid()),
+    Name = "My user reference field",
+    FieldType = typeof(string),
+    GroupNames = { "NOC Operators" } // Optional
+};
+```
+
+## Adding a value for the FieldDescriptor
+
+```csharp
+var instance = new DomInstance
+{
+    ID = new DomInstanceId(Guid.NewGuid()),
+    DomDefinitionId = domDefinitionId
+};
+
+var userName = @"COMPANY\JohnDO";
+instance.AddOrUpdateFieldValue(sectionDefinitionId, fieldDescriptorId, userName);
+```

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_UserFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_UserFieldDescriptor.md
@@ -13,7 +13,7 @@ uid: DOM_UserFieldDescriptor
 |--------------------|-----------|-----------------|
 | References a single DataMiner user | string | string |
 
-Defines a DOM field that stores the name of a DataMiner user in the form of a `string`. The 'Name' field of a DataMiner user is saved, while the 'Full Name' field is used as the display value in an LCA form. The `GroupNames` property can be used to define which groups the user should be part of. The validity and existence of the user is not checked server-side. However, when displayed in the DOM LCA form, a value will be marked invalid when the user does not exist in the DMS or is not part of the defined groups.
+Defines a DOM field that stores the name of a DataMiner user in the form of a `string`. The *Name* field of a DataMiner user is saved, while the *Full Name* field is used as the display value in a low-code app form. The `GroupNames` property can be used to define which groups the user should be part of. The validity and existence of the user is not checked server-side. However, when displayed in the DOM low-code app form, a value will be marked invalid when the user does not exist in the DMS or is not part of the defined groups.
 
 ## Defining the FieldDescriptor
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_UserFieldDescriptor.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_FieldDescriptors/DOM_UserFieldDescriptor.md
@@ -13,7 +13,7 @@ uid: DOM_UserFieldDescriptor
 |--------------------|-----------|-----------------|
 | References a single DataMiner user | string | string |
 
-Defines a DOM field that stores the name of a DataMiner user in the form of a `string`. The *Name* field of a DataMiner user is saved, while the *Full Name* field is used as the display value in a low-code app form. The `GroupNames` property can be used to define which groups the user should be part of. The validity and existence of the user is not checked server-side. However, when displayed in the DOM low-code app form, a value will be marked invalid when the user does not exist in the DMS or is not part of the defined groups.
+Defines a DOM field that stores the name of a DataMiner user in the form of a `string`. The *Name* field of a DataMiner user is saved, while the *Full Name* field is used as the display value in a low-code app form. The `GroupNames` property can be used to define which groups the user should be part of. The validity and existence of the user is not checked server-side. However, when a value is displayed in the DOM low-code app form, it will be marked invalid when the user does not exist in the DMS or is not part of the defined groups.
 
 ## Defining the FieldDescriptor
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
@@ -52,39 +52,27 @@ Below is an overview of all other important properties:
 
 There are also special types of `FieldDescriptors` that are purpose-made to store a special value. These include:
 
-- **AutoIncrementFieldDescriptor**: Defines a field that will automatically get an incremented value assigned. When a `DomInstance` does not have a value for this field yet, it will get assigned the next time the instance is updated.
+- [**AutoIncrementFieldDescriptor**](xref:DOM_AutoIncrementFieldDescriptor): Defines a field that will automatically get an incremented value assigned. When a `DomInstance` does not have a value for this field yet, it will get assigned the next time the instance is updated.
 
-  - The `IDFormat` property is used to define a string format for the number value. In this string, "{0}" gets replaced by that number value. If the `IDFormat` property is empty, its value will not be formatted.
+- [**GenericEnumFieldDescriptor**](xref:DOM_GenericEnumFieldDescriptor): Defines a field that has a list of possible pre-determined values.
 
-    Some examples, assuming the next value is 10:
+- [**ReservationFieldDescriptor**](xref:DOM_ReservationFieldDescriptor): Defines a field that has the ID of an SRM `(Service)ReservationInstance`.
 
-    | Description | Format | Result |
-    |---|---|---|
-    | Add a prefix and postfix | Pre-{0}-Post | Pre-10-Post |
-    | Prefix with "REF-" and [format](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-numeric-format-strings) the value | REF-{0:000000} | REF-000010 |
-    | When no format is set, the value is stored | | 10 |
+- [**ResourceFieldDescriptor**](xref:DOM_ResourceFieldDescriptor): Defines a field that has the ID of an SRM resource. The descriptor has a *ResourcePoolIds* property that can be used to define from which resource pools the user can select a resource.
 
-  - When the field is marked as soft-deleted, no values will get assigned when a `DomInstance` gets saved.
+- [**ServiceDefinitionFieldDescriptor**](xref:DOM_ServiceDefinitionFieldDescriptor): Defines a field that has the ID of an SRM service definition. It contains a *ServiceDefinitionFilter* property that has a *FilterElement* that can be used to determine which service definitions will be presented to the user.
 
-- **GenericEnumFieldDescriptor**: Defines a field that has a list of possible pre-determined values.
+- [**StaticTextFieldDescriptor**](xref:DOM_StaticTextFieldDescriptor): Defines a field that should always have the same static value, defined by the *StaticText* property.
 
-- **ReservationFieldDescriptor**: Defines a field that has the ID of an SRM `(Service)ReservationInstance`.
+- [**DomInstanceFieldDescriptor**](xref:DOM_DomInstanceFieldDescriptor): Available from DataMiner 10.1.10/10.2.0 onwards. Can be used to define that a field should contain the ID of a `DomInstance`.
 
-- **ResourceFieldDescriptor**: Defines a field that has the ID of an SRM resource. The descriptor has a *ResourcePoolIds* property that can be used to define from which resource pools the user can select a resource.
+- [**ElementFieldDescriptor**](xref:DOM_ElementFieldDescriptor): Available from DataMiner 10.1.10/10.2.0 onwards. Can be used to define that a field should contain the ID of an element.
 
-- **ServiceDefinitionFieldDescriptor**: Defines a field that has the ID of an SRM service definition. It contains a *ServiceDefinitionFilter* property that has a *FilterElement* that can be used to determine which service definitions will be presented to the user.
+- [**DomInstanceValueFieldDescriptor**](xref:DOM_DomInstanceValueFieldDescriptor): Available from DataMiner 10.2.3/10.3.0 onwards. Can be used to define that a field should contain the ID of a `DomInstance`. However, compared to the `DomInstanceFieldDescriptor`, this one also references a specific value of that `DomInstance`.
 
-- **StaticTextFieldDescriptor**: Defines a field that should always have the same static value, defined by the *StaticText* property.
+- [**GroupFieldDescriptor**](xref:DOM_GroupFieldDescriptor): Available from DataMiner 10.3.3/10.4.0 onwards. Can be used to define that a field should contain the name of a DataMiner user group.
 
-- **DomInstanceFieldDescriptor**: Available from DataMiner 10.1.10/10.2.0 onwards. Can be used to define that a field should contain the ID of a `DomInstance`. This `DomInstance` can exist in a different DOM manager. This is why the descriptor has a *ModuleId* property that defines where the instances can be found. There is also a *DomDefinitionIds* list property that can be used to define whether DOM instances should be linked to the defined definitions. Both properties are intended for UIs, and their validity and existence is not checked server-side. The `FieldValues` are of type "Guid".
-
-- **ElementFieldDescriptor**: Available from DataMiner 10.1.10/10.2.0 onwards. Can be used to define that a field should contain the ID of an element. The ID must be saved as a string according to the common `[DMA ID]/[ELEMENT ID]` format (e.g. "868/65874"). There is a *ViewIds* list property that can be used to define whether the elements should be in any of these views. The `FieldValues` are of type "string".
-
-- **DomInstanceValueFieldDescriptor**: Available from DataMiner 10.2.3/10.3.0 onwards. Can be used to define that a field should contain the ID of a `DomInstance`. However, compared to the `DomInstanceFieldDescriptor`, this one also references a specific value of that `DomInstance`. The configuration is the same as the other descriptor, but it adds the *FieldDescriptorId* property that references a specific `FieldValue`.
-
-- **GroupFieldDescriptor**: Available from DataMiner 10.3.3/10.4.0 onwards. Can be used to define that a field should contain the name of a DataMiner user group.
-
-- **UserFieldDescriptor**: Available from DataMiner 10.3.3/10.4.0 onwards. Can be used to define that a field should contain the name of a DataMiner user. There is a *GroupNames* property that can be used to define which groups the user can be a part of.
+- [**UserFieldDescriptor**](xref:DOM_UserFieldDescriptor): Available from DataMiner 10.3.3/10.4.0 onwards. Can be used to define that a field should contain the name of a DataMiner user. There is a *GroupNames* property that can be used to define which groups the user can be a part of.
 
 > [!IMPORTANT]
 > The ID of a `FieldDescriptor` should be unique within a DOM module.
@@ -95,41 +83,20 @@ There are also special types of `FieldDescriptors` that are purpose-made to stor
 
 ### Multiple values
 
-Depending on the DataMiner version, the following `FieldDescriptors` can have **multiple values**:
+Some `FieldDescriptors` offer the capability to store multiple values rather than a single one. Refer to the respective descriptor documentation to check if a specific descriptor provides this functionality and from which DataMiner version onwards it is supported.
 
-- DomInstanceFieldDescriptor (from DataMiner 10.2.3/10.3.0 onwards)
-- DomInstanceValueFieldDescriptor (from DataMiner 10.2.5/10.3.0 onwards)<!-- RN 32904 -->
-- ElementFieldDescriptor (from DataMiner 10.2.3/10.3.0 onwards)
-- GenericEnumFieldDescriptor (from DataMiner 10.4.0/10.4.1 onwards)<!-- RN 37482 -->
-- ResourceFieldDescriptor (from DataMiner 10.2.3/10.3.0 onwards)
-- ReservationFieldDescriptor (from DataMiner 10.2.3/10.3.0 onwards)
-- ServiceDefinitionFieldDescriptor (from DataMiner 10.2.3/10.3.0 onwards)
-
-These `FieldDescriptors` therefore also support a list of the type that was already supported before.
-
-Adding multiple values to a `DomInstance` or updating the `DomInstance` with multiple values can be done as follows.
-
-- FieldDescriptor type configuration:
+When configuring a `FieldDescriptor` to accommodate multiple values, adjust the type property to match the list variant of the underlying base type. For instance, change `Guid` to `List<Guid>`. When assigning values to a `DomInstance`, utilize the `AddOrUpdateListFieldValue` extension method to easily add a list of values to the instance.
 
 ```csharp
-// Change the supported type of the fieldDescriptor to list
-fieldDescriptor.FieldType = typeof(List<Guid>);
+var fieldDescriptor = new ResourceFieldDescriptor
+{
+    FieldType = typeof(List<Guid>)
+};
 ```
 
-- Assigning a FieldValue with a list to a DomInstance:
-
 ```csharp
-// Adding a fieldValue to the domInstance
-var fieldValue = new FieldValue()
-{
-    FieldDescriptorID = fieldDescriptor.Id,
-    Value = new ListValueWrapper<Guid>(new List<Guid> { Guid.NewGuid(), Guid.NewGuid() })
-};
-domInstance.Sections.First().AddOrReplaceFieldValue(fieldValue);
- 
-// Update the FielValue of the domInstance
-var values = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
-domInstance.AddOrUpdateListFieldValue(sectionDefinition, fieldDescriptor, values);
+var multipleValues = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+domInstance.AddOrUpdateListFieldValue(sectionDefinitionId, fieldDescriptorId, multipleValues);
 ```
 
 > [!NOTE]

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
@@ -106,7 +106,7 @@ domInstance.AddOrUpdateListFieldValue(sectionDefinitionId, fieldDescriptorId, mu
 
 ## CustomSectionDefinition properties
 
-In the table below, you can the properties of the `CustomSectionDefinition` object (the base `SectionDefinition` object only exposes its ID). The table also indicates whether a property can be used for filtering using the `SectionDefinitionExposers`.
+In the table below, you can find the properties of the `CustomSectionDefinition` object (the base `SectionDefinition` object only exposes its ID). The table also indicates whether a property can be used for filtering using the `SectionDefinitionExposers`.
 
 > [!NOTE]
 > From DataMiner 10.3.2/10.4.0 onwards, the `CustomSectionDefinition` object also has [the *ITrackBase* properties](xref:DOM_objects#itrackbase-properties).

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
@@ -4,13 +4,13 @@ uid: DOM_SectionDefinition
 
 # SectionDefinition object
 
-A `SectionDefinition` object uses `FieldDescriptor` objects to define the fields a `DomInstance` should have. The Jobs module also uses this same `SectionDefinition` object.
+A `SectionDefinition` object uses `FieldDescriptor` objects to define the fields a `DomInstance` should have. The *Jobs* module also uses this same `SectionDefinition` object.
 
 The main class is an abstract implementation, as it allows the existence of two types:
 
-- **StaticSectionDefinition**: Currently not used by DOM managers, but used by the Jobs module.
+- **StaticSectionDefinition**: Currently not used by DOM managers, but used by the *Jobs* module.
 
-- **CustomSectionDefinition**: Used with DOM managers. When `SectionDefinitions` are discussed further on this page, it is always this custom type that is meant.
+- **CustomSectionDefinition**: Used with DOM managers. When `SectionDefinitions` are discussed below, it is always this custom type that is meant.
 
 When you work with `SectionDefinitions` in a script, you need to typecast them to the custom type, since you will otherwise not be able to set some properties.
 
@@ -48,7 +48,7 @@ Below is an overview of all other important properties:
 | IsReadonly | bool | Determines whether this descriptor can only be manipulated from scripts/API and not from the UI. |
 | Tooltip | string | Short description of the field that will be available as a tooltip in the UI. |
 | DefaultValue | IValueWrapper | The default value that will be used to pre-fill the field in the UI. |
-| IsSoftDeleted | bool | Determines whether this descriptor is soft-deleted. See [soft-deletable objects](xref:DOM_objects#soft-deletable-objects). Available from DataMiner 10.3.9/10.4.0 onwards. |
+| IsSoftDeleted | bool | Determines whether this descriptor is soft-deleted. See [soft-deletable objects](xref:DOM_objects#soft-deletable-objects).<br>Available from DataMiner 10.3.9/10.4.0 onwards. |
 
 There are also special types of `FieldDescriptors` that are purpose-made to store a special value. These include:
 
@@ -106,7 +106,7 @@ domInstance.AddOrUpdateListFieldValue(sectionDefinitionId, fieldDescriptorId, mu
 
 ## CustomSectionDefinition properties
 
-The table below lists the properties of the `CustomSectionDefinition` object. (The base `SectionDefinition` object only exposes its ID.) The table also indicates whether a property can be used for filtering using the `SectionDefinitionExposers`.
+In the table below, you can the properties of the `CustomSectionDefinition` object (the base `SectionDefinition` object only exposes its ID). The table also indicates whether a property can be used for filtering using the `SectionDefinitionExposers`.
 
 > [!NOTE]
 > From DataMiner 10.3.2/10.4.0 onwards, the `CustomSectionDefinition` object also has [the *ITrackBase* properties](xref:DOM_objects#itrackbase-properties).
@@ -148,11 +148,11 @@ The table below lists the properties of the `CustomSectionDefinition` object. (T
 
 ## Errors
 
-When something goes wrong during the CRUD actions, the `TraceData` can contain one or more `SectionDefinitionErrors`. Below is a list of all possible `ErrorReasons`. (This list does not contain the errors that are only used by the Jobs module.)
+When something goes wrong during the CRUD actions, the `TraceData` can contain one or more `SectionDefinitionErrors`. Below, you can find a list of all possible `ErrorReasons` (this list does not contain the errors that are only used by the Jobs module).
 
 | Reason | Description |
 |--|--|
-| FieldTypeNotSupported | A type was defined on a `FieldDescriptor` that is not supported by that descriptor. Available properties: *NotSupportedType*, *SupportedTypes*. |
-| SectionDefinitionInUseByDomInstances | The `SectionDefinition` could not be updated because it is being used by at least one `DomInstance`. Available properties: *SectionDefinition*, *OriginalSectionDefinition*, *DomInstanceIds*. |
-| SectionDefinitionInUseByDomDefinitions | The `SectionDefinition` could not be deleted because it is being used by at least one `DomDefinition`. Set the *FieldDecriptor.IsSoftDeleted* boolean for the `FieldDescriptor` you want to delete instead. Available properties: *SectionDefinition*, *DomDefinitionIds*. |
-| GenericEnumEntryInUseByDomInstances | The `GenericEnumEntry` could not be deleted or updated because it is being used by at least one `DomInstance`. Available properties: *GenericEnumEntry*, *DomInstanceIds*. |
+| FieldTypeNotSupported | A type was defined on a `FieldDescriptor` that is not supported by that descriptor.<br>Available properties: *NotSupportedType*, *SupportedTypes*. |
+| SectionDefinitionInUseByDomInstances | The `SectionDefinition` could not be updated because it is being used by at least one `DomInstance`.<br>Available properties: *SectionDefinition*, *OriginalSectionDefinition*, *DomInstanceIds*. |
+| SectionDefinitionInUseByDomDefinitions | The `SectionDefinition` could not be deleted because it is being used by at least one `DomDefinition`. Set the *FieldDecriptor.IsSoftDeleted* boolean for the `FieldDescriptor` you want to delete instead.<br>Available properties: *SectionDefinition*, *DomDefinitionIds*. |
+| GenericEnumEntryInUseByDomInstances | The `GenericEnumEntry` could not be deleted or updated because it is being used by at least one `DomInstance`.<br>Available properties: *GenericEnumEntry*, *DomInstanceIds*. |

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
@@ -4,11 +4,11 @@ uid: DOM_SectionDefinition
 
 # SectionDefinition object
 
-A `SectionDefinition` object uses `FieldDescriptor` objects to define the fields a `DomInstance` should have. The *Jobs* module also uses this same `SectionDefinition` object.
+A `SectionDefinition` object uses `FieldDescriptor` objects to define the fields a `DomInstance` should have. The Jobs module also uses this same `SectionDefinition` object.
 
 The main class is an abstract implementation, as it allows the existence of two types:
 
-- **StaticSectionDefinition**: Currently not used by DOM managers, but used by the *Jobs* module.
+- **StaticSectionDefinition**: Currently not used by DOM managers, but used by the Jobs module.
 
 - **CustomSectionDefinition**: Used with DOM managers. When `SectionDefinitions` are discussed below, it is always this custom type that is meant.
 

--- a/user-guide/Advanced_Modules/toc.yml
+++ b/user-guide/Advanced_Modules/toc.yml
@@ -765,6 +765,29 @@ items:
         items:
           - name: SectionDefinition object
             topicUid: DOM_SectionDefinition
+            items:
+              - name: AutoIncrementFieldDescriptor
+                topicUid: DOM_AutoIncrementFieldDescriptor
+              - name: DomInstanceFieldDescriptor
+                topicUid: DOM_DomInstanceFieldDescriptor
+              - name: DomInstanceValueFieldDescriptor
+                topicUid: DOM_DomInstanceValueFieldDescriptor
+              - name: ElementFieldDescriptor
+                topicUid: DOM_ElementFieldDescriptor
+              - name: GenericEnumFieldDescriptor
+                topicUid: DOM_GenericEnumFieldDescriptor
+              - name: GroupFieldDescriptor
+                topicUid: DOM_GroupFieldDescriptor
+              - name: ReservationFieldDescriptor
+                topicUid: DOM_ReservationFieldDescriptor
+              - name: ResourceFieldDescriptor
+                topicUid: DOM_ResourceFieldDescriptor              
+              - name: ServiceDefinitionFieldDescriptor
+                topicUid: DOM_ServiceDefinitionFieldDescriptor
+              - name: StaticTextFieldDescriptor
+                topicUid: DOM_StaticTextFieldDescriptor
+              - name: UserFieldDescriptor
+                topicUid: DOM_UserFieldDescriptor
           - name: DomDefinition object
             topicUid: DomDefinition
           - name: DomInstance object


### PR DESCRIPTION
Extended the DOM docs with a page for each special FieldDescriptor alongside all relevant info. (DCP196354)
Original PR: https://github.com/SkylineCommunications/dataminer-docs/pull/2850 by @AaronVanVyve.