### PR TITLE
Update MOP_Migrating_a_Failover_pair_to_new_hardware.md

### DIFF
--- a/user-guide/Reference/MOPs/MOP_Migrating_a_Failover_pair_to_new_hardware.md
+++ b/user-guide/Reference/MOPs/MOP_Migrating_a_Failover_pair_to_new_hardware.md
@@ -2,9 +2,9 @@
 uid: MOP_Migrating_a_Failover_pair_to_new_hardware
 ---
 
-# Migrating a Failover pair to new hardware
+# Migrating a Failover pair to new hardware to an existing cluster
 
-The procedure below details how you can migrate a pair of Failover DMAs to new hardware. After the procedure, both DMAs should be running just like before, but on new servers.
+The procedure below details how you can migrate a pair of Failover DMAs to new hardware in an existing cluster consisting of multiple agents. After the procedure, both DMAs should be running just like before, but on new servers.
 
 ## Requirements
 

--- a/user-guide/Reference/MOPs/MOP_Migrating_a_Failover_pair_to_new_hardware.md
+++ b/user-guide/Reference/MOPs/MOP_Migrating_a_Failover_pair_to_new_hardware.md
@@ -2,9 +2,9 @@
 uid: MOP_Migrating_a_Failover_pair_to_new_hardware
 ---
 
-# Migrating a Failover pair to new hardware to an existing cluster
+# Migrating a Failover pair to new hardware in an existing cluster
 
-The procedure below details how you can migrate a pair of Failover DMAs to new hardware in an existing cluster consisting of multiple agents. After the procedure, both DMAs should be running just like before, but on new servers.
+The procedure below details how you can migrate a pair of Failover DMAs to new hardware in an existing cluster consisting of multiple Agents. After the procedure, both DMAs should be running just like before, but on new servers.
 
 ## Requirements
 


### PR DESCRIPTION
The procedure assumes users are migrating Failover pair to an existing cluster. It was not clear and a user with a single failover pair followed these procedure and tried to remove his agent from the cluster when it was not necessary.  I updated the title and description based on steps: 2,6 and 7.