### PR TITLE
GQI DxM - Configuration - Remove unnecessary logging configuration

### DIFF
--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/GQI_Logging.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/GQI/GQI_Logging.md
@@ -66,12 +66,6 @@ Add the following configuration:
 
 ```json
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Debug",
-      "Microsoft": "Information"
-    }
-  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Debug",


### PR DESCRIPTION
See [RN42075: GQI - Configuration - Remove obsolete configuration for the .NET Core logging provider](https://intranet.skyline.be/DataMiner/Lists/Release%20Notes/DispForm2.aspx?ID=42075).