### PR TITLE
Update trending type to not trigger warning

### DIFF
--- a/develop/devguide/Connector/MonitoringTrending.md
+++ b/develop/devguide/Connector/MonitoringTrending.md
@@ -37,8 +37,8 @@ The following trend types can be defined in addition to the default average:
 <Display>
    <RTDisplay>true</RTDisplay>
    <Trending>
-      <Type>MAX</Type>
-</Trending>
+      <Type>max</Type>
+    </Trending>
 </Display>
 <Alarm>
    <Monitored>true</Monitored>


### PR DESCRIPTION
The provided trending type `MAX` triggered a warning:
<img width="220" alt="image" src="https://github.com/user-attachments/assets/d4984ed2-28aa-4e1c-b0bd-2b51bfa25646" />
In the meantime I also fixed the indentation of the closing tag.