### PR TITLE
Add a warning about Incident Tracking temporarily not working correctly after clustering

### DIFF
--- a/user-guide/Advanced_Functionality/DataMiner_Systems/Adding_a_DataMiner_Agent_to_a_DataMiner_System.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Systems/Adding_a_DataMiner_Agent_to_a_DataMiner_System.md
@@ -16,7 +16,6 @@ More information on adding DataMiner Agents is included in the following section
 >
 > - In most cases, when you add a DataMiner Agent to a DataMiner System, all other DataMiner Agents in the DataMiner System will connect to it using its primary IP address. However, in case e.g. NAT (Network Address Translation) is being used, you have to configure the connection strings by hand. See [Editing the connection string between two DataMiner Agents](xref:SLNetClientTest_editing_connection_string).
 > - If a [manual configuration was forced for NATS](xref:SLNetClientTest_disabling_automatic_nats_config) with the *NATSForceManualConfig* option in *MaintenanceSettings.xml*, you will need to manually adjust your NATS configuration with the added DMA.
-> - After adding a DataMiner Agent to a DMS, incidents created by Incident Tracking will temporarily be shown correctly for up to 30 minutes. If needed, this can be fixed sooner by manually changing the *Leader DataMiner ID* in the configuration, see [Automatic incident tracking configuration in System Center](xref:Automatic_incident_tracking#automatic-incident-tracking-configuration-in-system-center).
 
 > [!WARNING]
 > If you add a DataMiner Agent to a DataMiner System, please make sure that it is a new DataMiner Agent that has not yet been put into use and that uses the same software version as the other Agents in the system.

--- a/user-guide/Advanced_Functionality/DataMiner_Systems/Adding_a_DataMiner_Agent_to_a_DataMiner_System.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Systems/Adding_a_DataMiner_Agent_to_a_DataMiner_System.md
@@ -16,6 +16,7 @@ More information on adding DataMiner Agents is included in the following section
 >
 > - In most cases, when you add a DataMiner Agent to a DataMiner System, all other DataMiner Agents in the DataMiner System will connect to it using its primary IP address. However, in case e.g. NAT (Network Address Translation) is being used, you have to configure the connection strings by hand. See [Editing the connection string between two DataMiner Agents](xref:SLNetClientTest_editing_connection_string).
 > - If a [manual configuration was forced for NATS](xref:SLNetClientTest_disabling_automatic_nats_config) with the *NATSForceManualConfig* option in *MaintenanceSettings.xml*, you will need to manually adjust your NATS configuration with the added DMA.
+> - After adding a DataMiner Agent to a DMS, incidents created by Incident Tracking will temporarily be shown correctly for up to 30 minutes. If needed, this can be fixed sooner by manually changing the *Leader DataMiner ID* in the configuration, see [Automatic incident tracking configuration in System Center](xref:Automatic_incident_tracking#automatic-incident-tracking-configuration-in-system-center).
 
 > [!WARNING]
 > If you add a DataMiner Agent to a DataMiner System, please make sure that it is a new DataMiner Agent that has not yet been put into use and that uses the same software version as the other Agents in the system.

--- a/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features/Automatic_incident_tracking.md
+++ b/user-guide/Basic_Functionality/Alarms/Working_with_alarms/Advanced_analytics_features/Automatic_incident_tracking.md
@@ -51,6 +51,7 @@ The grouping of alarms into incidents is updated in real time whenever appropria
 >
 > - Using automatic incident tracking with history sets is supported; however, keep in mind that this may trigger the creation and immediate clearing of a large number of alarm groups.
 > - When an element is stopped or paused, the alarms associated with that element will not be taken into account when grouping alarms. Also, alarms associated with elements that are stopped or paused will be removed from any existing alarm group.
+> - After a [DataMiner Agent is added to a DMS](xref:Adding_a_DataMiner_Agent_to_a_DataMiner_System), incidents created by automatic incident tracking will temporarily be shown incorrectly. This issue will automatically be resolved within 30 minutes, but you can also manually fix this sooner by changing the *Leader DataMiner ID* in the [automatic incident tracking configuration in System Center](xref:Automatic_incident_tracking#automatic-incident-tracking-configuration-in-system-center).
 
 > [!TIP]
 > It is possible to manually customize alarm grouping. See [Customizing alarm grouping rules](xref:Customizing_alarm_grouping_rules).


### PR DESCRIPTION
Cfr. RN41836, I added a note about Incident Tracking temporarily not showing groups after adding a new agent to a cluster. Not sure this is the correct place to add it, so feel free to put it somewhere else if needed.