### PR TITLE
Update Installing_the_Keysight_Agilent_IO_Libraries.md

### DIFF
--- a/user-guide/Advanced_Modules/Spectrum_Analysis/Installation_and_configuration/Installing_the_Keysight_Agilent_IO_Libraries.md
+++ b/user-guide/Advanced_Modules/Spectrum_Analysis/Installation_and_configuration/Installing_the_Keysight_Agilent_IO_Libraries.md
@@ -9,7 +9,7 @@ On a DataMiner Agent that has to communicate through a GPIB/LAN gateway, you hav
 > [!NOTE]
 > After installing the IO Libraries or after changing the IO configuration, restart the DMA software.
 
-> [!NOTE]
+> [!WARNING]
 > Both the Keysight Agilent IO Libraries and the NATS module within DataMiner use IP port 9090. This can result in NATS issues and prevent DataMiner from starting. To fix this, see [Troubleshooting – NATS](xref:Investigating_NATS_Issues#check-if-port-is-already-in-use). This procedure must be followed for every DMA running DataMiner 10.1.0/10.1.1 or higher.
 
 ## Installing the IO Libraries


### PR DESCRIPTION
Installing this software without reconfiguring NATS will prevent the agent from starting. I consider this a dangerous consequence.