### PR TITLE
Update KI_LDAP_users_unable_to_log_in_after_upgrade.md

### DIFF
--- a/user-guide/Troubleshooting/Known_issues/KI_LDAP_users_unable_to_log_in_after_upgrade.md
+++ b/user-guide/Troubleshooting/Known_issues/KI_LDAP_users_unable_to_log_in_after_upgrade.md
@@ -16,7 +16,7 @@ This issue occurs on LDAP servers where `CN=CONTOSA,CN=Partitions,CN=Configurati
 
 ## Fix
 
-1. Check the logging in *ActiveDirectory.txt* (in the `C:\Skyline DataMiner\Logging folder`) to check whether the LDAP server returns `0x00005012` (S_ADS_NOMORE_ROWS) or `0x80072030` (ERROR_DS_NO_SUCH_OBJECT). If either of these two are present, install DataMiner 10.4.0 [CU12], 10.5.0, or 10.5.2.<!--RN 41339-->
+1. Install DataMiner 10.4.0 [CU12], 10.5.0, or 10.5.2.<!--RN 41339-->
 
 1. Wait up to an hour for LDAP synchronization to occur, or manually trigger the `Skyline DataMiner LDAP Resync` task in Windows Task Scheduler.
 
@@ -53,6 +53,8 @@ This issue occurs on LDAP servers where `CN=CONTOSA,CN=Partitions,CN=Configurati
   ```
 
   If the number of `Total rows` is 0, the issue is present.
+
+  In some cases, it can occur that the LDAP server returns `0x00005012` (S_ADS_NOMORE_ROWS) instead of `0x80072030` (ERROR_DS_NO_SUCH_OBJECT). The error is also present in such cases.
 
 - **After an upgrade**:
 

--- a/user-guide/Troubleshooting/Known_issues/KI_LDAP_users_unable_to_log_in_after_upgrade.md
+++ b/user-guide/Troubleshooting/Known_issues/KI_LDAP_users_unable_to_log_in_after_upgrade.md
@@ -6,11 +6,9 @@ uid: KI_LDAP_users_unable_to_log_in_after_upgrade
 
 ## Affected versions
 
-- Main Release versions from DataMiner 10.4.0 [CU4] to 10.4.0 [CU9]
+- Main Release versions from DataMiner 10.4.0 [CU4] to 10.4.0 [CU11]
 
-- Feature Release versions from DataMiner 10.4.7 to 10.4.12
-
-- Depending on the message returned by the LDAP server, DataMiner versions prior to 10.4.0 [CU12]/10.5.2 may also be affected (see [Fix](#fix)).
+- Feature Release versions from DataMiner 10.4.7 to 10.5.1
 
 ## Cause
 
@@ -18,11 +16,7 @@ This issue occurs on LDAP servers where `CN=CONTOSA,CN=Partitions,CN=Configurati
 
 ## Fix
 
-1. Check the logging in *ActiveDirectory.txt* (in the `C:\Skyline DataMiner\Logging folder`) to check whether the LDAP server returns `0x00005012` (S_ADS_NOMORE_ROWS) or `0x80072030` (ERROR_DS_NO_SUCH_OBJECT):
-
-   - If you see `0x80072030`, install DataMiner 10.4.0 [CU10], 10.5.0, or 10.5.1.<!--RN 41143-->
-
-   - If you see `0x00005012`, install DataMiner 10.4.0 [CU12], 10.5.0, or 10.5.2.<!--RN 41339-->
+1. Check the logging in *ActiveDirectory.txt* (in the `C:\Skyline DataMiner\Logging folder`) to check whether the LDAP server returns `0x00005012` (S_ADS_NOMORE_ROWS) or `0x80072030` (ERROR_DS_NO_SUCH_OBJECT). If either of these two are present, install DataMiner 10.4.0 [CU12], 10.5.0, or 10.5.2.<!--RN 41339-->
 
 1. Wait up to an hour for LDAP synchronization to occur, or manually trigger the `Skyline DataMiner LDAP Resync` task in Windows Task Scheduler.
 

