### PR TITLE
Update Installing_the_Keysight_Agilent_IO_Libraries.md

### DIFF
--- a/user-guide/Advanced_Modules/Spectrum_Analysis/Installation_and_configuration/Installing_the_Keysight_Agilent_IO_Libraries.md
+++ b/user-guide/Advanced_Modules/Spectrum_Analysis/Installation_and_configuration/Installing_the_Keysight_Agilent_IO_Libraries.md
@@ -7,10 +7,10 @@ uid: Installing_the_Keysight_Agilent_IO_Libraries
 On a DataMiner Agent that has to communicate through a GPIB/LAN gateway, you have to install and configure the Keysight IO Libraries (known as Agilent up till 2014).
 
 > [!NOTE]
-> After installing the IO Libraries or after changing the IO configuration, restart the DMA software.
+> After installing the IO Libraries, restart the machine. After changing the IO configuration, restart the DMA software.
 
 > [!WARNING]
-> Both the Keysight Agilent IO Libraries and the NATS module within DataMiner use IP port 9090. This can result in NATS issues and prevent DataMiner from starting. To fix this, see [Troubleshooting – NATS](xref:Investigating_NATS_Issues#check-if-port-is-already-in-use). This procedure must be followed for every DMA running DataMiner 10.1.0/10.1.1 or higher.
+> Both the Keysight Distributed Infrastructure Service (kdi-controller.exe) and the NATS module within DataMiner use IP port 9090. This will result in NATS issues and will prevent DataMiner from starting. To fix this, change the port number of the kdi service by editing *C:\\ProgramData\\Keysight\\Distributed Infrastructure\\kdi.yaml* and restart the machine, or change the NATS port, see [Troubleshooting – NATS](xref:Investigating_NATS_Issues#check-if-port-is-already-in-use). This procedure must be followed for every DMA running DataMiner 10.1.0/10.1.1 or higher.
 
 ## Installing the IO Libraries
 

--- a/user-guide/Advanced_Modules/Spectrum_Analysis/Installation_and_configuration/Installing_the_Keysight_Agilent_IO_Libraries.md
+++ b/user-guide/Advanced_Modules/Spectrum_Analysis/Installation_and_configuration/Installing_the_Keysight_Agilent_IO_Libraries.md
@@ -7,10 +7,10 @@ uid: Installing_the_Keysight_Agilent_IO_Libraries
 On a DataMiner Agent that has to communicate through a GPIB/LAN gateway, you have to install and configure the Keysight IO Libraries (known as Agilent up till 2014).
 
 > [!NOTE]
-> After installing the IO Libraries, restart the machine. After changing the IO configuration, restart the DMA software.
+> After installing the IO Libraries, you will need to restart the machine. After changing the IO configuration, you will need to restart the DMA software.
 
 > [!WARNING]
-> Both the Keysight Distributed Infrastructure Service (kdi-controller.exe) and the NATS module within DataMiner use IP port 9090. This will result in NATS issues and will prevent DataMiner from starting. To fix this, change the port number of the kdi service by editing *C:\\ProgramData\\Keysight\\Distributed Infrastructure\\kdi.yaml* and restart the machine, or change the NATS port, see [Troubleshooting – NATS](xref:Investigating_NATS_Issues#check-if-port-is-already-in-use). This procedure must be followed for every DMA running DataMiner 10.1.0/10.1.1 or higher.
+> Both the Keysight Distributed Infrastructure service (*kdi-controller.exe*) and the NATS module within DataMiner use IP port 9090. This will result in NATS issues and will prevent DataMiner from starting. To fix this, change the port number of the KDI service by editing *C:\\ProgramData\\Keysight\\Distributed Infrastructure\\kdi.yaml* and restarting the machine, or change the NATS port. See [Troubleshooting – NATS](xref:Investigating_NATS_Issues#check-if-port-is-already-in-use). This procedure must be followed for every DMA running DataMiner 10.1.0/10.1.1 or higher.
 
 ## Installing the IO Libraries
 
@@ -23,19 +23,23 @@ The minimum version for the IO libraries is 17.1.20011.
 > - In the file properties of *Setup.exe*, indicate that you want the file to run in *Windows XP compatibility mode*.
 > - Run *Setup.exe*. This should remove the existing IO libraries, IVI shared components, and VISA shared components. Go to *Programs and features* if you want to check whether all those items were removed.
 
-- You can download the most recent version of the IO libraries from the following website:<br><http://www.keysight.com/main/software.jspx?ckey=2175637&lc=dut&cc=BE&nid=-33330.977662&id=2175637&pageMode=PV>
+1. Download and install the IO libraries.
 
-- After installing the IO libraries, run *Keysight Connection Expert*, either from the right-click menu of the IO libraries taskbar icon or from the Windows start menu.
+   You can download the most recent version of the IO libraries from the following website:<br><http://www.keysight.com/main/software.jspx?ckey=2175637&lc=dut&cc=BE&nid=-33330.977662&id=2175637&pageMode=PV>
 
-  - Go to *Manual Configuration \> Edit Existing Instruments/Interfaces*. In the list, there should be an automatically created interface named “Lan Interface TCPIP0”.
+1. When the installation is complete, run *Keysight Connection Expert*, either from the right-click menu of the IO libraries taskbar icon or from the Windows start menu.
 
-  - Go to *Manual Configuration \> Add New Instruments/Interfaces*, click *Remote GPIB interface*, and change the default settings if necessary. The IP address is mandatory.
+   - Go to *Manual Configuration \> Edit Existing Instruments/Interfaces*. In the list, there should be an automatically created interface named "Lan Interface TCPIP0".
 
-  - Go to *Instruments*, and click *Rescan*. All instruments connected to the interface should start to appear.
+   - Go to *Manual Configuration \> Add New Instruments/Interfaces*, click *Remote GPIB interface*, and change the default settings if necessary. The IP address is mandatory.
 
-  - In the *Instruments* list, you can find the VISA addresses and SICL addresses of each device. These are the addresses to be used when you specify a device address in DataMiner.
+   - Go to *Instruments*, and click *Rescan*. All instruments connected to the interface should start to appear.
 
-  - If you want to set up VISA aliases, go to *Settings \> Aliases*. In DataMiner, these aliases can also be used as device address (VISA only).
+   - In the *Instruments* list, you can find the VISA addresses and SICL addresses of each device. These are the addresses to be used when you specify a device address in DataMiner.
+
+   - If you want to set up VISA aliases, go to *Settings \> Aliases*. In DataMiner, these aliases can also be used as device address (VISA only).
+
+1. Reboot the DataMiner server.
 
 > [!TIP]
 > See also: [GPIB connections](xref:GPIB_Connection)
@@ -47,16 +51,18 @@ The minimum version for the IO libraries is 17.1.20011.
 
 1. Right-click the blue IO icon in the Windows system tray, and select *Run IO Config*.
 
-1. In the *Available Interface Types* list on the left, select “\*LAN Client (LAN Instruments)”, and click *Configure*.
+1. In the *Available Interface Types* list on the left, select "\*LAN Client (LAN Instruments)", and click *Configure*.
 
-   *SICL Interface Name* contains the unique name of the LAN Client. The name of each LAN Client starts with the word “lan”, optionally followed by a number from 0 to 99. Note that you will have to enter this interface name when configuring a Spectrum Analyzer Element on the DataMiner Agent. See [GPIB connections](xref:GPIB_Connection).
+   *SICL Interface Name* contains the unique name of the LAN Client. The name of each LAN Client starts with the word "lan", optionally followed by a number from 0 to 99. Note that you will have to enter this interface name when configuring a Spectrum Analyzer Element on the DataMiner Agent. See [GPIB connections](xref:GPIB_Connection).
 
 1. In the *Default Protocol* box, specify the default protocol.
 
-   - Select “SICL-LAN” if the GPIB/LAN gateway uses the SICL-LAN protocol.
+   - Select "SICL-LAN" if the GPIB/LAN gateway uses the SICL-LAN protocol.
 
-   - Select “VXI-11 (TCP/IP Instrument Protocol)” if the GPIB/LAN gateway uses the TCP/IP Instrument protocol.
+   - Select "VXI-11 (TCP/IP Instrument Protocol)" if the GPIB/LAN gateway uses the TCP/IP Instrument protocol.
 
-   - Select “Auto” if you want the LAN Client to automatically detect the protocol being used.
+   - Select "Auto" if you want the LAN Client to automatically detect the protocol being used.
 
 1. Click *OK* to save the configuration.
+
+1. Restart DataMiner.


### PR DESCRIPTION
Keysight installation requires a restart of the machine to take full effect. Otherwise, SLPort won't find the dll even though the file is present in system32.

Add an alternative solution to fix the Keysight and NATS port problem.