### PR TITLE
Create KI_Hostnames_not_supported_with_SNMP_traps.md

### DIFF
--- a/user-guide/Troubleshooting/Known_issues/KI_Hostnames_not_supported_with_SNMP_traps.md
+++ b/user-guide/Troubleshooting/Known_issues/KI_Hostnames_not_supported_with_SNMP_traps.md
@@ -1,0 +1,21 @@
+---
+uid: KI_Hostnames_not_supported_with_SNMP_traps
+---
+
+# SNMP traps not working if hostname instead of an IP is used in the polling IP address of an element's SNMP connection(s)
+
+## Affected versions
+
+Any versions of DataMiner
+
+## Cause
+
+If a hostname instead of an IP is used in the polling IP address of an element's SNMP connection(s), the traps received from the hostname will not be captured. This is because DNS resolution does not occur when traps are received, causing the element's trap receivers to not know which IP to listen to.
+
+## Workaround
+
+Use IP instead of hostname in polling IP address of an element's SNMP connection(s)
+
+## Fix
+
+None at the moment


### PR DESCRIPTION
Hi,
I was working on a task recently and found out about this issue with SNMP traps not working if hostnames instead of IP were used in an element's polling IP. I thought it would be helpful to include this in the documentation. If there are any questions, feel free to reach out.

Below is the link to the related task:
https://collaboration.dataminer.services/task/238036