### PR TITLE
Update NATS section in Encryption in DataMiner

### DIFF
--- a/user-guide/Advanced_Functionality/Security/About_DMS_Security/Encryption_in_DataMiner.md
+++ b/user-guide/Advanced_Functionality/Security/About_DMS_Security/Encryption_in_DataMiner.md
@@ -97,7 +97,7 @@ For DataMiner Systems configured to use an Elasticsearch database, we recommend 
 
 From version 10.1.0/10.1.1 onwards, DataMiner relies on NATS for some inter-process communication. By default, this NATS traffic is not yet encrypted.
 
-Please refer to the official NATS documentation on [enabling TLS encryption](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/tls).
+Please refer to [Securing NATS](xref:Security_NATS) to learn how to set up TLS for NATS.
 
 ## Encryption at rest
 


### PR DESCRIPTION
The NATS section in the Encryption in DataMiner page used to refer to the NATS documentation. I changed this so it points to our own 'Securing NATS' page.