### PR TITLE
Small change: XML offload rate example incorrect

### DIFF
--- a/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/DB_xml.md
+++ b/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/DB_xml.md
@@ -332,7 +332,7 @@ In the following example, “1;TRUE” means that the real-time trend data recor
   <DataBase>
     <Offloads>
       ...
-      <Offload state="active" local="data" rate="5;FALSE" />
+      <Offload state="active" local="data" rate="1;TRUE" />
       ...
     </Offloads>
   </DataBase>


### PR DESCRIPTION

![XML offload rate example incorrect](https://github.com/user-attachments/assets/4ca4dc96-8e1c-40df-90df-1f82911e2a3c)
Text referencing the XML example of offload rate says “1;TRUE” but the actual XML example shows "5;FALSE"