### PR TITLE
View and parameter grouping should be switched before starting the exercise

### DIFF
--- a/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features/Tutorials/Incident_Tracking_Configuration_Tutorial.md
+++ b/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features/Tutorials/Incident_Tracking_Configuration_Tutorial.md
@@ -238,7 +238,7 @@ It is not possible to use the *ParentNode* alarm property from the previous step
 
    1. Open the *configuration.xml* file.
 
-   1. Make sure that parameter and view grouping is disabled as explained in [step 4](##step-4-switch-off-parameter-and-view-grouping).
+   1. Make sure that parameter and view grouping is disabled as explained in [step 4](#step-4-switch-off-parameter-and-view-grouping).
 
    1. Scroll down to the *GenericProperties* property.
 

--- a/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features/Tutorials/Incident_Tracking_Configuration_Tutorial.md
+++ b/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features/Tutorials/Incident_Tracking_Configuration_Tutorial.md
@@ -238,6 +238,8 @@ It is not possible to use the *ParentNode* alarm property from the previous step
 
    1. Open the *configuration.xml* file.
 
+   1. Make sure that parameter and view grouping is disabled as explained in [step 4](##step-4-switch-off-parameter-and-view-grouping).
+
    1. Scroll down to the *GenericProperties* property.
 
       ![Grouping on custom property](~/user-guide/images/customPropertyGrouping.png)


### PR DESCRIPTION
Three users have currently submitted the exercise, but they all made the same "mistake". It seems it was not clear that they should have performed what is mentioned in section 4 before going to the exercise. This is now explicitly mentioned.