### PR TITLE
Swarming - update startup stats

### DIFF
--- a/user-guide/Reference/Metrics/swarming_elements_benchmarks.md
+++ b/user-guide/Reference/Metrics/swarming_elements_benchmarks.md
@@ -14,8 +14,8 @@ uid: swarming_elements_benchmarks
 | 4 | Raw swarming time for 1 element | DMS | 0.154&nbsp;s | DaaS cluster.<br> Measured swarm action only, without time needed to start the element. |
 | 5 | Failover switch 100 elements | DMS | 50&nbsp;s | Non-swarming system. Measured until Cube availability. Nothing else on the Failover Agent. |
 | 6 | Swarming 100 elements (Failover-like switchover) | DMS | 10&nbsp;s | On-premises STaaS. Measured until all swarm actions were completed. Elements became available one by one. |
-| 7 | Agent startup with 100 elements present | DMS | 6.353&nbsp;s | Loading from database. On-premises STaaS system. |
-| 8 | Agent startup with 100 elements present (non-swarming) | DMS | 2.853&nbsp;s | Non-swarming system (loading from XML) |
+| 7 | Element startup (100 elements present) (non-swarming) | DMS | 4.862&nbsp;s | DaaS Cluster. Non-swarming system (loading element config from XML) |
+| 8 | Element startup (100 elements present) | DMS | 5.256&nbsp;s | DaaS Cluster. Swarming system (loading element config from database) |
 | 9 | Setting element property | DMS | 0.024&nbsp;s | Non-swarming, 10.5.2 |
 | 10 | Setting element property | DMS | 0.025&nbsp;s | Swarming-enabled dedicated clustered storage setup, 10.5.2 |
 | 11 | Setting element property | DMS | 0.070&nbsp;s | Swarming-enabled STaaS setup, 10.5.2 |


### PR DESCRIPTION
Redid startup performance tests.
- The timings were for element start up only (all elements) but not the whole agent
- The timings were on prem agent with on prem db vs staas. Redid them for daas + staas (swarming vs non swarming)