### PR TITLE
Added warning about possible deadlocks with DOM actions

### DIFF
--- a/user-guide/Advanced_Modules/DOM/DOM_actions.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_actions.md
@@ -34,12 +34,12 @@ This action can be used to execute a specified script. This has the following pr
 > - Prior to DataMiner versions 10.5.0/10.5.2<!-- RN 41536 -->, a "Script started" information event is generated when the configured script is launched. To reduce the load on the database, this no longer happens from those DataMiner versions onwards.
 
 > [!CAUTION]
-> To prevent deadlock situations in the SLAutomation module, it is generally recommended to avoid triggering DOM actions of this kind from other automation scripts. A deadlock can occur in the following scenario:
-> - A DOM action script is configured to run synchronously (`Async` property set to `false`)
-> - That DOM action script needs to interact with the SLNet API (this is the case when using most helpers, sending SLNet messages...)
+> To prevent deadlock situations in the SLAutomation module, avoid triggering DOM actions of this kind from other Automation scripts. A deadlock can occur in the following scenario:
 >
-> If triggering a DOM action is necessarry from a scipt, try to trigger it asynchronously or ensure that the DOM action sript does not need to interact with the SLNet API.
-> It may also be better to trigger the script directly as a subscript.
+> - A DOM action script is configured to run synchronously (`Async` property set to `false`).
+> - That DOM action script needs to interact with the SLNet API (this is the case when using most helpers, sending SLNet messages, etc.).
+>
+> If triggering a DOM action from a script is necessary, try to trigger it asynchronously or ensure that the DOM action script does not need to interact with the SLNet API. It may also be better to trigger the script directly as a subscript.
 
 The scripts that will be executed using this action require a custom entry point of type "OnDomAction". This entry point method should have the `IEngine` object as it first argument, and an `ExecuteScriptDomActionContext` object as its second object. A script with this entry point can look like this:
 

--- a/user-guide/Advanced_Modules/DOM/DOM_actions.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_actions.md
@@ -33,6 +33,14 @@ This action can be used to execute a specified script. This has the following pr
 > - If no condition is defined (null), the action can always be executed.
 > - Prior to DataMiner versions 10.5.0/10.5.2<!-- RN 41536 -->, a "Script started" information event is generated when the configured script is launched. To reduce the load on the database, this no longer happens from those DataMiner versions onwards.
 
+> [!CAUTION]
+> To prevent deadlock situations in the SLAutomation module, it is generally recommended to avoid triggering DOM actions of this kind from other automation scripts. A deadlock can occur in the following scenario:
+> - A DOM action script is configured to run synchronously (`Async` property set to `false`)
+> - That DOM action script needs to interact with the SLNet API (this is the case when using most helpers, sending SLNet messages...)
+>
+> If triggering a DOM action is necessarry from a scipt, try to trigger it asynchronously or ensure that the DOM action sript does not need to interact with the SLNet API.
+> It may also be better to trigger the script directly as a subscript.
+
 The scripts that will be executed using this action require a custom entry point of type "OnDomAction". This entry point method should have the `IEngine` object as it first argument, and an `ExecuteScriptDomActionContext` object as its second object. A script with this entry point can look like this:
 
 ```csharp


### PR DESCRIPTION
When you configure a DOM action that triggers and automation script, there is a chance that deadlocks occur in SLAutomation if you trigger the DOM actions via another script. This is because the DOM action trigger request is a SLNet API call, which uses one of the 10 available slots of the SLAutomation connection to SLNet. As long as the DOM action script is running, that slot is taken up. If the DOM action script then sends an SLNet request as well, another slot is needed. If all 10 slots have been taken up by DOM action trigger requests, the action scripts themselves will have to wait forever, as there won't be a slot freed anymore.