### PR TITLE
Remove mention of DMZ in docs for STaaS

### DIFF
--- a/user-guide/Advanced_Functionality/Databases/STaaS/STaaS.md
+++ b/user-guide/Advanced_Functionality/Databases/STaaS/STaaS.md
@@ -275,8 +275,6 @@ In addition, the following **other limitations** currently apply:
 
 - [Exporting trend data](xref:Exporting_elements_services_etc_to_a_dmimport_file) to a .dmimport file is not supported.
 
-- DMZ setups are currently not supported.
-
 - Adding a DataMiner Agent to a DMS using STaaS requires [additional manual configuration steps](xref:Adding_a_DMA_to_a_DMS_running_STaaS).
 
 - Regarding logger tables:


### PR DESCRIPTION
Only possible options for STaaS is internet access directly or through a proxy. A third DMZ kind of setup like we have with CloudGateway is not possible. Removing it as it's subject to confusion.