### PR TITLE
Small change: link to SSH.NET page is broken

### DIFF
--- a/overwrite/Tamir.SharpSsh.md
+++ b/overwrite/Tamir.SharpSsh.md
@@ -6,4 +6,4 @@ remarks: *content
 This namespace contains classes implementing SSH File Transfer Protocol (SFTP) and Secure Copy (SCP) functionality.
 
 > [!WARNING]
-> This namespace is obsolete for SCP and SFTP implementations. Please refer to the following page for an alternative for such implementations: https://github.com/sshnet/SSH.NET.|
+> This namespace is obsolete for SCP and SFTP implementations. Please refer to the following page for an alternative for such implementations: https://github.com/sshnet/SSH.NET


### PR DESCRIPTION
Corrected an issue with the link to SSH.NET GitHub page.