### PR TITLE
Update Exporting_elements_services_etc_to_a_dmimport_file.md

### DIFF
--- a/user-guide/Advanced_Functionality/DataMiner_Agents/Exporting_and_importing/Exporting_elements_services_etc_to_a_dmimport_file.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Agents/Exporting_and_importing/Exporting_elements_services_etc_to_a_dmimport_file.md
@@ -7,8 +7,7 @@ uid: Exporting_elements_services_etc_to_a_dmimport_file
 In the DataMiner Cube Surveyor, you can right-click a view in order to export it, with any elements, services, redundancy groups, documents, SLAs and service templates it contains, to .dmimport format. It is also possible to right-click an element or service directly to export it. The .dmimport package will also contain any related properties, protocols, information templates, trend templates, alarm template and Automation scripts.
 
 > [!NOTE]
->
-> Exporting of Spectrum Analyzer elements is currently not supported.
+> Exporting spectrum analyzer elements is currently not supported.
 
 1. In the Surveyor right-click menu, select *Actions \> Export*.
 


### PR DESCRIPTION
Export for Spectrum elements is not supported. 
Source: https://community.dataminer.services/question/delt-export-for-spectrum-analyzer-best-practices-for-exporting-or-migrating-spectrum-elements/