### PR TITLE
Added important note about DOM editor versions

### DIFF
--- a/user-guide/Advanced_Modules/DOM/DOM_DevOps/DOM_DevOps_installation.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_DevOps/DOM_DevOps_installation.md
@@ -24,4 +24,4 @@ uid: DOM_DevOps_installation
    > For example, package version 10.3.3.x requires at least DataMiner 10.3.3, and package 10.4.1.x requires at least DataMiner 10.4.1.
 
    > [!IMPORTANT]
-   > It is recommended that the DOM Editor version matches as close as possible to the DataMiner agent version. When using an old script version on a much newer DMA, there is a risk where the configuration of DOM features added inbetween these two version could get corrupted by the use of the old DOM Editor tool.
+   > Make sure your DOM Editor version matches the DataMiner Agent version as closely as possible. If you use an outdated DOM Editor version on a more recent DMA, the configuration of DOM features that have been added in the meantime could get corrupted.

--- a/user-guide/Advanced_Modules/DOM/DOM_DevOps/DOM_DevOps_installation.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_DevOps/DOM_DevOps_installation.md
@@ -22,3 +22,6 @@ uid: DOM_DevOps_installation
    > To deploy the tool, pick the version that matches your DataMiner System. The versioning of the tools package indicates which **minimum version** of DataMiner is required.
    >
    > For example, package version 10.3.3.x requires at least DataMiner 10.3.3, and package 10.4.1.x requires at least DataMiner 10.4.1.
+
+   > [!IMPORTANT]
+   > It is recommended that the DOM Editor version matches as close as possible to the DataMiner agent version. When using an old script version on a much newer DMA, there is a risk where the configuration of DOM features added inbetween these two version could get corrupted by the use of the old DOM Editor tool.


### PR DESCRIPTION
With this note, I want to warn about the potential risk where DOM configuration could break if you use a DOM editor version that is a lot older than your DataMiner agent version. It is always recommended to update the script to the version that either exactly matches the DataMiner version, or the most recent available right before that version. (Never after, since that may include features not available on the DMA)