### PR TITLE
Update General_Feature_Release_10.5.3.md

### DIFF
--- a/release-notes/Breaking_changes/Breaking_changes.md
+++ b/release-notes/Breaking_changes/Breaking_changes.md
@@ -8,7 +8,7 @@ The following breaking changes have been introduced in recent DataMiner releases
 
 | Release note ID | Release version(s) | Description |
 |--|--|--|
-| [41713](xref:General_Feature_Release_10.5.3#protocols-separate-slscripting-process-for-every-protocol-used-id-41713) | DataMiner 10.6.0/10.5.3 | From now on, DataMiner will by default start a separate SLScripting process for every SLProtocol process. |
+| [41713](xref:General_Feature_Release_10.5.3#protocols-separate-slscripting-process-for-every-slprotocol-process-id-41713) | DataMiner 10.6.0/10.5.3 | From now on, DataMiner will by default start a separate SLScripting process for every SLProtocol process. |
 | [41546](xref:General_Feature_Release_10.5.2#dataminer-object-models-an-exception-will-now-be-thrown-when-an-issue-occurs-for-any-of-the-dominstances-that-are-created-updated-or-deleted-in-bulk-id-41546) | DataMiner 10.5.0/10.5.2 | An exception will now be thrown when an issue occurs for any of the `DomInstances` that are created, updated, or deleted in bulk. |
 | [41195](xref:General_Feature_Release_10.5.1#automation-locking-behavior-of-automation-script-actions-has-been-enhanced-id-41195) | DataMiner 10.4.0 [CU10]/10.5.1 | Changes made to the locking behavior of Automation script actions will affect the behavior of the *Generate Information*, *Log*, *Send Notification*, *Send Report*, *Set State* and *Set Template* actions. |
 | [41178](xref:Skyline_DataMiner_Core_DataMinerSystem_Range_1.1#api-changes-for-improved-performance-id-41178) | Skyline.DataMiner.Core.DataMinerSystem | API changes for improved performance cause some calls to no longer throw an ElementStoppedException but instead an ElementNotFoundException or no exception at all. |

--- a/release-notes/General/General_Feature_Release_10.5/General_Feature_Release_10.5.3.md
+++ b/release-notes/General/General_Feature_Release_10.5/General_Feature_Release_10.5.3.md
@@ -118,17 +118,17 @@ If necessary, users can force RAD to retrain its internal model by sending a `Re
 
 ### Breaking changes
 
-#### Protocols: Separate SLScripting process for every protocol used [ID 41713]
+#### Protocols: Separate SLScripting process for every SLProtocol process [ID 41713]
 
 <!-- MR 10.6.0 - FR 10.5.3 -->
 
 From now on, DataMiner will by default start a separate SLScripting process for every SLProtocol process.
 
-Up to now, if you wanted to have separate SLScripting processes created for every protocol being used, you had to explicitly configure this in `ProcessOptions` element of the *DataMiner.xml* file. See the example below.
+Up to now, if you wanted to have separate SLScripting processes created for every SLProtocol being used, you had to explicitly configure this in `ProcessOptions` element of the *DataMiner.xml* file. See the example below.
 
 ```xml
 <DataMiner>
-  <ProcessOptions protocolProcesses="protocol" scriptingProcesses="protocol" />
+  <ProcessOptions protocolProcesses="18" scriptingProcesses="protocol" />
 </DataMiner>
 ```
 

--- a/release-notes/General/General_Feature_Release_10.5/General_Feature_Release_10.5.3.md
+++ b/release-notes/General/General_Feature_Release_10.5/General_Feature_Release_10.5.3.md
@@ -124,7 +124,7 @@ If necessary, users can force RAD to retrain its internal model by sending a `Re
 
 From now on, DataMiner will by default start a separate SLScripting process for every SLProtocol process.
 
-Up to now, if you wanted to have separate SLScripting processes created for every SLProtocol being used, you had to explicitly configure this in `ProcessOptions` element of the *DataMiner.xml* file. See the example below.
+Up to now, if you wanted to have a separate SLScripting process created for every SLProtocol process being used, you had to explicitly configure this in the `ProcessOptions` element of the *DataMiner.xml* file. See the example below.
 
 ```xml
 <DataMiner>

--- a/release-notes/General/General_Main_Release_10.6/General_Main_Release_10.6.0_changes.md
+++ b/release-notes/General/General_Main_Release_10.6/General_Main_Release_10.6.0_changes.md
@@ -11,17 +11,17 @@ uid: General_Main_Release_10.6.0_changes
 
 ### Breaking changes
 
-#### Protocols: Separate SLScripting process for every protocol used [ID 41713]
+#### Protocols: Separate SLScripting process for every SLProtocol process [ID 41713]
 
 <!-- MR 10.6.0 - FR 10.5.3 -->
 
 From now on, DataMiner will by default start a separate SLScripting process for every SLProtocol process.
 
-Up to now, if you wanted to have separate SLScripting processes created for every protocol being used, you had to explicitly configure this in `ProcessOptions` element of the *DataMiner.xml* file. See the example below.
+Up to now, if you wanted to have a separate SLScripting process created for every SLProtocol process being used, you had to explicitly configure this in the `ProcessOptions` element of the *DataMiner.xml* file. See the example below.
 
 ```xml
 <DataMiner>
-  <ProcessOptions protocolProcesses="protocol" scriptingProcesses="protocol" />
+  <ProcessOptions protocolProcesses="18" scriptingProcesses="protocol" />
 </DataMiner>
 ```
 


### PR DESCRIPTION
The previous description incorrectly associated this with having an SLScripting instance per protocol (connector), whereas it actually pertains to having an SLScripting process per SLProtocol process.

For an example of how this functionality previously required explicit configuration, refer to:https://docs.dataminer.services/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/Configuration_of_DataMiner_processes.html#configuring-a-separate-slscripting-process-for-each-slprotocol-process