### PR TITLE
Dedicated clustered storage - Add middle set when copying DB.xml

### DIFF
--- a/user-guide/Advanced_Functionality/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
+++ b/user-guide/Advanced_Functionality/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
@@ -92,6 +92,7 @@ If you want to add the Failover pair to a DataMiner System that uses STaaS, firs
       > [!NOTE]
       > If multiple [OpenSearch clusters](xref:Configuring_multiple_OpenSearch_clusters) or [Elasticsearch clusters](xref:Configuring_multiple_Elasticsearch_clusters) are used, you may wish to configure the *priorityOrder* attribute differently on the main or backup DMA. You can do this if you want to change which indexing cluster is read from when there is a Failover switch. For more info on the *priorityOrder* attribute, see [OpenSearch clusters](xref:Configuring_multiple_OpenSearch_clusters) or [Elasticsearch clusters](xref:Configuring_multiple_Elasticsearch_clusters).
 
+   1. In the tags `PWD` replace the GUID reference with the password in plaintext
    1. Restart the backup DMA.
 
 1. If TLS is used, make sure that the required certificates are imported, and this is correctly configured on the backup DMA as well.

--- a/user-guide/Advanced_Functionality/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
+++ b/user-guide/Advanced_Functionality/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
@@ -92,7 +92,10 @@ If you want to add the Failover pair to a DataMiner System that uses STaaS, firs
       > [!NOTE]
       > If multiple [OpenSearch clusters](xref:Configuring_multiple_OpenSearch_clusters) or [Elasticsearch clusters](xref:Configuring_multiple_Elasticsearch_clusters) are used, you may wish to configure the *priorityOrder* attribute differently on the main or backup DMA. You can do this if you want to change which indexing cluster is read from when there is a Failover switch. For more info on the *priorityOrder* attribute, see [OpenSearch clusters](xref:Configuring_multiple_OpenSearch_clusters) or [Elasticsearch clusters](xref:Configuring_multiple_Elasticsearch_clusters).
 
-   1. In the tags `PWD` replace the GUID reference with the password in plaintext
+   1. In the `PWD` tags, replace the GUID reference with the password in plain text.
+
+      During the next startup, DataMiner will encrypt this password again and replace it with a placeholder GUID.
+
    1. Restart the backup DMA.
 
 1. If TLS is used, make sure that the required certificates are imported, and this is correctly configured on the backup DMA as well.


### PR DESCRIPTION
Replace the GUID reference to the password with the plaintext password after copying the DB.xml from the main agent to the backup agent. By doing this, no issue will occur when the backup agent connects to the database.