### PR TITLE
Update STaaS documentation to always direct to support for the endpoints

### DIFF
--- a/user-guide/Advanced_Functionality/Databases/STaaS/STaaS.md
+++ b/user-guide/Advanced_Functionality/Databases/STaaS/STaaS.md
@@ -44,7 +44,9 @@ For a self-managed DataMiner System, follow the steps below to set up STaaS.
 
 1. Make sure your DataMiner System is [connected to dataminer.services](xref:Connecting_your_DataMiner_System_to_the_cloud).
 
-1. Make sure that all Agents in your DataMiner System have internet access. This can be direct or through a proxy. For specific endpoints or IPs to whitelist, contact staas@dataminer.services. The configuration depends on the region you plan on registering you system for.
+1. Make sure that all Agents in your DataMiner System have internet access, either directly or through a proxy.
+
+   For specific endpoints or IPs to whitelist, contact <staas@dataminer.services>. The configuration depends on the region you will register your system for.
 
    > [!NOTE]
    > All communication for STaaS happens through HTTPS. The DataMiner System initiates all outbound connections.

--- a/user-guide/Advanced_Functionality/Databases/STaaS/STaaS.md
+++ b/user-guide/Advanced_Functionality/Databases/STaaS/STaaS.md
@@ -44,11 +44,7 @@ For a self-managed DataMiner System, follow the steps below to set up STaaS.
 
 1. Make sure your DataMiner System is [connected to dataminer.services](xref:Connecting_your_DataMiner_System_to_the_cloud).
 
-1. Make sure that all Agents in your DataMiner System have internet access and are able to reach the following endpoints, depending on the data location that will be used:
-
-   - STaaS West Europe: 20.76.71.123
-   - STaaS UK South: 20.162.131.128
-   - STaaS Southeast Asia: 20.247.192.226
+1. Make sure that all Agents in your DataMiner System have internet access. This can be direct or through a proxy. For specific endpoints or IPs to whitelist, contact staas@dataminer.services. The configuration depends on the region you plan on registering you system for.
 
    > [!NOTE]
    > All communication for STaaS happens through HTTPS. The DataMiner System initiates all outbound connections.


### PR DESCRIPTION
Update docs to always direct the user to staas@dataminer.services as the IPs mentioned before aren't enough. The storage queue and eventhub need different ranges and hostnames