### PR TITLE
Update Migrating_the_general_database_to_Cassandra.md

### DIFF
--- a/user-guide/Advanced_Functionality/Databases/Configuring_dedicated_clustered_storage/Migrating_existing_systems/Migrating_the_general_database_to_Cassandra.md
+++ b/user-guide/Advanced_Functionality/Databases/Configuring_dedicated_clustered_storage/Migrating_existing_systems/Migrating_the_general_database_to_Cassandra.md
@@ -41,6 +41,11 @@ Before you start the Cassandra migration wizard, we recommend that you check the
 - Make sure you have the DataMiner permissions *System configuration* > *Database* > *Configure local DB* or *Configure general DB* (depending on your DataMiner version), and *System configuration* > *Agents* > *Upgrade / restore*, as otherwise you will not be able to run the wizard.
 
 - Do not specify the loopback IP address (127.0.0.1) as the first IP address for an Agent that is to use Cassandra.
+  
+- Increase the tombstone threshold values within the Cassandra.yaml file:
+   - **tombstone_warn_threshold**: Set to 100000. Cassandra warns in the Debug.log whenever there are more tombstones than this threshold. This provides a good indication of when the *tombstone_failure_threshold* might be exceeded.
+
+  - **tombstone_failure_threshold**: Set to 200000. Queries will fail if a record has more tombstones than the value set here. Increases of this value will slow down your reads but might be manageable depending on the use case.
 
 ## Preparing for the Cassandra migration
 

--- a/user-guide/Advanced_Functionality/Databases/Configuring_dedicated_clustered_storage/Migrating_existing_systems/Migrating_the_general_database_to_Cassandra.md
+++ b/user-guide/Advanced_Functionality/Databases/Configuring_dedicated_clustered_storage/Migrating_existing_systems/Migrating_the_general_database_to_Cassandra.md
@@ -41,11 +41,6 @@ Before you start the Cassandra migration wizard, we recommend that you check the
 - Make sure you have the DataMiner permissions *System configuration* > *Database* > *Configure local DB* or *Configure general DB* (depending on your DataMiner version), and *System configuration* > *Agents* > *Upgrade / restore*, as otherwise you will not be able to run the wizard.
 
 - Do not specify the loopback IP address (127.0.0.1) as the first IP address for an Agent that is to use Cassandra.
-  
-- Increase the tombstone threshold values within the Cassandra.yaml file:
-   - **tombstone_warn_threshold**: Set to 100000. Cassandra warns in the Debug.log whenever there are more tombstones than this threshold. This provides a good indication of when the *tombstone_failure_threshold* might be exceeded.
-
-  - **tombstone_failure_threshold**: Set to 200000. Queries will fail if a record has more tombstones than the value set here. Increases of this value will slow down your reads but might be manageable depending on the use case.
 
 ## Preparing for the Cassandra migration
 
@@ -197,6 +192,12 @@ After you have followed the procedure above and system requirements are met, you
 ## After the migration
 
 1. To improve the security of the Cassandra database, follow the procedures mentioned under [Cassandra authentication](xref:Cassandra_authentication).
+
+1. Adjust the tombstone settings in the *Cassandra.yml* file:
+
+   - **tombstone_warn_threshold**: Set this to 100000. Cassandra warns in the *Debug.log* file whenever there are more tombstones than this threshold. This provides a good indication of when the *tombstone_failure_threshold* might be exceeded.
+
+   - **tombstone_failure_threshold**: Set this to 200000. Queries will fail if a record has more tombstones than the value set here. Increases of this value will slow down your reads but might be manageable depending on the use case.
 
 1. To ensure that your Cassandra database does not run out of memory under load, configure the heap size for Cassandra.
 


### PR DESCRIPTION
After receiving feedback on "Cassandra_General_DB_Failure.md", appending the tombstone threshold values for Windows here. Given "Cassandra per DMA" is even less recommended than clustered Cassandra, I just provided the essentials without full procedure.