--- a/user-guide/Troubleshooting/Known_issues/Known_issues.md
+++ b/user-guide/Troubleshooting/Known_issues/Known_issues.md
@@ -18,7 +18,7 @@ uid: Known_issues
 | [Problem after removing DMA from cluster](xref:KI_Problem_after_removing_DMA_from_cluster) | Any DataMiner version with clustered storage and/or indexing | | December 15, 2023 |
 | [NATS not starting if DMS name contains special characters](xref:KI_NATS_not_starting_special_chars) | From DataMiner 10.1.0/10.1.2 <br>onwards | | November 8, 2022 |
 | [Upgrade fails because of VerifyClusterPort.dll prerequisite](xref:KI_Upgrade_fails_VerifyClusterPorts_prerequisite) | From 10.2.0 [CU1] and 10.2.4 onwards | | September 2, 2022 |
-| [LDAP/ActiveDirectory domain users no longer able to log in after upgrade](xref:KI_LDAP_users_unable_to_log_in_after_upgrade) | DataMiner 10.4.0 [CU4] to 10.4.0 [CU9] or 10.4.0 [CU11]<br>DataMiner 10.4.7 to 10.4.12 or 10.5.1 | DataMiner 10.4.0 [CU10]/10.5.0/10.5.1 or<br>DataMiner 10.4.0 [CU12]/10.5.0/10.5.2, depending on the message returned by the LDAP server | December 13, 2024 |
+| [LDAP/ActiveDirectory domain users no longer able to log in after upgrade](xref:KI_LDAP_users_unable_to_log_in_after_upgrade) | DataMiner 10.4.0 [CU4] to 10.4.0 [CU11]<br>DataMiner 10.4.7 to 10.5.1 | DataMiner 10.4.0 [CU12]/10.5.0/10.5.2 | December 13, 2024 |
 
 ## 10.4.x
 
@@ -35,7 +35,7 @@ uid: Known_issues
 | [NATS not starting if DMS name contains special characters](xref:KI_NATS_not_starting_special_chars) | From DataMiner 10.1.0/10.1.2 <br>onwards | | November 8, 2022 |
 | [Upgrade fails because of VerifyClusterPort.dll prerequisite](xref:KI_Upgrade_fails_VerifyClusterPorts_prerequisite) | From 10.2.0 [CU1] and 10.2.4 onwards | | September 2, 2022 |
 | [Offline Failover DMA not synchronized](xref:KI_offline_DMA_cannot_sync) | DataMiner 10.3.0 [CU11] to 10.4.0 [CU9]<br>DataMiner 10.4.2 to 10.4.12 | DataMiner 10.4.0 [CU10] and 10.5.1 | December 18, 2024 |
-| [LDAP/ActiveDirectory domain users no longer able to log in after upgrade](xref:KI_LDAP_users_unable_to_log_in_after_upgrade) | DataMiner 10.4.0 [CU4] to 10.4.0 [CU9]/10.4.0 [CU12]<br>DataMiner 10.4.7 to 10.4.12/10.5.1 | DataMiner 10.4.0 [CU10]/10.5.0/10.5.1 or<br>DataMiner 10.5.0/10.5.2, depending on the message returned by the LDAP server | December 13, 2024 |
+| [LDAP/ActiveDirectory domain users no longer able to log in after upgrade](xref:KI_LDAP_users_unable_to_log_in_after_upgrade) | DataMiner 10.4.0 [CU4] to 10.4.0 [CU11]<br>DataMiner 10.4.7 to 10.5.1 | DataMiner 10.4.0 [CU12]/10.5.0/10.5.2 | December 13, 2024 |
 | [SNMPv3 elements not loaded correctly after upgrade](xref:KI_SNMPv3_elements_broken_after_upgrade) | DataMiner 10.4.9 to 10.4.12, after upgrade from 10.4.0 [CU6] or higher | DataMiner 10.5.0/10.5.1 | December 4, 2024 |
 | [Inter-DMA connection issues when ExternalAuthentication is used](xref:KI_Inter-DMA-connection_issues_when_ExternAuthentication_is_used) | From DataMiner 10.4.3 onwards | DataMiner 10.4.12/10.5.0 | December 2, 2024 |
 | [nats-server.config file not included in DataMiner backups](xref:KI_nats-server_config_file_not_included_in_backups) | From DataMiner 10.2.0 [CU6]/10.2.8 onwards | DataMiner 10.4.11/10.5.0 | October 10, 2024 |


### PR DESCRIPTION
Adjusting the versions and advocating for a blanket skip of the first RN which was intended to fix this issue. As the chance of it re-occurring on said version after an edit of the LDAP server is realistic. So we'd prefer to guide customers to the version with the full fix in place.