### PR TITLE
Client requirements .NET Framework update

### DIFF
--- a/user-guide/Cloud_Platform/RemoteAccess/Accessing_DMS_remotely_with_Cube.md
+++ b/user-guide/Cloud_Platform/RemoteAccess/Accessing_DMS_remotely_with_Cube.md
@@ -14,7 +14,7 @@ From DataMiner 10.3.0/10.3.2 onwards, you can use DataMiner Cube to access your 
 - The [APIGateway DxM](xref:DataMinerExtensionModules#apigateway) is installed and running on the DMA you are connecting to.
 - [Remote access to Cube is enabled](xref:Controlling_remote_access) for the DMS.
 - You have been [granted access to dataminer.services features](xref:Giving_users_access_to_cloud_features).
-- You [have the DataMiner Cube desktop application installed](xref:Installing_configuring_the_DataMiner_Cube_software).
+- You [have the DataMiner Cube desktop application installed](xref:Installing_configuring_the_DataMiner_Cube_software) and all [client requirements](DataMiner_Client_Requirements) are met.
 - Your user account has been granted access to the DataMiner System.
 
 > [!IMPORTANT]

--- a/user-guide/Cloud_Platform/RemoteAccess/Accessing_DMS_remotely_with_Cube.md
+++ b/user-guide/Cloud_Platform/RemoteAccess/Accessing_DMS_remotely_with_Cube.md
@@ -14,7 +14,7 @@ From DataMiner 10.3.0/10.3.2 onwards, you can use DataMiner Cube to access your 
 - The [APIGateway DxM](xref:DataMinerExtensionModules#apigateway) is installed and running on the DMA you are connecting to.
 - [Remote access to Cube is enabled](xref:Controlling_remote_access) for the DMS.
 - You have been [granted access to dataminer.services features](xref:Giving_users_access_to_cloud_features).
-- You [have the DataMiner Cube desktop application installed](xref:Installing_configuring_the_DataMiner_Cube_software) and all [client requirements](DataMiner_Client_Requirements) are met.
+- You [have the DataMiner Cube desktop application installed](xref:Installing_configuring_the_DataMiner_Cube_software) and all [client requirements](xref:DataMiner_Client_Requirements) are met.
 - Your user account has been granted access to the DataMiner System.
 
 > [!IMPORTANT]

--- a/user-guide/Reference/DataMiner_Client_Requirements.md
+++ b/user-guide/Reference/DataMiner_Client_Requirements.md
@@ -30,7 +30,7 @@ Recommended DataMiner client configuration:
 
 ### Microsoft .NET Framework
 
-Microsoft .NET Framework 4.6.2
+Microsoft .NET Framework 4.7.2
 
 > [!IMPORTANT]
 > We recommend always upgrading to the latest .NET Framework version.

--- a/user-guide/Reference/DataMiner_Client_Requirements.md
+++ b/user-guide/Reference/DataMiner_Client_Requirements.md
@@ -35,9 +35,6 @@ Microsoft .NET Framework 4.7.2
 > [!IMPORTANT]
 > We recommend always upgrading to the latest .NET Framework version.
 
-> [!NOTE]
-> When you connect to DataMiner using HTTPS, TLS 1.0 is required to install Cube. It is also possible to use TLS 1.1 or TLS 1.2, but in that case Microsoft .NET Framework 4.6.2 is required.
-
 ### Skyline certificates
 
 To install the Skyline certificates:


### PR DESCRIPTION
Based on https://community.dataminer.services/question/remote-cube-method-not-found-grpc-net-client-grpcchanneloptions-set_httpclient/ and further investigation, .NET Framework 4.7.2 is currently required to be able to set up a gRPC connection.