### PR TITLE
Update SNMPv3_Connection.md

### DIFF
--- a/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/SNMPv3_Connection.md
+++ b/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/SNMPv3_Connection.md
@@ -43,4 +43,4 @@ For SNMPv3 connections, you can specify the following connection settings while 
 > We recommend that you use SHA-512 and AES-256, since this is the most secure combination. As such, this is the combination that is selected by default.
 
 > [!NOTE]
-> If a URL instead of an IP is used in the polling IP address of an element's SNMP connection(s), the traps received from the URL will not be captured. This is because DNS resolution does not occur when traps are received, causing the element's trap receivers to not know which IP to listen to.
+> If a hostname instead of an IP is used in the polling IP address of an element's SNMP connection(s), the traps received from the hostname will not be captured. This is because DNS resolution does not occur when traps are received, causing the element's trap receivers to not know which IP to listen to.

--- a/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/SNMPv3_Connection.md
+++ b/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/SNMPv3_Connection.md
@@ -41,3 +41,6 @@ For SNMPv3 connections, you can specify the following connection settings while 
 > - MD5/SHA-1/SHA-224 and AES256
 >
 > We recommend that you use SHA-512 and AES-256, since this is the most secure combination. As such, this is the combination that is selected by default.
+
+> [!NOTE]
+> If a URL instead of an IP is used in the polling IP address of an element's SNMP connection(s), the traps received from the URL will not be captured. This is because DNS resolution does not occur when traps are received, causing the element's trap receivers to not know which IP to listen to.

--- a/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/SNMPv3_Connection.md
+++ b/user-guide/Basic_Functionality/Elements/Working_with_elements/Adding_Elements/SNMPv3_Connection.md
@@ -10,6 +10,9 @@ For SNMPv3 connections, you can specify the following connection settings while 
 
 - **IP address/host**: The polling IP or URL of the destination.
 
+  > [!IMPORTANT]
+  > Do not fill in a hostname instead of an IP address if this connection will be used to receive SNMP traps. Using a hostname is not supported for SNMP trap reception.
+
 - **Network**: The network interface (NIC). If only one network interface is available on the DMA, it is automatically selected.
 
 - **Port number**: By default 161.
@@ -41,6 +44,3 @@ For SNMPv3 connections, you can specify the following connection settings while 
 > - MD5/SHA-1/SHA-224 and AES256
 >
 > We recommend that you use SHA-512 and AES-256, since this is the most secure combination. As such, this is the combination that is selected by default.
-
-> [!NOTE]
-> If a hostname instead of an IP is used in the polling IP address of an element's SNMP connection(s), the traps received from the hostname will not be captured. This is because DNS resolution does not occur when traps are received, causing the element's trap receivers to not know which IP to listen to.


### PR DESCRIPTION
Hi,
I was working on a task recently and found out about this issue with SNMP traps not working if hostnames instead of IP were used in an element's polling IP. I thought it would be helpful to include this in the documentation. If there are any questions, feel free to reach out.

Below is the link to the related task:
https://collaboration.dataminer.services/task/238036