### PR TITLE
Catalog readme guidelines

### DIFF
--- a/user-guide/Cloud_Platform/Catalog/Best_Practices_When_Documenting_Catalog_Items.md
+++ b/user-guide/Cloud_Platform/Catalog/Best_Practices_When_Documenting_Catalog_Items.md
@@ -7,4 +7,148 @@ uid: Best_Practices_When_Documenting_Catalog_Items
 On this page, you will find more information about writing documentation for your Catalog item. In order to have a consistent, clear and uniform Catalog, we recommend following the best practice.
 
 > [!IMPORTANT]
-> If you have discovered other solutions or workarounds while troubleshooting, feel free to [propose your changes](xref:CTB_Quick_Edit) to this guide.
+> Basic principle to follow: The Catalog should contain the sales pitch / value proposition for your Catalog item! Technical or detailed documentation should reside on another location.
+
+## Overview of the Catalog item structure
+
+When creating items for the DataMiner Catalog, focus on showcasing the value of each solution in a concise and engaging way, while keeping the technical details to a minimum. Follow this structure to ensure clarity and consistency:
+
+1. Overview
+1. Key Features
+1. Visuals
+   1. Note: Visual representations are not considered a seperate section but should be blended in the text.
+1. Optional: Use Cases
+1. Optional: Prerequisites
+1. Optional: Other Technical reference sections which potentially link to public docs.
+1. Support: Include a support sentence, e.g., "For additional help, reach out to support at [techsupport@skyline.be](mailto:techsupport@skyline.be).
+
+## Overview
+
+**Purpose:** Summarize the value proposition of the item, explaining why customers should deploy it. Address the problem it solves and its primary benefits.
+
+**Format:** 1 introductory paragraph with up to 3 supporting paragraphs, 3-4 sentences each.
+
+**Do's**
+
+- Begin with a concise **introductory paragraph** focused on the solution’s value.
+- Add **up to 3 additional paragraphs** elaborating on features or key use cases.
+- Keep the tone **professional**, focused on **motivating** user adoption.
+- Highlight important points with **bold text**.
+- **Organize content** from broad benefits to specific features and practical applications.
+- Use **accessible language** for both technical and non-technical readers.
+- Make use of visual **[Alerts](xref:CTB_Markdown_Syntax#alerts)** where applicable.
+
+**Don'ts**
+
+- Avoid **excessive technical detail**; link to reference documentation instead.
+- Refrain from jargon or **overly complex language** that could obscure the message.
+
+## Visuals
+
+**Purpose:** Enhance the text by showcasing a key feature or advantage with visuals. This is not an individual section, but should be part inline your Overview, Key Feature and Use Cases.
+
+**Format:** Supported formats (e.g., PNG, GIF, SVG) should be added to the ‘Images’ folder within the `manifest.zip` file.
+
+**Do's**
+
+- Include **up to 3 visuals** to support key points.
+- Ensure visuals are **clear, focused, and free from irrelevant elements**.
+  - When showing a table, make sure to hide irrelevant columns.
+  - Only show items that contribute and part of the Catalog item.
+- Maintain **high quality** resolution.
+- Keep GIFs **concise** (around 10 seconds) and **focused** on demonstrating a specific feature or action.
+- When creating GIFs, make sure to take sufficient **time between each click** or visual change so that the changes do not disturb the user too much.
+
+**Don'ts**
+
+- Only show DataMiner card **tabs** if necessary for understanding a feature.
+- Avoid blurry or pixelated visuals — **quality is key**.
+- Avoid **unnecessary open panels**, collapsing elements like the Alarm Console when they don’t add value.
+- Avoid **unnecessary blank space** by resizing your screen when taking a screen capture.
+- Make sure to not show any **confidential data** by pixelating or blurring the data. Keep data that is not sensitive to still have a good representation.
+
+## Key Features
+
+**Purpose:** **Product-centric**. Outline the main features that distinguish the item, focusing on functionality and unique benefits.
+
+**Format:** Maximum of 5 features, quality over quantity.
+
+**Do's**
+
+- Use direct, **benefit-oriented** language.
+- Ensure each feature relates to **customer value**.
+- Use **action verbs** (e.g., "Monitor," "Track").
+- Prioritize features that **differentiate** your solution.
+
+**Don'ts**
+
+- Avoid **excessive detail** or vague descriptors like "high-performance" without specific context.
+- Avoid adding key feature that **do not specifically relate to your solution**, but is general to DataMiner (e.g. The benefits of having alarms on your equipment which is exposed by a key feature of DataMiner, i.e. alarm templates.).
+
+## Use Cases
+
+> [!NOTE]
+> Depending on the size and complexity of your Catalog item, you can decide to blend (or exclude) some sections related to Overview, Key Features and Use Cases.
+
+**Purpose:** **Customer-centric**. Demonstrate practical, real-world scenarios where the solution provides value.
+
+**Format:** Provide a link to a [DOJO Use Case](https://community.dataminer.services/use-cases/) or include 2-3 bullet points.
+
+**Do's**
+
+- Connect examples to common **customer challenges** (e.g., remote connectivity, high data usage).
+- Use **specific, relatable examples**, such as “Monitor remote satellite terminals in real-time.”
+
+**Don'ts**
+
+- Avoid **hypothetical scenarios**; ensure examples are relevant to the typical user base, showing the value ot this solution.
+- Do not **duplicate** points covered in the **Key Features** section.
+
+## Prerequisites
+
+**Purpose:** List essential technical requirements needed for deployment.
+
+**Format:** 1-3 concise bullet points, limited to necessary information.
+
+**applicable requirements**:
+
+To most of the items below, you can evaluate if there is a maximum and/or minimum version.
+
+- DataMiner version
+- DxM version
+- Licenses (e.g. DOM, SRM)
+- Web version
+- DataMiner Cube version
+- Soft-Launch Flags
+- Requirements from components included in the package
+
+**Do's**
+
+- Clearly list **essential requirements** (e.g., software versions, API access).
+- Be direct and **specific** about version numbers, required permissions, or additional licenses needed for the solution to work.
+  - If there is a specific DataMiner version dependency, make sure to include **both main and feature release**. If the cumulative update of the Main Release is irrelevant, you can leave it away (e.g. DataMiner 10.2.5/10.3.0).
+
+**Don'ts**
+
+- Avoid **installation or configuration steps**; link to comprehensive documentation instead.
+- Avoid listing every **small technical dependency** — focus only on the essentials.
+- If the minimum version of the DataMiner version dependency of the Catalog Item is **below the current supported DataMiner version**, we should not bother including it.
+
+## Technical Reference
+
+**Purpose:** Direct users to detailed technical documentation, as the Catalog should focus on high-level information.
+
+**Format:** Link to technical documentation using the designated URL field in the manifest. Next to this, you can also use the [Note alert](xref:CTB_Markdown_Syntax#alerts) with a link within your description.
+
+**Do's**
+
+- Use **consistent** naming conventions, e.g., ‘Installing…’, 'Working with…'.
+- Use a **public Link** for additional technical resources (e.g. [docs.dataminer.services](https://docs.dataminer.services) for standard solution published by Skyline Communications).
+- Use aka links to link to docs.dataminer.services. This way, if something changes to the structure of the documentation, the links can easily be updated.
+
+**Don'ts**
+
+- Don't include tricks or flows that shouldn't be followed by the user.
+- Don't add **redundant information** that is available somewhere else.
+- Avoid documenting features that are **frequently changing** and not too important to document (e.g. UI).
+- Avoid listing every **small technical dependency** — focus only on the essentials.

--- a/user-guide/Cloud_Platform/Catalog/Best_Practices_When_Documenting_Catalog_Items.md
+++ b/user-guide/Cloud_Platform/Catalog/Best_Practices_When_Documenting_Catalog_Items.md
@@ -35,7 +35,7 @@ When you create documentation for an item in the DataMiner Catalog, focus on sho
 
 **Purpose:** Enhance the *Overview*, *Key Features*, and *Use Cases* sections where appropriate by showcasing key features or advantages with visuals.
 
-**Format:** Add the images to the *Images* folder within the `manifest.zip` file. For a list of the supported image formats, see [Registering a Catalog item](xref:Register_Catalog_Item#body)
+**Format:** Add the images to the *Images* folder within the `manifest.zip` file. For a list of the supported image formats, see [Registering a Catalog item](xref:Register_Catalog_Item#body).
 
 **Do's:**
 
@@ -53,7 +53,7 @@ When you create documentation for an item in the DataMiner Catalog, focus on sho
 - Avoid blurry or pixelated visuals — **quality is key**.
 - Avoid **unnecessary open panels**. Collapse panels like the Alarm Console if these do not add value.
 - Avoid **unnecessary blank space** by resizing the window when taking a screen capture.
-- Make sure not to show any **confidential data**. Blur any sensitive data, but keep the data that is not sensitive to still have a useful image.
+- Make sure not to show any **confidential data**. Blur any sensitive data, but keep the data that is not sensitive visible to still have a useful image.
 
 ## Overview section
 
@@ -74,7 +74,7 @@ When you create documentation for an item in the DataMiner Catalog, focus on sho
 **Don'ts:**
 
 - Avoid **excessive technical details**; link to reference documentation instead.
-- Refrain from jargon or **overly complex language** that could obscure the message.
+- Avoid jargon or **overly complex language** that could obscure the message.
 - Avoid **excessive** amounts of **bold text and/or alerts**, as these then lose their purpose of drawing the reader's attention.
 
 ## Key Features section
@@ -115,7 +115,7 @@ When you create documentation for an item in the DataMiner Catalog, focus on sho
 
 **Purpose:** List essential technical requirements needed for deployment.
 
-**Format:** Concise bullet points, limited to information that is strictly necessary.
+**Format:** Use concise bullet points, limited to information that is strictly necessary.
 
 **applicable requirements**:
 
@@ -139,7 +139,7 @@ For most of the items below, you can evaluate if there is a maximum and/or minim
 
 - Avoid **installation or configuration steps**. Link to comprehensive documentation instead.
 - Avoid listing every **small technical dependency**. Focus only on the essentials.
-- If the minimum required DataMiner version for the Catalog item is **below the currently supported DataMiner versions**, do not mention it.
+- If the minimum required DataMiner version for the Catalog item is **below the [currently supported DataMiner versions](xref:Software_support_life_cycles)**, do not mention it.
 
 ## Technical Reference section
 

--- a/user-guide/Cloud_Platform/Catalog/Best_Practices_When_Documenting_Catalog_Items.md
+++ b/user-guide/Cloud_Platform/Catalog/Best_Practices_When_Documenting_Catalog_Items.md
@@ -4,151 +4,158 @@ uid: Best_Practices_When_Documenting_Catalog_Items
 
 # Best practices when documenting Catalog items
 
-On this page, you will find more information about writing documentation for your Catalog item. In order to have a consistent, clear and uniform Catalog, we recommend following the best practice.
+On this page, you will find more information about writing documentation for your Catalog item. In order to have consistent, clear, and uniform documentation in the Catalog, we recommend following these best practices.
 
-> [!IMPORTANT]
-> Basic principle to follow: The Catalog should contain the sales pitch / value proposition for your Catalog item! Technical or detailed documentation should reside on another location.
+The main principle to keep in mind is that the documentation in the Catalog should be **attractive and clearly present the value** of the Catalog item. Technical and more detailed documentation should reside in another location.
 
-## Overview of the Catalog item structure
+## Catalog item documentation structure
 
-When creating items for the DataMiner Catalog, focus on showcasing the value of each solution in a concise and engaging way, while keeping the technical details to a minimum. Follow this structure to ensure clarity and consistency:
+When you create documentation for an item in the DataMiner Catalog, focus on showcasing the value of the item in a concise and engaging way, while keeping the technical details to a minimum. Use this structure to ensure clarity and consistency, and make sure to [include visuals](#visuals) in your text:
 
-1. Overview
-1. Key Features
-1. Visuals
-   1. Note: Visual representations are not considered a seperate section but should be blended in the text.
-1. Optional: Use Cases
-1. Optional: Prerequisites
-1. Optional: Other Technical reference sections which potentially link to public docs.
-1. Support: Include a support sentence, e.g., "For additional help, reach out to support at [techsupport@skyline.be](mailto:techsupport@skyline.be).
+1. [Overview](#overview-section)
 
-## Overview
+1. [Key Features](#key-features-section)
 
-**Purpose:** Summarize the value proposition of the item, explaining why customers should deploy it. Address the problem it solves and its primary benefits.
+1. [Use Cases](#use-cases-section) *(optional)*
 
-**Format:** 1 introductory paragraph with up to 3 supporting paragraphs, 3-4 sentences each.
+1. [Prerequisites](#prerequisites-section) *(optional)*
 
-**Do's**
+1. [Technical Reference](#technical-reference-section) *(optional)*
 
-- Begin with a concise **introductory paragraph** focused on the solution’s value.
+   Link to public documentation for more extensive info when necessary.
+
+1. Support
+
+   Include a support sentence, such as "For additional help, reach out to support at [techsupport@skyline.be](mailto:techsupport@skyline.be)".
+
+> [!NOTE]
+> Depending on the size and complexity of your Catalog item, you can combine or exclude some sections. For example, for a very simple item you could leave out the Use Cases section but mention this information under Key Features.
+
+## Visuals
+
+**Purpose:** Enhance the *Overview*, *Key Features*, and *Use Cases* sections where appropriate by showcasing key features or advantages with visuals.
+
+**Format:** Add the images to the *Images* folder within the `manifest.zip` file. For a list of the supported image formats, see [Registering a Catalog item](xref:Register_Catalog_Item#body)
+
+**Do's:**
+
+- Include **up to 3 visuals** to support key points.
+- Ensure visuals are **clear, focused, and free from irrelevant elements**.
+  - When showing a table, make sure to hide irrelevant columns.
+  - Only show items that are relevant for and clearly show the Catalog item.
+- Use **high-quality** resolution.
+- Keep GIFs **concise** (at most 10 seconds) and **focused** on demonstrating a specific feature or action.
+- When creating GIFs, make sure to take sufficient **time between each click** or visual change so that the changes do not disturb the user too much.
+
+**Don'ts:**
+
+- Only show DataMiner **card tabs** if necessary to help understand a feature.
+- Avoid blurry or pixelated visuals — **quality is key**.
+- Avoid **unnecessary open panels**. Collapse panels like the Alarm Console if these do not add value.
+- Avoid **unnecessary blank space** by resizing the window when taking a screen capture.
+- Make sure not to show any **confidential data**. Blur any sensitive data, but keep the data that is not sensitive to still have a useful image.
+
+## Overview section
+
+**Purpose:** Summarize what makes the item valuable and why users should deploy it. Address the problems it solves and its primary benefits.
+
+**Format:** One introductory paragraph with up to 3 supporting paragraphs, of 3 to 4 sentences each.
+
+**Do's:**
+
+- Begin with a concise **introductory paragraph** focused on the item’s value.
 - Add **up to 3 additional paragraphs** elaborating on features or key use cases.
 - Keep the tone **professional**, focused on **motivating** user adoption.
 - Highlight important points with **bold text**.
 - **Organize content** from broad benefits to specific features and practical applications.
 - Use **accessible language** for both technical and non-technical readers.
-- Make use of visual **[Alerts](xref:CTB_Markdown_Syntax#alerts)** where applicable.
+- Make use of visual **[alerts](xref:CTB_Markdown_Syntax#alerts)** where applicable.
 
-**Don'ts**
+**Don'ts:**
 
-- Avoid **excessive technical detail**; link to reference documentation instead.
+- Avoid **excessive technical details**; link to reference documentation instead.
 - Refrain from jargon or **overly complex language** that could obscure the message.
+- Avoid **excessive** amounts of **bold text and/or alerts**, as these then lose their purpose of drawing the reader's attention.
 
-## Visuals
-
-**Purpose:** Enhance the text by showcasing a key feature or advantage with visuals. This is not an individual section, but should be part inline your Overview, Key Feature and Use Cases.
-
-**Format:** Supported formats (e.g., PNG, GIF, SVG) should be added to the ‘Images’ folder within the `manifest.zip` file.
-
-**Do's**
-
-- Include **up to 3 visuals** to support key points.
-- Ensure visuals are **clear, focused, and free from irrelevant elements**.
-  - When showing a table, make sure to hide irrelevant columns.
-  - Only show items that contribute and part of the Catalog item.
-- Maintain **high quality** resolution.
-- Keep GIFs **concise** (around 10 seconds) and **focused** on demonstrating a specific feature or action.
-- When creating GIFs, make sure to take sufficient **time between each click** or visual change so that the changes do not disturb the user too much.
-
-**Don'ts**
-
-- Only show DataMiner card **tabs** if necessary for understanding a feature.
-- Avoid blurry or pixelated visuals — **quality is key**.
-- Avoid **unnecessary open panels**, collapsing elements like the Alarm Console when they don’t add value.
-- Avoid **unnecessary blank space** by resizing your screen when taking a screen capture.
-- Make sure to not show any **confidential data** by pixelating or blurring the data. Keep data that is not sensitive to still have a good representation.
-
-## Key Features
+## Key Features section
 
 **Purpose:** **Product-centric**. Outline the main features that distinguish the item, focusing on functionality and unique benefits.
 
-**Format:** Maximum of 5 features, quality over quantity.
+**Format:** Maximum of 5 features. Focus on those features that are most relevant for the user: quality over quantity.
 
-**Do's**
+**Do's:**
 
 - Use direct, **benefit-oriented** language.
-- Ensure each feature relates to **customer value**.
-- Use **action verbs** (e.g., "Monitor," "Track").
-- Prioritize features that **differentiate** your solution.
+- Ensure that each feature relates to **specific value** for the user.
+- Use **action verbs** (such as "Monitor", "Track", etc.).
+- Prioritize features that **differentiate** the item.
 
-**Don'ts**
+**Don'ts:**
 
 - Avoid **excessive detail** or vague descriptors like "high-performance" without specific context.
-- Avoid adding key feature that **do not specifically relate to your solution**, but is general to DataMiner (e.g. The benefits of having alarms on your equipment which is exposed by a key feature of DataMiner, i.e. alarm templates.).
+- Avoid adding key features that **do not specifically relate to the item**, but that are general to DataMiner (for example, the benefits of having alarms for your equipment, which is already a key feature of DataMiner itself).
 
-## Use Cases
+## Use Cases section
 
-> [!NOTE]
-> Depending on the size and complexity of your Catalog item, you can decide to blend (or exclude) some sections related to Overview, Key Features and Use Cases.
+**Purpose:** **User-centric**. Demonstrate practical, real-world scenarios where the solution provides value.
 
-**Purpose:** **Customer-centric**. Demonstrate practical, real-world scenarios where the solution provides value.
+**Format:** Provide a link to a [use case on DataMiner Dojo](https://community.dataminer.services/use-cases/) or include 2 or 3 bullet points summarizing use cases.
 
-**Format:** Provide a link to a [DOJO Use Case](https://community.dataminer.services/use-cases/) or include 2-3 bullet points.
+**Do's:**
 
-**Do's**
+- Connect examples to **common challenges** that users face (e.g. remote connectivity, high data usage).
+- Use **specific, relatable examples**, such as "Monitor remote satellite terminals in real-time".
 
-- Connect examples to common **customer challenges** (e.g., remote connectivity, high data usage).
-- Use **specific, relatable examples**, such as “Monitor remote satellite terminals in real-time.”
+**Don'ts:**
 
-**Don'ts**
-
-- Avoid **hypothetical scenarios**; ensure examples are relevant to the typical user base, showing the value ot this solution.
+- Avoid **hypothetical scenarios**. Make sure the examples are relevant to the typical user base, showing the value of the item.
 - Do not **duplicate** points covered in the **Key Features** section.
 
-## Prerequisites
+## Prerequisites section
 
 **Purpose:** List essential technical requirements needed for deployment.
 
-**Format:** 1-3 concise bullet points, limited to necessary information.
+**Format:** 1-3 concise bullet points, limited to information that is strictly necessary.
 
 **applicable requirements**:
 
-To most of the items below, you can evaluate if there is a maximum and/or minimum version.
+For most of the items below, you can evaluate if there is a maximum and/or minimum version.
 
 - DataMiner version
 - DxM version
-- Licenses (e.g. DOM, SRM)
+- Licenses (for example, DOM, SRM)
 - Web version
 - DataMiner Cube version
-- Soft-Launch Flags
-- Requirements from components included in the package
+- Soft-launch options
+- Requirements for components included in the package
 
-**Do's**
+**Do's:**
 
-- Clearly list **essential requirements** (e.g., software versions, API access).
-- Be direct and **specific** about version numbers, required permissions, or additional licenses needed for the solution to work.
-  - If there is a specific DataMiner version dependency, make sure to include **both main and feature release**. If the cumulative update of the Main Release is irrelevant, you can leave it away (e.g. DataMiner 10.2.5/10.3.0).
+- Clearly list **essential requirements** (for example, software versions, API access).
+- Be direct and **specific** about version numbers, required permissions, or additional licenses needed for the item to work.
+- If there is a specific DataMiner version dependency, make sure to include **both Main and Feature Release**. If the cumulative update of the Main Release is irrelevant, you can leave it out (e.g. "DataMiner 10.2.5/10.3.0").
 
-**Don'ts**
+**Don'ts:**
 
-- Avoid **installation or configuration steps**; link to comprehensive documentation instead.
-- Avoid listing every **small technical dependency** — focus only on the essentials.
-- If the minimum version of the DataMiner version dependency of the Catalog Item is **below the current supported DataMiner version**, we should not bother including it.
+- Avoid **installation or configuration steps**. Link to comprehensive documentation instead.
+- Avoid listing every **small technical dependency**. Focus only on the essentials.
+- If the minimum required DataMiner version for the Catalog item is **below the currently supported DataMiner versions**, do not mention it.
 
-## Technical Reference
+## Technical Reference section
 
-**Purpose:** Direct users to detailed technical documentation, as the Catalog should focus on high-level information.
+**Purpose:** Provide links to detailed technical documentation, as the Catalog should focus on high-level information only.
 
-**Format:** Link to technical documentation using the designated URL field in the manifest. Next to this, you can also use the [Note alert](xref:CTB_Markdown_Syntax#alerts) with a link within your description.
+**Format:** Link to technical documentation using the designated URL field in the manifest. If relevant, use a ["Note" alert](xref:CTB_Markdown_Syntax#alerts) with a link in your description.
 
-**Do's**
+**Do's:**
 
-- Use **consistent** naming conventions, e.g., ‘Installing…’, 'Working with…'.
-- Use a **public Link** for additional technical resources (e.g. [docs.dataminer.services](https://docs.dataminer.services) for standard solution published by Skyline Communications).
-- Use aka links to link to docs.dataminer.services. This way, if something changes to the structure of the documentation, the links can easily be updated.
+- Use **consistent** naming conventions, such as "Installing ...", "Working with ...".
+- Use a **public link** for additional technical resources (e.g. [docs.dataminer.services](https://docs.dataminer.services) for standard solutions published by Skyline Communications).
+- If you link to docs.dataminer.services as a Skyline employee, use "aka" redirect links. This way, if something changes to the structure of the documentation, the links can easily be updated.
 
-**Don'ts**
+**Don'ts:**
 
-- Don't include tricks or flows that shouldn't be followed by the user.
-- Don't add **redundant information** that is available somewhere else.
-- Avoid documenting features that are **frequently changing** and not too important to document (e.g. UI).
-- Avoid listing every **small technical dependency** — focus only on the essentials.
+- Do not include procedures that should not be followed by the user.
+- Do not add **redundant information** that is already available somewhere else. If relevant, link to that information instead.
+- Avoid documenting features that **change frequently** and are not that important to document (e.g. UI).
+- Avoid listing every **small technical dependency**. Focus only on the essentials.

--- a/user-guide/Cloud_Platform/Catalog/Best_Practices_When_Documenting_Catalog_Items.md
+++ b/user-guide/Cloud_Platform/Catalog/Best_Practices_When_Documenting_Catalog_Items.md
@@ -115,7 +115,7 @@ When you create documentation for an item in the DataMiner Catalog, focus on sho
 
 **Purpose:** List essential technical requirements needed for deployment.
 
-**Format:** 1-3 concise bullet points, limited to information that is strictly necessary.
+**Format:** Concise bullet points, limited to information that is strictly necessary.
 
 **applicable requirements**:
 

--- a/user-guide/Cloud_Platform/Catalog/Best_Practices_When_Documenting_Catalog_Items.md
+++ b/user-guide/Cloud_Platform/Catalog/Best_Practices_When_Documenting_Catalog_Items.md
@@ -1,0 +1,10 @@
+---
+uid: Best_Practices_When_Documenting_Catalog_Items
+---
+
+# Best practices when documenting Catalog items
+
+On this page, you will find more information about writing documentation for your Catalog item. In order to have a consistent, clear and uniform Catalog, we recommend following the best practice.
+
+> [!IMPORTANT]
+> If you have discovered other solutions or workarounds while troubleshooting, feel free to [propose your changes](xref:CTB_Quick_Edit) to this guide.

--- a/user-guide/Cloud_Platform/Catalog/Register_Catalog_Item.md
+++ b/user-guide/Cloud_Platform/Catalog/Register_Catalog_Item.md
@@ -45,14 +45,14 @@ The value of this key should be a .zip file containing the following items:
 
 - A *README.md* file containing the description of the Catalog item (optional).
 
+  > [!TIP]
+  > See also: [Best practices when documenting Catalog items](xref:Best_Practices_When_Documenting_Catalog_Items).
+
 - An *images* folder containing any image referenced in the readme file (optional). Supported image extensions are .jpg, .jpeg, .png, .gif, .bmp, .tif, .tiff, and .webp.
 
 ```json
 file: <the zip file containing manifest, README and optional images>
 ```
-
-> [!TIP]
-> In order to write the documentation for your Catalog item (i.e. README file), feel free to check out the [best practices](xref:Best_Practices_When_Documenting_Catalog_Items).
 
 > [!NOTE]
 > To reference images in the README.md file, you can use the home directory (~/images) or relative path syntax (./images).

--- a/user-guide/Cloud_Platform/Catalog/Register_Catalog_Item.md
+++ b/user-guide/Cloud_Platform/Catalog/Register_Catalog_Item.md
@@ -51,6 +51,9 @@ The value of this key should be a .zip file containing the following items:
 file: <the zip file containing manifest, README and optional images>
 ```
 
+> [!TIP]
+> In order to write the documentation for your Catalog item (i.e. README file), feel free to check out the [best practices](xref:Best_Practices_When_Documenting_Catalog_Items).
+
 > [!NOTE]
 > To reference images in the README.md file, you can use the home directory (~/images) or relative path syntax (./images).
 

--- a/user-guide/Cloud_Platform/Catalog/Tutorials/Tutorial_Register_Catalog_Item.md
+++ b/user-guide/Cloud_Platform/Catalog/Tutorials/Tutorial_Register_Catalog_Item.md
@@ -71,6 +71,9 @@ The Catalog item register API call is authenticated using an [organization key](
      This Catalog item has been made available as part of the [Catalog registration tutorial](https://docs.dataminer.services/tutorials/Tutorials.html)
      ```
 
+    > [!TIP]
+    > In order to write the documentation for your Catalog item (i.e. README file), feel free to check out the [best practices](xref:Best_Practices_When_Documenting_Catalog_Items).
+
    - Optionally, if you want to use images in the readme, an images folder containing those images.
 
    - A *manifest.yml* file describing the properties of the Catalog item.

--- a/user-guide/Cloud_Platform/Catalog/Tutorials/Tutorial_Register_Catalog_Item.md
+++ b/user-guide/Cloud_Platform/Catalog/Tutorials/Tutorial_Register_Catalog_Item.md
@@ -71,8 +71,8 @@ The Catalog item register API call is authenticated using an [organization key](
      This Catalog item has been made available as part of the [Catalog registration tutorial](https://docs.dataminer.services/tutorials/Tutorials.html)
      ```
 
-    > [!TIP]
-    > In order to write the documentation for your Catalog item (i.e. README file), feel free to check out the [best practices](xref:Best_Practices_When_Documenting_Catalog_Items).
+     > [!TIP]
+     > See also: [Best practices when documenting Catalog items](xref:Best_Practices_When_Documenting_Catalog_Items).
 
    - Optionally, if you want to use images in the readme, an images folder containing those images.
 

--- a/user-guide/Cloud_Platform/toc.yml
+++ b/user-guide/Cloud_Platform/toc.yml
@@ -67,6 +67,8 @@ items:
     topicUid: Register_Catalog_Item
   - name: Deploying a Catalog item
     topicUid: Deploying_a_catalog_item
+  - name: Best practices when documenting Catalog items
+    topicUid: Best_Practices_When_Documenting_Catalog_Items
   - name: Tutorials
     items:
     - name: Registering a new connector in the Catalog

--- a/user-guide/Cloud_Platform/toc.yml
+++ b/user-guide/Cloud_Platform/toc.yml
@@ -65,10 +65,11 @@ items:
     topicUid: Looking_up_an_item_in_the_catalog
   - name: Registering a Catalog item
     topicUid: Register_Catalog_Item
+    items:
+    - name: Best practices when documenting Catalog items
+      topicUid: Best_Practices_When_Documenting_Catalog_Items
   - name: Deploying a Catalog item
     topicUid: Deploying_a_catalog_item
-  - name: Best practices when documenting Catalog items
-    topicUid: Best_Practices_When_Documenting_Catalog_Items
   - name: Tutorials
     items:
     - name: Registering a new connector in the Catalog


### PR DESCRIPTION
Added best practice based on [Catalog Documentation Guidelines](https://skylinebe.sharepoint.com/sites/DeployandAccelerate/SitePages/Catalog%20Documentation%20Guidelines.aspx?csf=1&web=1&share=EQWtIMFWhuhOp0-MVP_lA50BigZWpFjKaPkl2TlHtzM3oA&e=oZFz33&CID=13b104b1-48da-435c-92fa-fb2a925af703). This targets mainly writing the readme and no other fields from the Manifest.yml.