### PR TITLE
Update Winpcap and Npcap references

### DIFF
--- a/user-guide/Advanced_Functionality/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
+++ b/user-guide/Advanced_Functionality/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
@@ -15,7 +15,7 @@ Before you start the actual configuration, make sure you have the following:
   > [!NOTE]
   > If you use IP addresses instead of a hostname:
   >
-  > - Make sure WinPCap (deprecated) or [NPCap](https://nmap.org/npcap/) is installed on both DMAs (see [Before you run the installer](xref:Installing_DM_using_the_DM_installer#before-you-run-the-installer)).
+  > - Make sure [NPCap](https://nmap.org/npcap/) or WinPCap (deprecated) is installed on both DMAs (see [Before you run the installer](xref:Installing_DM_using_the_DM_installer#before-you-run-the-installer)).
   > - To avoid possible conflicts, make sure the IP addresses are not used anywhere else and that these are reserved for the Failover pair.
 
 In addition, make sure the [required ports are opened](#opening-the-required-ports), and the [database is prepared](#preparing-the-database).

--- a/user-guide/Advanced_Functionality/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
+++ b/user-guide/Advanced_Functionality/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
@@ -15,7 +15,7 @@ Before you start the actual configuration, make sure you have the following:
   > [!NOTE]
   > If you use IP addresses instead of a hostname:
   >
-  > - Make sure WinPCap or [NPCap](https://nmap.org/npcap/) is installed on both DMAs (see [Before you run the installer](xref:Installing_DM_using_the_DM_installer#before-you-run-the-installer)).
+  > - Make sure WinPCap (deprecated) or [NPCap](https://nmap.org/npcap/) is installed on both DMAs (see [Before you run the installer](xref:Installing_DM_using_the_DM_installer#before-you-run-the-installer)).
   > - To avoid possible conflicts, make sure the IP addresses are not used anywhere else and that these are reserved for the Failover pair.
 
 In addition, make sure the [required ports are opened](#opening-the-required-ports), and the [database is prepared](#preparing-the-database).

--- a/user-guide/Getting_started/Installing_a_DMA/Checking_the_DM_installation.md
+++ b/user-guide/Getting_started/Installing_a_DMA/Checking_the_DM_installation.md
@@ -14,7 +14,7 @@ After installation, we recommend that you do the following checks in order to be
   - Microsoft Visual C++ 2005 Redistributable (x64) (if working on a x64 system)
   - Microsoft Visual C++ 2010 x86 Redistributable
   - Microsoft Visual C++ 2010 x64 Redistributable (if working on a x64 system)
-  - WinPcap (only needed for Failover systems)
+  - WinPCap (deprecated) or [NPCap](https://nmap.org/npcap/) (This is only needed for DataMiner Failover based on virtual IP. Make sure it is installed on both DMAs.)
   - MySQL Server (optional)
   - MySQL Workbench (optional)
 

--- a/user-guide/Getting_started/Installing_a_DMA/Checking_the_DM_installation.md
+++ b/user-guide/Getting_started/Installing_a_DMA/Checking_the_DM_installation.md
@@ -14,7 +14,7 @@ After installation, we recommend that you do the following checks in order to be
   - Microsoft Visual C++ 2005 Redistributable (x64) (if working on a x64 system)
   - Microsoft Visual C++ 2010 x86 Redistributable
   - Microsoft Visual C++ 2010 x64 Redistributable (if working on a x64 system)
-  - WinPCap (deprecated) or [NPCap](https://nmap.org/npcap/) (This is only needed for DataMiner Failover based on virtual IP. Make sure it is installed on both DMAs.)
+  - In case the DMA will be used in a [Failover setup based on virtual IP](xref:About_DMA_Failover): [NPCap](https://nmap.org/npcap/) or WinPCap (deprecated)
   - MySQL Server (optional)
   - MySQL Workbench (optional)
 

--- a/user-guide/Getting_started/Installing_a_DMA/Installing_DM_using_the_DM_Installer.md
+++ b/user-guide/Getting_started/Installing_a_DMA/Installing_DM_using_the_DM_Installer.md
@@ -32,7 +32,7 @@ The DataMiner installer allows you to run a default DataMiner installation, whic
 1. Download the DataMiner installer from [DataMiner Dojo](https://community.dataminer.services/download/dataminer-installer-v10-2).
 
 > [!NOTE]
-> The default installation requires that WinPCap (deprecated) or [NPCap](https://nmap.org/npcap/) is installed for systems intended for DataMiner Failover based on virtual IP. If you intend to configure a [Failover setup based on hostname](xref:Failover_configuration_in_Cube), this software will not be needed. WinPCap can be installed with a custom installation using the DataMiner 10.0 installer; however, note that WinPCap is considered obsolete since 2018. For now, NPCap is not included in the DataMiner Installer.
+> The default installation requires that [NPCap](https://nmap.org/npcap/) or WinPCap (deprecated) is installed for systems intended for DataMiner Failover based on virtual IP. If you intend to configure a [Failover setup based on hostname](xref:Failover_configuration_in_Cube), this software will not be needed. WinPCap can be installed with a custom installation using the DataMiner 10.0 installer; however, note that WinPCap is considered obsolete since 2018. For now, NPCap is not included in the DataMiner Installer.
 
 ### Default DataMiner installation
 
@@ -120,7 +120,7 @@ At this point, the basic installation is complete. However, to be able to make f
    - If you are using the DataMiner 10.0 installer, on systems intended for DataMiner Failover based on virtual IP, install WinPcap by clicking *Install WinPcap*. The Setup Wizard of WinPcap will be launched. Follow the wizard, select *Automatically start the WinPcap driver at boot time*, and click *Next* when necessary.
 
      > [!NOTE]
-     > The DataMiner 10.2 installer no longer supports WinPCap as it is depcrecated. If you intend to configure a [Failover setup based on hostname](xref:Failover_configuration_in_Cube), this software will not be needed. However, if you intend to configure a [Failover setup based on virtual IP](xref:Failover_configuration_in_Cube), you will need to install [NPCap](https://nmap.org/npcap/) instead.
+     > The DataMiner 10.2 installer no longer supports WinPCap as it is deprecated. If you intend to configure a [Failover setup based on hostname](xref:Failover_configuration_in_Cube), this software will not be needed. However, if you intend to configure a [Failover setup based on virtual IP](xref:Failover_configuration_in_Cube), you will need to install [NPCap](https://nmap.org/npcap/) instead.
 
    - If the built-in Administrator account is not enabled, select *Create administrator account for current user* to create a Windows user account.
 

--- a/user-guide/Getting_started/Installing_a_DMA/Installing_DM_using_the_DM_Installer.md
+++ b/user-guide/Getting_started/Installing_a_DMA/Installing_DM_using_the_DM_Installer.md
@@ -32,7 +32,7 @@ The DataMiner installer allows you to run a default DataMiner installation, whic
 1. Download the DataMiner installer from [DataMiner Dojo](https://community.dataminer.services/download/dataminer-installer-v10-2).
 
 > [!NOTE]
-> The default installation requires that WinPCap or [NPCap](https://nmap.org/npcap/) is installed for systems intended for DataMiner Failover based on virtual IP. If you intend to configure a [Failover setup based on hostname](xref:Failover_configuration_in_Cube), this software will not be needed. WinPCap can be installed with a custom installation using the DataMiner 10.0 installer; however, note that WinPCap is considered obsolete since 2018. For now, NPCap is not included in the DataMiner Installer.
+> The default installation requires that WinPCap (deprecated) or [NPCap](https://nmap.org/npcap/) is installed for systems intended for DataMiner Failover based on virtual IP. If you intend to configure a [Failover setup based on hostname](xref:Failover_configuration_in_Cube), this software will not be needed. WinPCap can be installed with a custom installation using the DataMiner 10.0 installer; however, note that WinPCap is considered obsolete since 2018. For now, NPCap is not included in the DataMiner Installer.
 
 ### Default DataMiner installation
 
@@ -117,10 +117,10 @@ At this point, the basic installation is complete. However, to be able to make f
      > - MySQL is no longer included in the 10.2.0 DataMiner installer.
      > - If a MySQL database is used, certain DataMiner features (e.g. trend predictions, ticketing, jobs, service & resource manager) will **not be available**.
 
-   - If you are using the DataMiner 10.0 installer, on systems intended for DataMiner Failover, install WinPcap by clicking *Install WinPcap*. The Setup Wizard of WinPcap will be launched. Follow the wizard, select *Automatically start the WinPcap driver at boot time*, and click *Next* when necessary.
+   - If you are using the DataMiner 10.0 installer, on systems intended for DataMiner Failover based on virtual IP, install WinPcap by clicking *Install WinPcap*. The Setup Wizard of WinPcap will be launched. Follow the wizard, select *Automatically start the WinPcap driver at boot time*, and click *Next* when necessary.
 
      > [!NOTE]
-     > The DataMiner 10.2 installer no longer supports WinPCap. If you intend to configure a [Failover setup based on hostname](xref:Failover_configuration_in_Cube), this software will not be needed. However, if you intend to configure a [Failover setup based on virtual IP](xref:Failover_configuration_in_Cube), you will need to install [NPCap](https://nmap.org/npcap/) instead.
+     > The DataMiner 10.2 installer no longer supports WinPCap as it is depcrecated. If you intend to configure a [Failover setup based on hostname](xref:Failover_configuration_in_Cube), this software will not be needed. However, if you intend to configure a [Failover setup based on virtual IP](xref:Failover_configuration_in_Cube), you will need to install [NPCap](https://nmap.org/npcap/) instead.
 
    - If the built-in Administrator account is not enabled, select *Create administrator account for current user* to create a Windows user account.
 

--- a/user-guide/Getting_started/Installing_a_DMA/Unattended_DM_installation.md
+++ b/user-guide/Getting_started/Installing_a_DMA/Unattended_DM_installation.md
@@ -38,8 +38,7 @@ Once the installation process has started, the installer will go through the fol
    > [!NOTE]
    >
    > - The installer requires that at least .Net Framework 4.5 is already installed. If this is not the case, you will not be able to run the installer.
-   > - When DataMiner Failover based on virtual IP is needed, WinPcap (deprecated) or [NPCap](https://nmap.org/npcap/) can only be installed during an attended installation. 
-       For an unattended installation, make sure it is installed beforehand on both DMAs.
+   > - When DataMiner Failover based on virtual IP will be used, [NPCap](https://nmap.org/npcap/) or WinPCap (deprecated) can only be installed during an attended installation. For an unattended installation, make sure it is installed beforehand on both DMAs.
 
 1. Installation of the DataMiner version provided in the installer.
 

--- a/user-guide/Getting_started/Installing_a_DMA/Unattended_DM_installation.md
+++ b/user-guide/Getting_started/Installing_a_DMA/Unattended_DM_installation.md
@@ -38,7 +38,8 @@ Once the installation process has started, the installer will go through the fol
    > [!NOTE]
    >
    > - The installer requires that at least .Net Framework 4.5 is already installed. If this is not the case, you will not be able to run the installer.
-   > - WinPcap can only be installed during an attended installation. For an unattended installation, make sure it is installed beforehand.
+   > - When DataMiner Failover based on virtual IP is needed, WinPcap (deprecated) or [NPCap](https://nmap.org/npcap/) can only be installed during an attended installation. 
+       For an unattended installation, make sure it is installed beforehand on both DMAs.
 
 1. Installation of the DataMiner version provided in the installer.
 


### PR DESCRIPTION
Goal of this change is to make sure that every reference of WinPcap is stated as deprecated, that Npcap is also mentioned with a link to their website, and that tis is needed for DataMiner Failover based on Virtual IP, and as well that it is installed on both DMAs.