### PR TITLE
Removed reference to Dojo, dataminer docs is the main documentation

### DIFF
--- a/user-guide/Standard_Apps/Monitoring_Solutions/DataMiner_Objects_Tool/DataMiner_Objects_Tool.md
+++ b/user-guide/Standard_Apps/Monitoring_Solutions/DataMiner_Objects_Tool/DataMiner_Objects_Tool.md
@@ -15,6 +15,3 @@ The DataMiner Objects Tool addresses the need for **finding, viewing, and intera
 - Service definitions
 
 You can then manually fine-tune the result of the query, view the selected objects as JSON objects, or even delete selected objects.
-
-> [!TIP]
-> See also: [Use case: DataMiner Objects Tool](https://community.dataminer.services/use-case/) on DataMiner Dojo


### PR DESCRIPTION
Removed this broken reference to Dojo. This documentation should not be referencing to Dojo as the Dojo article will not have any info that is not already in here.