### PR TITLE
Clearify that proxy config needs port

### DIFF
--- a/user-guide/Cloud_Platform/Connecting_to_cloud/Connect_to_cloud_via_proxy.md
+++ b/user-guide/Cloud_Platform/Connecting_to_cloud/Connect_to_cloud_via_proxy.md
@@ -25,7 +25,7 @@ To configure this:
    ```
 
    - **Enabled**: Set this to `true`.
-   - **Address**: Specify the address of the proxy server. Example: `127.0.0.1` or `localhost`.
+   - **Address**: Specify the address of the proxy server. Example: `127.0.0.1:8080` or `localhost:5000`.
 
 1. Restart the CloudGateway service for the changes to take effect.
 


### PR DESCRIPTION
When setting up a proxy for the cloud connection, the address used need to include the port of the proxy.