### PR TITLE
Note on reboot 10.5.0/10.5.2

### DIFF
--- a/release-notes/General/General_Feature_Release_10.5/General_Feature_Release_10.5.1.md
+++ b/release-notes/General/General_Feature_Release_10.5/General_Feature_Release_10.5.1.md
@@ -7,9 +7,6 @@ uid: General_Feature_Release_10.5.1
 > [!NOTE]
 > For known issues with this version, refer to [Known issues](xref:Known_issues).
 
-> [!IMPORTANT]
-> When downgrading from DataMiner Feature Release version 10.3.8 (or higher) to DataMiner Feature Release version 10.3.4, 10.3.5, 10.3.6 or 10.3.7, an extra manual step has to be performed. For more information, see [Downgrading a DMS](xref:MOP_Downgrading_a_DMS).
-
 > [!TIP]
 >
 > - For release notes related to DataMiner Cube, see [DataMiner Cube Feature Release 10.5.1](xref:Cube_Feature_Release_10.5.1).

--- a/release-notes/General/General_Feature_Release_10.5/General_Feature_Release_10.5.2.md
+++ b/release-notes/General/General_Feature_Release_10.5/General_Feature_Release_10.5.2.md
@@ -8,7 +8,13 @@ uid: General_Feature_Release_10.5.2
 > We are still working on this release. Some release notes may still be modified or moved to a later release. Check back soon for updates!
 
 > [!IMPORTANT]
-> When downgrading from DataMiner Feature Release version 10.3.8 (or higher) to DataMiner Feature Release version 10.3.4, 10.3.5, 10.3.6 or 10.3.7, an extra manual step has to be performed. For more information, see [Downgrading a DMS](xref:MOP_Downgrading_a_DMS).
+>
+> Before you upgrade to this DataMiner version, make sure **version 14.40.33816** or higher of the **Microsoft Visual C++ x86/x64 redistributables** is installed. Otherwise, the upgrade will trigger an **automatic reboot** of the DMA in order to complete the installation.
+>
+> The latest version of the redistributables can be downloaded from the [Microsoft website](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version):
+>
+> - [vc_redist.x86.exe](https://aka.ms/vs/17/release/vc_redist.x86.exe)
+> - [vc_redist.x64.exe](https://aka.ms/vs/17/release/vc_redist.x64.exe)
 
 > [!TIP]
 >

--- a/release-notes/General/General_Main_Release_10.5/General_Main_Release_10.5.0.md
+++ b/release-notes/General/General_Main_Release_10.5/General_Main_Release_10.5.0.md
@@ -7,6 +7,14 @@ uid: General_Main_Release_10.5.0
 > [!IMPORTANT]
 > We are still working on this release. Some release notes may still be modified or moved to a later release. Check back soon for updates!
 
+> [!IMPORTANT]
+> Before you upgrade to this DataMiner version, make sure **version 14.40.33816** or higher of the **Microsoft Visual C++ x86/x64 redistributables** is installed. Otherwise, the upgrade will trigger an **automatic reboot** of the DMA in order to complete the installation.
+>
+> The latest version of the redistributables can be downloaded from the [Microsoft website](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version):
+>
+> - [vc_redist.x86.exe](https://aka.ms/vs/17/release/vc_redist.x86.exe)
+> - [vc_redist.x64.exe](https://aka.ms/vs/17/release/vc_redist.x64.exe)
+
 > [!TIP]
 >
 > - For release notes related to DataMiner Cube, see [DataMiner Cube 10.5.0](xref:Cube_Main_Release_10.5.0).


### PR DESCRIPTION
Added a note to warn users of the automatic reboot that will happen if they install 10.5.0/10.5.2 when prerequisites are not met. Also removed obsolete note from 10.5.1 and 10.5.2.