### PR TITLE
Update Upgrading_a_DataMiner_Agent_in_System_Center.md

### DIFF
--- a/user-guide/Advanced_Functionality/DataMiner_Agents/Upgrading_a_DMA/Upgrading_a_DataMiner_Agent_in_System_Center.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Agents/Upgrading_a_DMA/Upgrading_a_DataMiner_Agent_in_System_Center.md
@@ -37,6 +37,10 @@ Proceed as follows to upgrade your DataMiner Agent(s) in System Center:
 
    - To upgrade one or more individual Agents, select *Individual Agents* and expand the *DataMiner Agents* section to select the Agents or add them by entering an external IP.
 
+   > [!NOTE]
+   >
+   > If you choose to upgrade one or more individual Agents, please, make sure you have only one agent orchestrating the upgrade. If you are upgrading a group of agents, wait until the upgrade is completed, only then you can trigger a new group or agent to upgrade.
+
 1. If you do not want to use the default upgrade options settings, expand the *Advanced upgrade options* section and select the necessary upgrade options. For more information on these, options, see [default upgrade options](xref:Configuring_the_default_upgrade_options).
 
 1. If you do not want to use the default policy for Agents in a Failover setup, open the section *Advanced Failover options* and select the Failover policy, which determines in what order the DMAs are upgraded. The following options are available:


### PR DESCRIPTION
only one agent can be the orchestrator of the upgrade (based on SLA1 from Speedcast)