### PR TITLE
RN 42074

### DIFF
--- a/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/Changing_the_IP_of_a_DMA.md
+++ b/user-guide/Advanced_Functionality/DataMiner_Agents/Configuring_a_DMA/Changing_the_IP_of_a_DMA.md
@@ -192,6 +192,9 @@ For a single DMA within a cluster that does not use the Cassandra cluster featur
 
    1. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
 
+      > [!NOTE]
+      > You will only be able to send this message if automatic NATS configuration is not disabled (with the [NATSForceManualConfig option](xref:SLNetClientTest_disabling_automatic_nats_config)). If this is disabled, you will need to reset NATS manually.
+
    1. Close the SLNetClientTest tool.
 
 > [!NOTE]
@@ -291,6 +294,9 @@ For a Failover DMA within a cluster that does not use the Cassandra cluster feat
    1. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
 
    1. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
+
+      > [!NOTE]
+      > You will only be able to send this message if automatic NATS configuration is not disabled (with the [NATSForceManualConfig option](xref:SLNetClientTest_disabling_automatic_nats_config)). If this is disabled, you will need to reset NATS manually.
 
    1. Close the SLNetClientTest tool.
 
@@ -403,6 +409,9 @@ If your DataMiner System uses the Cassandra cluster feature for its general data
    1. Go to the *Build Message* tab of the main window of the SLNetClientTest tool.
 
    1. In the *Message Type* drop-down list, select *Skyline.DataMiner.Net.Apps.NATSCustodian.NATSCustodianResetNatsRequest* and click *Send Message*.
+
+      > [!NOTE]
+      > You will only be able to send this message if automatic NATS configuration is not disabled (with the [NATSForceManualConfig option](xref:SLNetClientTest_disabling_automatic_nats_config)). If this is disabled, you will need to reset NATS manually.
 
    1. Close the SLNetClientTest tool.
 

--- a/user-guide/Troubleshooting/Procedures/Investigating_NATS_Issues.md
+++ b/user-guide/Troubleshooting/Procedures/Investigating_NATS_Issues.md
@@ -469,6 +469,9 @@ To trigger a NATS reset:
 
 This will recalculate the NAS and NATS configs in the entire cluster, so any faulty configurations are cleaned up automatically.
 
+> [!NOTE]
+> You will only be able to send this message if automatic NATS configuration is not disabled (with the [NATSForceManualConfig option](xref:SLNetClientTest_disabling_automatic_nats_config)). If this is disabled, you will need to reset NATS manually.
+
 ## Check if new NATS connections can be established
 
 Try restarting things one by one to see whether their functionality is restored, or whether the error changes:


### PR DESCRIPTION
@LaurensVergote, would it also make sense to add this note under [Remaining steps](https://docs.dataminer.services/user-guide/Troubleshooting/Procedures/Investigating_NATS_Issues.html?q=NatsCustodianResetNatsRequest&tabs=tabid-1%2Ctabid-4%2Ctabid-8%2Ctabid-10#remaining-steps) on the troubleshooting page, or will the full reinstall make sure automatic NATS configuration is enabled?