### PR TITLE
Only elements with SNMP traps on clusters without trap forwarding are…

### DIFF
--- a/user-guide/Advanced_Functionality/Swarming/Swarming.md
+++ b/user-guide/Advanced_Functionality/Swarming/Swarming.md
@@ -68,7 +68,7 @@ Below you can find a complete overview of the differences between a system using
 | Elements polling localhost                       | Supported                              | Supported but not swarmable    |
 | Elements with element connections                | Supported                              | Supported but not swarmable*   |
 | Smart-serial elements in server mode             | Supported                              | Supported but not swarmable    |
-| Elements receiving SNMP traps                    | Supported                              | Supported but not swarmable    |
+| Elements receiving SNMP traps in a DMS with trap distribution disabled on at least one DMA.       | Supported                              | Supported but not swarmable    |
 
 (*) To be added in later versions.
 


### PR DESCRIPTION
… not swarmable.

Elements that can receive traps will be blocked for swarming only in case SNMP trap distribution is not enabled on all agents in the cluster. If SNMP trap distribution is enabled on the whole DMS, this limitation is not in place. See https://intranet.skyline.be/DataMiner/Lists/Release%20Notes/DispForm.aspx?ID=41356