### PR TITLE
Added note about max DOM TimeSpan value

### DIFF
--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
@@ -41,7 +41,7 @@ A `FieldDescriptor` object defines what a field of a `DomInstance` should look l
 >
 > - When you store `DateTime` values, you can save them in either the local or UTC time zone. However, we strongly recommend always using UTC. When a `DateTime` field value is displayed in a low-code app form, the values will be converted to the time zone set by the browser. When it is updated via the form, the value will be converted and saved in UTC even if the value was originally stored in local time.
 > - When a `string` value is stored, from DataMiner 10.4.12/10.5.0 onwards, the value is limited to a maximum of 32 766 UTF-8 bytes, so the maximum number of characters will have to be lower.<!-- RN 39496 -->
-> - When a `TimeSpan` value is used, make sure its value does not exceed (+ or -) 10,000 days.
+> - When a `TimeSpan` value is used, make sure its value does not exceed (+ or -) 10,000 years.
 
 Below is an overview of all other important properties:
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
@@ -41,7 +41,7 @@ A `FieldDescriptor` object defines what a field of a `DomInstance` should look l
 >
 > - When you store `DateTime` values, you can save them in either the local or UTC time zone. However, we strongly recommend always using UTC. When a `DateTime` field value is displayed in a low-code app form, the values will be converted to the time zone set by the browser. When it is updated via the form, the value will be converted and saved in UTC even if the value was originally stored in local time.
 > - When a `string` value is stored, from DataMiner 10.4.12/10.5.0 onwards, the value is limited to a maximum of 32 766 UTF-8 bytes, so the maximum number of characters will have to be lower.<!-- RN 39496 -->
-> - When a `TimeSpan` value is used, make sure its value does not exceed (+ or -) 10,000 years.
+> - When a `TimeSpan` value is used, make sure its value does not exceed 10,000 or go below -10,000 years.
 
 Below is an overview of all other important properties:
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
@@ -41,6 +41,7 @@ A `FieldDescriptor` object defines what a field of a `DomInstance` should look l
 >
 > - When you store `DateTime` values, you can save them in either the local or UTC time zone. However, we strongly recommend always using UTC. When a `DateTime` field value is displayed in a low-code app form, the values will be converted to the time zone set by the browser. When it is updated via the form, the value will be converted and saved in UTC even if the value was originally stored in local time.
 > - When a `string` value is stored, from DataMiner 10.4.12/10.5.0 onwards, the value is limited to a maximum of 32 766 UTF-8 bytes, so the maximum number of characters will have to be lower.<!-- RN 39496 -->
+> - When a `TimeSpan` value is used, make sure its value does not exceed (+ or -) 10,000 years.
 
 Below is an overview of all other important properties:
 

--- a/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_objects/DOM_SectionDefinition.md
@@ -41,7 +41,7 @@ A `FieldDescriptor` object defines what a field of a `DomInstance` should look l
 >
 > - When you store `DateTime` values, you can save them in either the local or UTC time zone. However, we strongly recommend always using UTC. When a `DateTime` field value is displayed in a low-code app form, the values will be converted to the time zone set by the browser. When it is updated via the form, the value will be converted and saved in UTC even if the value was originally stored in local time.
 > - When a `string` value is stored, from DataMiner 10.4.12/10.5.0 onwards, the value is limited to a maximum of 32 766 UTF-8 bytes, so the maximum number of characters will have to be lower.<!-- RN 39496 -->
-> - When a `TimeSpan` value is used, make sure its value does not exceed (+ or -) 10,000 years.
+> - When a `TimeSpan` value is used, make sure its value does not exceed (+ or -) 10,000 days.
 
 Below is an overview of all other important properties:
 


### PR DESCRIPTION
As noted by the following dojo question, there is a limit to the timespan values of a DOM instance which is lower than the C# 'TimeSpan' object type. Added this as a note to the docs. https://community.dataminer.services/question/what-is-the-max-value-a-timespan-can-have-on-dom/