### PR TITLE
Update default number of SLProtocol processes in Inner workings intro

### DIFF
--- a/develop/devguide/Connector/InnerWorkingsIntroduction.md
+++ b/develop/devguide/Connector/InnerWorkingsIntroduction.md
@@ -15,7 +15,7 @@ The following diagram gives an overview of the processes running in a DataMiner 
 
 The <xref:InnerWorkingsSLDataMiner> process is the central process of a DataMiner Agent (DMA). It is responsible for starting, stopping and configuring elements, services and redundancy groups, and manages all traffic from and to those items. SLDataMiner also performs database offloads toward the offload database (if one exists). This process is not aware of any other DMAs in the DataMiner System (DMS).
 
-The <xref:InnerWorkingsSLProtocol> process executes the logic defined in a DataMiner protocol of the active elements on the DataMiner Agent. By default, before DataMiner 10.4.12/10.5.0, five SLProtocol processes ran simultaneously, distributing the elements of the DataMiner Agent across them at startup. Starting from DataMiner 10.5.2, the default number of SLProtocol processes is ten.
+The <xref:InnerWorkingsSLProtocol> process executes the logic defined in a DataMiner protocol of the active elements on the DataMiner Agent. By default, several SLProtocol processes (5 prior to DataMiner 10.4.12/10.5.0, and 10 in later versions) run simultaneously, and the elements of the DataMiner Agent are distributed across them at startup.
 
 The <xref:InnerWorkingsSLScripting> process is responsible for executing Quick Actions defined in the protocol when requested by the SLProtocol process (i.e. when triggered to execute).
 

--- a/develop/devguide/Connector/InnerWorkingsIntroduction.md
+++ b/develop/devguide/Connector/InnerWorkingsIntroduction.md
@@ -15,7 +15,7 @@ The following diagram gives an overview of the processes running in a DataMiner 
 
 The <xref:InnerWorkingsSLDataMiner> process is the central process of a DataMiner Agent (DMA). It is responsible for starting, stopping and configuring elements, services and redundancy groups, and manages all traffic from and to those items. SLDataMiner also performs database offloads toward the offload database (if one exists). This process is not aware of any other DMAs in the DataMiner System (DMS).
 
-The <xref:InnerWorkingsSLProtocol> process executes the logic defined in a DataMiner protocol of the active elements on the DataMiner Agent. By default, five SLProtocol processes run simultaneously and the elements of the DataMiner Agent are spread over these processes at startup.
+The <xref:InnerWorkingsSLProtocol> process executes the logic defined in a DataMiner protocol of the active elements on the DataMiner Agent. By default, before DataMiner 10.4.12/10.5.0, five SLProtocol processes ran simultaneously, distributing the elements of the DataMiner Agent across them at startup. Starting from DataMiner 10.5.2, the default number of SLProtocol processes is ten.
 
 The <xref:InnerWorkingsSLScripting> process is responsible for executing Quick Actions defined in the protocol when requested by the SLProtocol process (i.e. when triggered to execute).
 


### PR DESCRIPTION
The SLProtocol tab of the inner workings was already updated to reflect the new default number of SLProtocol processes starting from DataMiner 10.4.12/10.5.0, but the introduction was not updated accordingly. This commit rectifies this.