### PR TITLE
Add links to options on same page

### DIFF
--- a/develop/devguide/Connector/Actions/ActionAggregate.md
+++ b/develop/devguide/Connector/Actions/ActionAggregate.md
@@ -20,20 +20,20 @@ Specifies the aggregation options.
 
 The following options are available:
 
-- allowValues/ignoreValues
-- avoidZeroInResult
-- defaultIf
-- defaultValue
-- equation
-- equationvalue
-- filter
-- groupby
-- groupbyTable
-- join
-- return
-- status
-- threaded
-- type
+- [allowValues/ignoreValues](#allowvaluesignorevalues)
+- [avoidZeroInResult](#avoidzeroinresult)
+- [defaultIf](#defaultif)
+- [defaultValue](#defaultvalue)
+- [equation](#equation)
+- [equationvalue](#equationvalue)
+- [filter](#filter)
+- [groupby](#groupby)
+- [groupbyTable](#groupbytable)
+- [join](#join)
+- [return](#return)
+- [status](#status)
+- [threaded](#threaded)
+- [type](#type)
 
 #### allowValues/ignoreValues
 


### PR DESCRIPTION
There are a lot of type@options.
Navigating on sight was difficult.
This commit converts the items in the bullet list into clickable links.