### PR TITLE
KI: nats-server.config file is not automatically restored after backup

### DIFF
--- a/user-guide/Reference/DataMiner_Tools/SLNetClientTest_tool/SLNetClientTest_tool_advanced_procedures/SLNetClientTest_disabling_automatic_nats_config.md
+++ b/user-guide/Reference/DataMiner_Tools/SLNetClientTest_tool/SLNetClientTest_tool_advanced_procedures/SLNetClientTest_disabling_automatic_nats_config.md
@@ -27,3 +27,8 @@ To disable automatic NATS configuration:
 
 > [!WARNING]
 > Always be extremely careful when using the SLNetClientTest tool, as it can have far-reaching consequences on the functionality of your DataMiner System.
+
+Changes to the *NATSForceManualConfig* option are included in a DataMiner backup to make sure that the automatic NATS configuration status remains consistent after performing a backup. From DataMiner 10.4.11/10.5.0 onwards<!--RN 40812-->, any changes made to the *nats-server.config* file after disabling automatic NATS configuration will also be included in the backup and restored automatically. Prior to this, you need to manually restore the *nats-server.config* file, located in the `C:\Skyline DataMiner\NATS\nats-streaming-server\` folder.
+
+> [!TIP]
+> See also: [nats-server.config file is not automatically restored after DataMiner backup](xref:KI_nats-server_config_file_not_restored_after_backup)

--- a/user-guide/Troubleshooting/Known_issues/KI_nats-server_config_file_not_restored_after_backup.md
+++ b/user-guide/Troubleshooting/Known_issues/KI_nats-server_config_file_not_restored_after_backup.md
@@ -1,0 +1,28 @@
+---
+uid: KI_nats-server_config_file_not_restored_after_backup
+---
+
+# nats-server.config file is not automatically restored after DataMiner backup
+
+## Affected versions
+
+From DataMiner 10.2.0 [CU6]/10.2.8 onwards.
+
+## Cause
+
+When automatic NATS configuration is disabled via the *NATSForceManualConfig* option, the *nats-server.config* file is saved in the `C:\Skyline DataMiner\NATS\nats-streaming-server\` folder as part of a DataMiner backup. However, the file is not automatically restored after the backup, which may give the impression that changes made to the file have been lost.
+
+> [!CAUTION]
+> We strongly recommend against disabling automatic NATS configuration unless absolutely necessary. For more information, see [Disabling automatic NATS configuration](xref:SLNetClientTest_disabling_automatic_nats_config).
+
+## Fix
+
+Install DataMiner 10.4.11/10.5.0 to ensure the *nats-server.config* file is automatically restored after a backup<!--RN 40812-->.
+
+## Issue description
+
+When a DataMiner backup is restored in versions prior to DataMiner 10.4.11/10.5.0, the *nats-server.config* file is not automatically restored, leading to the impression that manual changes to the file have been lost.
+
+## Workaround
+
+Manually restore the *nats-server.config* file from the `C:\Skyline DataMiner\NATS\nats-streaming-server\` folder.

--- a/user-guide/Troubleshooting/Known_issues/Known_issues.md
+++ b/user-guide/Troubleshooting/Known_issues/Known_issues.md
@@ -14,6 +14,7 @@ uid: Known_issues
 | [Problem after removing DMA from cluster](xref:KI_Problem_after_removing_DMA_from_cluster) | Any DataMiner version with clustered storage <br>and/or indexing | | December 15, 2023 |
 | [NATS not starting if DMS name contains special characters](xref:KI_NATS_not_starting_special_chars) | From DataMiner 10.1.0/10.1.2 <br>onwards | | November 8, 2022 |
 | [Upgrade fails because of VerifyClusterPort.dll prerequisite](xref:KI_Upgrade_fails_VerifyClusterPorts_prerequisite) | From 10.2.0 [CU1] and 10.2.4 onwards | | September 2, 2022 |
+| [nats-server.config file is not automatically restored after DataMiner backup](xref:KI_nats-server_config_file_not_restored_after_backup) | From DataMiner 10.2.0 [CU6]/10.2.8 onwards | DataMiner 10.4.11/10.5.0 | October 10, 2024 |
 | [Web apps experience frequent disconnects](xref:KI_Web_apps_experience_frequent_disconnects) | DataMiner 10.4.0 [CU6]<br>DataMiner 10.4.9 | DataMiner 10.4.0 [CU7]<br>DataMiner 10.4.10 | September 23, 2024 |
 | [Problem when DMA server is named DATAMINER](xref:KI_Problem_when_server_name_is_DATAMINER) | From DataMiner 10.4.0 [CU2]/10.4.5 onwards | DataMiner 10.4.0 [CU9]<br>DataMiner 10.4.12 | September 10, 2024 |
 | [ButtonState shapes in Visual Overview fail to hide as expected](xref:KI_ButtonState_shapes_in_Visual_Overview_fail_to_hide_as_expected) | DataMiner Cube versions prior to 10.4.2425.2536<br>DataMiner 10.4.8, if Cube client does not have internet access | DataMiner 10.3.0 [CU19]/10.4.0 [CU7]/10.4.10 | August 13, 2024 |
@@ -44,6 +45,7 @@ uid: Known_issues
 | [Problem after removing DMA from cluster](xref:KI_Problem_after_removing_DMA_from_cluster) | Any DataMiner version with clustered storage <br>and/or indexing | | December 15, 2023 |
 | [NATS not starting if DMS name contains special characters](xref:KI_NATS_not_starting_special_chars) | From DataMiner 10.1.0/10.1.2 <br>onwards | | November 8, 2022 |
 | [Upgrade fails because of VerifyClusterPort.dll prerequisite](xref:KI_Upgrade_fails_VerifyClusterPorts_prerequisite) | From 10.2.0 [CU1] and 10.2.4 onwards | | September 2, 2022 |
+| [nats-server.config file is not automatically restored after DataMiner backup](xref:KI_nats-server_config_file_not_restored_after_backup) | From DataMiner 10.2.0 [CU6]/10.2.8 onwards | DataMiner 10.4.11/10.5.0 | October 10, 2024 |
 | [ButtonState shapes in Visual Overview fail to hide as expected](xref:KI_ButtonState_shapes_in_Visual_Overview_fail_to_hide_as_expected) | DataMiner Cube versions prior to 10.4.2425.2536<br>DataMiner 10.4.8, if Cube client does not have internet access | DataMiner 10.3.0 [CU19]/10.4.0 [CU7]/10.4.10 | August 13, 2024 |
 | [Process crashes when trying to connect to MySQL database](xref:KI_MySQL_Unhandled_Exception) | From DataMiner 10.3.0 [CU14]/10.4.0 [CU2]/10.4.5 <br>onwards | DataMiner 10.3.0 [CU18]/10.4.0 [CU6]/10.4.9 | July 15, 2024 |
 | [SLDataMiner crashes because of subgroup query failure](xref:KI_SLDataMiner_crashes_because_of_subgroup_query_failure) | DataMiner 10.4.2 and 10.4.3<br>DataMiner 10.3.0 [CU11] and [CU12]<br>DataMiner 10.4.0 [CU0] | DataMiner 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 | March 11, 2024 |
@@ -99,6 +101,7 @@ uid: Known_issues
 | [Elasticsearch not initialized when DataMiner starts up](xref:KI_Elasticsearch_not_initialized_on_DMA_startup) | Any version using Elasticsearch | | April 20, 2023 |
 | [NATS not starting if DMS name contains special characters](xref:KI_NATS_not_starting_special_chars) | From DataMiner 10.1.0/10.1.2 <br>onwards | | November 8, 2022 |
 | [Upgrade fails because of VerifyClusterPort.dll prerequisite](xref:KI_Upgrade_fails_VerifyClusterPorts_prerequisite) | From DataMiner 10.2.0 [CU1] and 10.2.4 onwards | | September 2, 2022 |
+| [nats-server.config file is not automatically restored after DataMiner backup](xref:KI_nats-server_config_file_not_restored_after_backup) | From DataMiner 10.2.0 [CU6]/10.2.8 onwards | DataMiner 10.4.11/10.5.0 | October 10, 2024 |
 | [ButtonState shapes in Visual Overview fail to hide as expected](xref:KI_ButtonState_shapes_in_Visual_Overview_fail_to_hide_as_expected) | DataMiner Cube versions prior to 10.4.2425.2536<br>DataMiner 10.4.8, if Cube client does not have internet access | DataMiner 10.3.0 [CU19]/10.4.0 [CU7]/10.4.10 | August 13, 2024 |
 | [Timetrace data is no longer written during Cassandra Cluster migration](xref:KI_Timetrace_Data_no_longer_written_during_Cassandra_Cluster_Migration) | Cassandra Cluster setups | DataMiner 10.3.0 [CU19]/10.4.0 [CU7]/10.4.10 | February 29, 2024 |
 | [Port exhaustion because of NATS reconnection attempts](xref:KI_port_exhaustion_because_of_NATS_reconnect_attempts) | Any DataMiner version | DataMiner 10.4.6/10.5.0 | February 2, 2024 |

--- a/user-guide/Troubleshooting/toc.yml
+++ b/user-guide/Troubleshooting/toc.yml
@@ -262,6 +262,8 @@ items:
             topicUid: KI_Setting_a_protocol_to_production_takes_a_long_time
       - name: Resolved issues
         items:
+          - name: nats-server.config file is not automatically restored after DataMiner backup
+            topicUid: KI_nats-server_config_file_not_restored_after_backup
           - name: Problem when DMA server is named DATAMINER
             topicUid: KI_Problem_when_server_name_is_DATAMINER
           - name: Web apps experience frequent disconnects


### PR DESCRIPTION
@lustpieter, as discussed, I've added the content of RN 40812 as a known issue. I've also mentioned the change on the 'Disabling automatic NATS configuration' page. Could you double-check whether this is OK to merge? Thanks in advance!