### PR TITLE
Update Preparing_to_upgrade_a_DataMiner_Agent.md

### DIFF
--- a/user-guide/Advanced_Functionality/DataMiner_Agents/Upgrading_a_DMA/Preparing_to_upgrade_a_DataMiner_Agent.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Agents/Upgrading_a_DMA/Preparing_to_upgrade_a_DataMiner_Agent.md
@@ -39,7 +39,7 @@ To upload an upgrade package:
 > When you upload a package, several [prerequisite checks](#prerequisite-checks) will be executed, so that you will immediately get informed if certain conditions or requirements for the update are not met yet.
 
 > [!TIP]
-> We recommend to upload the package a few days before executing the upgrade. This will allow you extra time to perform corrective actions if some of the prerequisite checks would fail.
+> We recommend that you upload the package a few days before you execute the upgrade. This will allow you extra time to perform corrective actions in case any of the prerequisite checks fail.
 
 ### Have a backup at the ready
 

--- a/user-guide/Advanced_Functionality/DataMiner_Agents/Upgrading_a_DMA/Preparing_to_upgrade_a_DataMiner_Agent.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Agents/Upgrading_a_DMA/Preparing_to_upgrade_a_DataMiner_Agent.md
@@ -39,7 +39,7 @@ To upload an upgrade package:
 > When you upload a package, several [prerequisite checks](#prerequisite-checks) will be executed, so that you will immediately get informed if certain conditions or requirements for the update are not met yet.
 
 > [!TIP]
-> To be safe, upload the package at least a week before executing the upgrade.
+> We recommend to upload the package a few days before executing the upgrade. This will allow you extra time to perform corrective actions if some of the prerequisite checks would fail.
 
 ### Have a backup at the ready
 


### PR DESCRIPTION
I suggest changing the wording in the tip to upload the package "at least a week before the upgrade".

This recommendation is arguable. 
1. The phrase "to be safe..." implies there is a danger in not uploading the package in advance, and the earlier one uploads the package, the better. This is not correct.
2. I find "at least a week in advance" too much. Here we actually run into a different risk - if the package is in uploaded & ready state for too long, some events in the DMS (crashes, reboots, Windows updates, etc.) may render it invalid. A few days, or a week at most, should be enough.  
3. Note that this recommendation appears again in lines 122-125 in a slightly different and less worrying form.