### PR TITLE
RN 42031

### DIFF
--- a/develop/DMI/EPM_Integration_Training/Visios/DashboardAndAppsNavigation.md
+++ b/develop/DMI/EPM_Integration_Training/Visios/DashboardAndAppsNavigation.md
@@ -12,7 +12,7 @@ To do so, use a **Link** shape data field. The value has to be the dashboard or 
 http://<DMAIP>/dashboard/#/db/Training/Station/01.%20Device%20Overview.dmadb?data={"version":1,"feed":null,"components":[{"cid":1,"select":{"epm-selections":["[param:[cardVar: _elementInfo],901]/5502/[fieldId]"]}}],"feedAndSelect":{}}
 ```
 
-For detailed information about the JSON syntax, see [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_dashboard_URL).
+For detailed information about the JSON syntax, see [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_URL).
 
 To link to EPM objects in this JSON syntax, you will need to use the **epm-selections** field, with the DMA ID, element ID, field PID and primary key value, separated by forward slashes. This field has to be used within a component field, which means you will need to find the ID of the component. You can do so by editing the dashboard or low-code app and looking up the number in the lower right corner of the component:
 
@@ -30,4 +30,4 @@ Here is an example of what this will look like in a live system:
 > See also:
 >
 > - [Linking a shape to a dashboard component](xref:Linking_a_shape_to_a_dashboard_component)
-> - [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_dashboard_URL)
+> - [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_URL)

--- a/release-notes/Web_apps/Web_apps_Feature_Release_10.3/Web_apps_Feature_Release_10.3.5.md
+++ b/release-notes/Web_apps/Web_apps_Feature_Release_10.3/Web_apps_Feature_Release_10.3.5.md
@@ -123,7 +123,7 @@ A default value can be set by means of a URL option:
 
   - `?data=<URL-encoded JSON object>`
 
-For more information on how to pass data using a JSON object, see [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_dashboard_URL).
+For more information on how to pass data using a JSON object, see [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_URL).
 
 #### Dashboards app & Low-Code Apps: New 'Numeric input' feed [ID 35911]
 
@@ -148,7 +148,7 @@ A default value can be set by means of a URL option:
 
   - `?data=<URL-encoded JSON object>`
 
-For more information on how to pass data using a JSON object, see [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_dashboard_URL).
+For more information on how to pass data using a JSON object, see [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_URL).
 
 #### Low-Code Apps: 'Open monitoring card' action can now also be linked to a feed [ID 35986]
 

--- a/release-notes/Web_apps/Web_apps_Feature_Release_10.5/Web_apps_Feature_Release_10.5.4.md
+++ b/release-notes/Web_apps/Web_apps_Feature_Release_10.5/Web_apps_Feature_Release_10.5.4.md
@@ -91,7 +91,7 @@ When you add the following argument to the URL of a low-code app, all UI compone
 
 Up to now, low-code apps would only support using URL data to pass default values to components. For example, to select a particular default value in a dropdown box. From now on, low-code apps will also be able to consume data passed via their URL using either the JSON syntax or the legacy syntax. For example, you will now be able to use an element specified in the URL to filter a GQI query.
 
-For more information regarding the above-mentioned JSON syntax and legacy syntax, see [Specifying data input in a dashboard URL](xref:Specifying_data_input_in_a_dashboard_URL).
+For more information regarding the above-mentioned JSON syntax and legacy syntax, see [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_URL).
 
 > [!NOTE]
 > Contrary to dashboards, low-code apps will not push data to the URL. In other words, the URL will not change when data is selected in a component.

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Dashboards_app/Tutorials/Embed_Dashboard_in_Visio.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Dashboards_app/Tutorials/Embed_Dashboard_in_Visio.md
@@ -115,7 +115,7 @@ Before you can actually use the URL you have copied, some manual adjustments are
     <code>https://<span style="background-color: #FFFF00">\<DMAIP\></span>/dashboard/#/db/Generic Dummy.dmadb?data=%7B%22version%22%3A1,%22feed%22%3Anull,%22components%22%3A%5B%7B%22cid%22%3A1,%22select%22%3A%7B%22elements%22%3A%5B%22[EscapeDataString:[this elementID]]%22%5D%7D%7D%5D,%22feedAndSelect%22%3A%7B%7D%7D&embed=true</code>
 
 > [!TIP]
-> See also: [Specifying data input in a dashboard URL](xref:Specifying_data_input_in_a_dashboard_URL)
+> See also: [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_URL)
 
 ## Step 3: Create a Visio file and embed the dashboard
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Specifying_data_input_in_a_dashboard_URL.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Specifying_data_input_in_a_dashboard_URL.md
@@ -4,14 +4,15 @@ uid: Specifying_data_input_in_a_URL
 
 # Specifying data input in a dashboard or app URL
 
-In the URL of a dashboard, you can specify data input for the dashboard. This way, you can immediately make the dashboard display specific data when it is opened. From DataMiner 10.2.0/10.2.2 onwards<!--RN 31833-->, you can pass the data using a [JSON object](#json-syntax) in the URL. Prior to DataMiner 10.2.0/10.2.2, you can use the [legacy syntax](#legacy-syntax), which continues to be supported in recent DataMiner versions for now.
+If a dashboard has been configured with one or more components, it is possible to specify data input for this data in a dashboard URL. This way, you can immediately make the dashboard display specific data when it is opened. From DataMiner 10.2.0/10.2.2 onwards<!--RN 31833-->, you can pass the data using a [JSON object](#json-syntax) in the URL. Prior to DataMiner 10.2.0/10.2.2, you can use the [legacy syntax](#legacy-syntax), which continues to be supported in recent DataMiner versions for now.
+
+From DataMiner 10.4.0 [CU13]/10.5.0 [CU1]/10.5.4 onwards<!--RN 42031-->, low-code apps also support specifying data input in an app URL, using either the JSON syntax or the legacy syntax. Prior to this, the low-code app URL can only be used to set a component's default value, such as selecting a default element in a dropdown.
 
 > [!NOTE]
 >
-> - From DataMiner 10.2.0/10.2.2 onwards<!--RN 31833-->, when a dashboard updates its own URL, it will use a compressed JSON syntax. In this compressed syntax, the query parameter "d" is used instead of "data".
-> - To refer to a query in the dashboard URL, use the following format: *?queries=\[***alias***\]\\x1F\[***queryJsonString***\]*. In this format, \[alias\] is the name of the query and \[queryJsonString\] is the query in the format of a JSON string, for example: *?queries=Get Elements/{"ID": "Elements"}*.
 > - To only display a dashboard without the rest of the app, add the argument "*embed=true*". To display the *Clear all* button for an embedded dashboard, add "*subheader=true*" as well. For example: *https://**\[DMA IP\]**/dashboard/#/MyDashboards/dashboard.dmadb?embed=true&subheader=true*
 > - The *showAdvancedSettings=true* URL option can be used with some components in order to make additional functionality available.
+> - When data is selected in a component, the URL of a dashboard changes. However, unlike dashboards, low-code apps will not push data to the URL.
 
 > [!IMPORTANT]
 > To guarantee support across all browsers and prevent possible issues, the URL value should be encoded. If, for example, the JSON structure contains any ampersands ("&"), this will not work unencoded. See [URL-encoded equivalents](#url-encoded-equivalents).
@@ -21,6 +22,8 @@ In the URL of a dashboard, you can specify data input for the dashboard. This wa
 You can pass the data using a JSON object in the URL:
 
 ``url?data=<URL-encoded JSON object>``
+
+From DataMiner 10.2.0/10.2.2 onwards<!--RN 31833-->, when a dashboard updates its own URL, it will use a compressed JSON syntax. In this compressed syntax, the query parameter `d` is used instead of `data`.
 
 This JSON object has to have the following structure:
 
@@ -194,6 +197,14 @@ Within the dashboard URL, the following data objects can be specified:
 - *object manager instances*: Supported from DataMiner 10.3.6/10.4.0 onwards<!-- RN 36124 -->. Requires the [DOM instance ID](xref:DomInstance).
 
 - *object manager modules*: Supported from DataMiner 10.3.6/10.4.0 onwards<!-- RN 36124 -->. Requires the [DOM module ID](xref:DOM_ModuleId).
+
+- *queries*: Allows referencing a query in the dashboard or app URL. Use the following format: `?queries=[alias]\x1F[queryJsonString]`.
+
+  - `[alias]`: the name of the query.
+
+  - `[queryJsonString]`: the query in the format of a JSON string.
+
+  For example: `?queries=Get Elements/{"ID": "Elements"}`
 
 - *query columns*: Supported from DataMiner 10.3.9/10.4.0 onwards. A GQI query filter, structured as follows: `query columns=[query ID]%1e[column ID]%1e[filter type]%1e[filter values]`. The following filter types are supported: *list*, *range*, *boolean*, *number*, and *string*.
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Specifying_data_input_in_a_dashboard_URL.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Specifying_data_input_in_a_dashboard_URL.md
@@ -1,8 +1,8 @@
 ---
-uid: Specifying_data_input_in_a_dashboard_URL
+uid: Specifying_data_input_in_a_URL
 ---
 
-# Specifying data input in a dashboard URL
+# Specifying data input in a dashboard or app URL
 
 In the URL of a dashboard, you can specify data input for the dashboard. This way, you can immediately make the dashboard display specific data when it is opened. From DataMiner 10.2.0/10.2.2 onwards<!--RN 31833-->, you can pass the data using a [JSON object](#json-syntax) in the URL. Prior to DataMiner 10.2.0/10.2.2, you can use the [legacy syntax](#legacy-syntax), which continues to be supported in recent DataMiner versions for now.
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Specifying_data_input_in_a_dashboard_URL.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Specifying_data_input_in_a_dashboard_URL.md
@@ -54,12 +54,12 @@ This JSON object has to have the following structure:
 
 - When you provide data in the (optional) *feedAndSelect* item, that data will be interpreted as if it was passed using the [legacy syntax](#legacy-syntax) described below.
 
-- When you provide data in the (optional) *feed* item, that data will only be used in the URL feed. It will not be used to select items in selection boxes on the dashboard.
+- When you provide data in the (optional) *feed* item, that data will only be used in the URL feed. It will not be used to select items in selection boxes on the dashboard or app page.
 
   > [!NOTE]
   > The (optional) *feed* item is currently only available for passing data input in a dashboard URL.
 
-- When you provide data in the (optional) *select* item, that data will only be used to select items in selection boxes on the dashboard page. It will not be used in the URL feed.
+- When you provide data in the (optional) *select* item, that data will only be used to select items in selection boxes on the dashboard or app page. It will not be used in the URL feed.
 
 - In the *components* item, you can provide data to be selected in specific components referred to by their ID. ``<component-data>`` is an array of objects containing the component ID and the data that should be passed to the component:
 
@@ -147,7 +147,7 @@ For example:
 
 ## Supported objects
 
-Within the dashboard URL, the following data objects can be specified:
+Within the dashboard or app URL, the following data objects can be specified:
 
 - *elements*: Requires the DMA ID and element ID.
 
@@ -234,4 +234,4 @@ Within the dashboard URL, the following data objects can be specified:
 
   `v:1\u001FIDColumn\u000EID\u000Estring\u001FValueColumn\u000EValue\u000Enumber\u001Evalue1\u000EValue 1\u001F5\u000EFive\u001ERowKey`
 
-- *booleans*: Supported from DataMiner 10.4.0 [CU12]/10.5.3 onwards<!--RN 41845-->. Used to specify whether a boolean value is set to "true" or "false" when the dashboard is loaded.
+- *booleans*: Supported from DataMiner 10.4.0 [CU12]/10.5.3 onwards<!--RN 41845-->. Used to specify whether a boolean value is set to "true" or "false" when the dashboard or app is loaded.

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Specifying_data_input_in_a_dashboard_URL.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Specifying_data_input_in_a_dashboard_URL.md
@@ -4,12 +4,13 @@ uid: Specifying_data_input_in_a_URL
 
 # Specifying data input in a dashboard or app URL
 
-If a dashboard has been configured with one or more components, it is possible to specify data input for this data in a dashboard URL. This way, you can immediately make the dashboard display specific data when it is opened. From DataMiner 10.2.0/10.2.2 onwards<!--RN 31833-->, you can pass the data using a [JSON object](#json-syntax) in the URL. Prior to DataMiner 10.2.0/10.2.2, you can use the [legacy syntax](#legacy-syntax), which continues to be supported in recent DataMiner versions for now.
+It is possible to specify data input for a dashboard using the dashboard URL. This way, you can immediately make the dashboard display specific data when it is opened. From DataMiner 10.2.0/10.2.2 onwards<!--RN 31833-->, you can pass the data using a [JSON object](#json-syntax) in the URL. Prior to DataMiner 10.2.0/10.2.2, you can use the [legacy syntax](#legacy-syntax), which continues to be supported in recent DataMiner versions for now.
 
-From DataMiner 10.4.0 [CU13]/10.5.0 [CU1]/10.5.4 onwards<!--RN 42031-->, low-code apps also support specifying data input in an app URL, using either the JSON syntax or the legacy syntax. Prior to this, the low-code app URL can only be used to set a component's default value, such as selecting a default element in a dropdown.
+From DataMiner 10.4.0 [CU13]/10.5.0 [CU1]/10.5.4 onwards<!--RN 42031-->, low-code apps also support specifying data input in an app URL, using either the JSON syntax or the legacy syntax. Prior to this, the low-code app URL can only be used to set a component's default value, for example to select a default element in a dropdown.
 
 > [!NOTE]
 >
+> - From DataMiner 10.2.0/10.2.2 onwards<!--RN 31833-->, when a dashboard updates its own URL, it will use a compressed JSON syntax. In this compressed syntax, the query parameter `d` is used instead of `data`.
 > - To only display a dashboard without the rest of the app, add the argument "*embed=true*". To display the *Clear all* button for an embedded dashboard, add "*subheader=true*" as well. For example: *https://**\[DMA IP\]**/dashboard/#/MyDashboards/dashboard.dmadb?embed=true&subheader=true*
 > - The *showAdvancedSettings=true* URL option can be used with some components in order to make additional functionality available.
 > - When data is selected in a component, the URL of a dashboard changes. However, unlike dashboards, low-code apps will not push data to the URL.
@@ -22,8 +23,6 @@ From DataMiner 10.4.0 [CU13]/10.5.0 [CU1]/10.5.4 onwards<!--RN 42031-->, low-cod
 You can pass the data using a JSON object in the URL:
 
 ``url?data=<URL-encoded JSON object>``
-
-From DataMiner 10.2.0/10.2.2 onwards<!--RN 31833-->, when a dashboard updates its own URL, it will use a compressed JSON syntax. In this compressed syntax, the query parameter `d` is used instead of `data`.
 
 This JSON object has to have the following structure:
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Basic_controls/DashboardNumericInput.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Basic_controls/DashboardNumericInput.md
@@ -33,7 +33,7 @@ In the *Settings* pane, you can also configure the following optional settings:
 - *Maximum*: The maximum value for the numeric input.
 
 > [!NOTE]
-> From DataMiner 10.3.0 [CU10]/10.4.1 onwards<!-- RN 37736 -->, you can drag data to the component to link it to that data, or [specify data input in the URL](xref:Specifying_data_input_in_a_dashboard_URL). This way, the component will be filled in based on the linked data, but users will still be able to modify the value.
+> From DataMiner 10.3.0 [CU10]/10.4.1 onwards<!-- RN 37736 -->, you can drag data to the component to link it to that data, or [specify data input in the URL](xref:Specifying_data_input_in_a_URL). This way, the component will be filled in based on the linked data, but users will still be able to modify the value.
 
 ## Component actions
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Basic_controls/DashboardSearchInput.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Basic_controls/DashboardSearchInput.md
@@ -6,7 +6,7 @@ uid: DashboardSearchInput
 
 Available from DataMiner 10.3.0 [CU16]/10.4.0 [CU4]/10.4.7 onwards<!--  RN 39555 -->. This basic control allows users to enter text that will then be available as text data in the dashboard or low-code app. The text data can be used by queries and by script parameters in low-code app actions. This text data can also be cleared with an "x" button available in the input.
 
-You can drag data to the component to link it to that data, or [specify data input in the dashboard URL](xref:Specifying_data_input_in_a_dashboard_URL). This way, the component will be filled in based on the data, but users will still be able to modify the value.
+You can drag data to the component to link it to that data, or [specify data input in the dashboard URL](xref:Specifying_data_input_in_a_URL). This way, the component will be filled in based on the data, but users will still be able to modify the value.
 
 The following options are available to fine-tune the component layout:
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Basic_controls/DashboardTextInput.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Basic_controls/DashboardTextInput.md
@@ -27,7 +27,7 @@ In the *Settings* pane, you can also configure the following optional settings:
 - *Multiline*: Determines whether the input can consist of multiple lines or not.
 
 > [!NOTE]
-> From DataMiner 10.3.0 [CU10]/10.4.1 onwards<!-- RN 37736 -->, you can drag data to the component to link it to that data, or [specify data input in the dashboard URL](xref:Specifying_data_input_in_a_dashboard_URL). This way, the component will be filled in based on the data, but users will still be able to modify the value.
+> From DataMiner 10.3.0 [CU10]/10.4.1 onwards<!-- RN 37736 -->, you can drag data to the component to link it to that data, or [specify data input in the dashboard URL](xref:Specifying_data_input_in_a_URL). This way, the component will be filled in based on the data, but users will still be able to modify the value.
 
 ## Component actions
 

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Feeds.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Feeds.md
@@ -16,7 +16,7 @@ From DataMiner 10.3.0 [CU21]/10.4.0 [CU9]/10.4.12 onwards, these components are 
 - Other: [List](xref:DashboardList), [tree](xref:DashboardTree), [parameter picker](xref:DashboardParameterPicker), and [EPM picker](xref:DashboardEPMPicker) components.
 
 > [!NOTE]
-> Feeds can be pre-configured in dashboard URLs. See [Specifying data input in a dashboard URL](xref:Specifying_data_input_in_a_dashboard_URL).
+> Feeds can be pre-configured in dashboard URLs. See [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_URL).
 
 > [!TIP]
 > Prior to DataMiner 10.3.0 [CU21]/10.4.0 [CU9]/10.4.12, the term "feeds" is also used for [component data](xref:Component_Data) and [URL data](xref:URL_data).

--- a/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Tables/Table_component.md
+++ b/user-guide/Advanced_Modules/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Tables/Table_component.md
@@ -211,7 +211,7 @@ You can do this in several different ways, for example:
 
   1. Hover over the component, click the filter icon, and then add a filter from the *URL > Text* section of the *Data* pane. Prior to DataMiner 10.3.0 [CU21]/10.4.0 [CU9]/10.4.12<!--RN 41075 + 41141-->, add a filter from the *Feeds > URL > Strings* section of the *Data* pane.
 
-  1. Pass a string data object within the URL, as explained in [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_dashboard_URL).
+  1. Pass a string data object within the URL, as explained in [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_URL).
 
      This URL will automatically display a filtered version of the table when the dashboard or app is opened.
 

--- a/user-guide/Advanced_Modules/toc.yml
+++ b/user-guide/Advanced_Modules/toc.yml
@@ -284,7 +284,7 @@ items:
               - name: Embedding a dashboard component in a webpage or Visio drawing
                 topicUid: Embedding_a_dashboard_component_in_a_webpage_or_Visio_drawing
               - name: Specifying data input in a dashboard or app URL
-                topicUid: Specifying_data_input_in_a_dashboard_URL
+                topicUid: Specifying_data_input_in_a_URL
           - name: Sharing a dashboard
             topicUid: Sharing_a_dashboard
           - name: Generating a report based on a dashboard

--- a/user-guide/Basic_Functionality/Visio/linking_shapes/Linking_a_shape_to_a_webpage.md
+++ b/user-guide/Basic_Functionality/Visio/linking_shapes/Linking_a_shape_to_a_webpage.md
@@ -125,7 +125,7 @@ http://localhost/foo/test.php?id=123&action=save#SL_ALLOW_POPUPS#
 > - Prior to DataMiner 10.3.6/10.4.0, adding a URL fragment to a linked webpage causes the connection info to be automatically added after the fragment, rendering the URL invalid and requiring a reload of the page, which means the user may need to log in again. From DataMiner 10.3.6/10.4.0 onwards, Visual Overview can recognize if a URL fragment is added or changed and update only the necessary parts of the page, avoiding the need to recreate the browser instance. <!-- RN 36044 + 36104 -->
 
 > [!TIP]
-> If you want to pass data to a dashboard using placeholders, take a look at [how to specify data input in a dashboard URL](xref:Specifying_data_input_in_a_dashboard_URL).
+> If you want to pass data to a dashboard using placeholders, take a look at [how to specify data input in a dashboard URL](xref:Specifying_data_input_in_a_URL).
 >
 > It can also be useful to copy the URL directly from the Dashboards app. However, some of the URL parameters may be compressed. If you need the uncompressed URL parameters to insert placeholders, [retrieve the URL via the sharing option](xref:Sharing_a_dashboard#sharing-a-dashboard-url) and select *Use uncompressed URL parameters*.
 
@@ -172,7 +172,7 @@ You can link to a dashboard or low-code app in the same way as you would link to
 In the URL of the dashboard or low-code app, you can add placeholders in order to dynamically specify data for the dashboard or low-code app.
 
 > [!TIP]
-> For more information about the URL syntax, refer to [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_dashboard_URL).
+> For more information about the URL syntax, refer to [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_URL).
 
 > [!NOTE]
 > It is also possible to [link a shape to a component of a dashboard](xref:Linking_a_shape_to_a_dashboard_component) instead of the entire dashboard.

--- a/user-guide/Basic_Functionality/Visio/tutorials/Using_visio_to_control_dashboard_feed_components.md
+++ b/user-guide/Basic_Functionality/Visio/tutorials/Using_visio_to_control_dashboard_feed_components.md
@@ -243,5 +243,5 @@ For each table row that was added in [step 1](#step-1-create-a-new-virtual-conne
 - [Visio drawings](xref:visio)
 - [Getting started with basic shapes](xref:Getting_started_with_basic_shapes)
 - [Component data](xref:Component_Data)
-- [Specifying data input in a dashboard URL](xref:Specifying_data_input_in_a_dashboard_URL)
+- [Specifying data input in a dashboard or app URL](xref:Specifying_data_input_in_a_URL)
 - [Generating shapes based on table rows](xref:Generating_shapes_based_on_table_rows)

--- a/user-guide/Reference/Feature_overview.md
+++ b/user-guide/Reference/Feature_overview.md
@@ -34,7 +34,7 @@ Below you can find an overview of the main features that have been added to Data
 | Cube: [Hiding the close button](xref:Working_with_cards_in_DataMiner_Cube#marking-cards-as-non-closable) and [Selecting a Master card](xref:Working_with_cards_in_DataMiner_Cube#selecting-a-master-card) | DataMiner Cube 10.3.9/10.4.0 <!-- [ID 36912] [ID 36956] --> |
 | Cube: [*UseInitialArgumentsAfterDisconnect* argument](xref:Options_for_opening_DataMiner_Cube#useinitialargumentsafterdisconnecttrue) | DataMiner Cube 10.2.0 [CU22]/10.3.0 [CU10]/10.4.1 <!-- [ID 37888] --> |
 | Dashboards: [*Alarm table* component](xref:DashboardAlarmTable) | DataMiner 10.1.5/10.2.0<br>DataMiner 9.6.8 with [soft-launch option](xref:Overview_of_Soft_Launch_Options#reportsanddashboardsalarmlist) <!-- [ID 29456] -->|
-| Dashboards: [JSON input in URL parameters](xref:Specifying_data_input_in_a_dashboard_URL) | DataMiner 10.2.0/10.2.2 <!-- [ID 31833] [ID 31885] -->|
+| Dashboards: [JSON input in URL parameters](xref:Specifying_data_input_in_a_URL) | DataMiner 10.2.0/10.2.2 <!-- [ID 31833] [ID 31885] -->|
 | Dashboards: [*Node edge graph* component](xref:DashboardNodeEdgeGraph) | DataMiner 10.1.5/10.2.0 <!-- [ID 29425] -->|
 | Dashboards: [PDF export](xref:Sharing_PDF_report_from_Dashboards_app) | DataMiner 10.2.12/10.3.0<br>DataMiner 10.2.2 with [soft-launch option](xref:Overview_of_Soft_Launch_Options#reportsanddashboardsexport) <!-- [ID 34634] -->|
 | Dashboards: [*Progress bar* component](xref:DashboardProgressBar) | DataMiner 10.1.7/10.2.0 <!-- [ID 29773] --> |


### PR DESCRIPTION
@GillesBara, could you please review this pull request to confirm the accurate inclusion of release note 42031 in the user guide? Thanks in advance!

Note: To avoid the `> [!NOTE]` at the top of the *Specifying data input in a dashboard or app URL* page from becoming even longer and more intimidating, I moved some points to different sections on the page.

- Note about compressed syntax using `d` instead of `data` has been moved to *JSON syntax* section.
- Note about referencing a query has been moved to the list of supported objects.