### PR TITLE
Update Preparing_the_two_DataMiner_Agents.md

### DIFF
--- a/user-guide/Advanced_Functionality/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
+++ b/user-guide/Advanced_Functionality/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
@@ -43,7 +43,7 @@ The backup DMA must be a newly installed DataMiner Agent.
 
 When Failover is configured, one or two additional IP addresses are needed, depending on the number of network interfaces of the DMAs. These will be used as the virtual IP addresses of the primary or the backup DMA, depending on which of the two is online. If the DMAs only have one network interface, only one additional IP address is needed.
 
-Alternatively, from DataMiner 10.2.0/10.1.8 onwards, a shared hostname can be used instead of the virtual IP addresses. This hostname must be configured in the network, i.e. a corresponding DNS record must exist. The hostname must resolve to both primary IP addresses of the Failover Agents. For example, this could be the output of an nslookup of such a hostname:
+Alternatively, from DataMiner 10.2.0/10.1.8 onwards, a shared hostname can be used instead of the virtual IP addresses. This hostname must be configured in the network, i.e. a corresponding DNS record must exist which can be resolved from the hostname to both primary IP addresses of the Failover Agents and vice versa with a reverse lookup. For example, this could be the output of an nslookup of such a hostname and IP:
 
 ```txt
 Name: ResetPlease.FailoverZone


### PR DESCRIPTION
Adaptation to make it clear that it should be possible to do a reverse lookup on the DNS record as well.

At TotalPlay they didn't have their own DNS record and made a public DNS record on the internet pointing to two addresses in the private IP range. This resulted in the hostname -> IP lookup succeeding, however failover was failing due to the reverse lookup being impossible for a private IP address.