### PR TITLE
Update Importing_and_exporting_elements

### DIFF
--- a/user-guide/Basic_Functionality/Elements/Working_with_elements/Importing_and_exporting_elements.md
+++ b/user-guide/Basic_Functionality/Elements/Working_with_elements/Importing_and_exporting_elements.md
@@ -68,7 +68,7 @@ Name checks are case-insensitive. This means that for instance "element1" is con
 
 1. In the *WHAT* section of the *Export* window, select what is to be included in the export:
 
-   - All data (i.e. the full list, with all columns included),
+   - All data (suitable for CSV import),
 
    - The data displayed in the element list of a view card,
 


### PR DESCRIPTION
Current explanation in the DataMiner docs is confusing, as "All data" doesn't mean the full list (with all columns included). Example when using this option, the column "Impacted Services" (visible in Cube UI) is not exported.
So I propose to put the same explanation as shown in the Cube UI: "All data (suitable for CSV import)", refer my screenshot in https://community.dataminer.services/question/can-i-export-a-filtered-element-list-with-the-impacted-services-column-to-csv/.