### PR TITLE
Update UIComponentsTableForeignKeys.md to mention the possibility of …

### DIFF
--- a/develop/devguide/Connector/UIComponentsTableForeignKeys.md
+++ b/develop/devguide/Connector/UIComponentsTableForeignKeys.md
@@ -13,8 +13,13 @@ One column of table 2 has to contain references (keys) to information stored in 
 ```xml
 <ColumnOption idx="9" pid="2010" type="custom" value="" options=";foreignKey=1000"/>
 ```
+It is possible to have multiple columns in a table that are foreign keys to the same table, but referencing a different key. Based on the previous example, you can add another Column with the Foreign Key to table 1000. 
 
-It is possible to implement recursive linking, in which case the table will have a column with a foreign key to itself. This can be required for specific aggregate actions in EPM environments, for example in case there is a list of amplifiers in a table, but all amplifiers are connected to each other, and a count needs to be done for the number of amplifiers connected from a certain starting point.
+```xml
+<ColumnOption idx="10" pid="2011" type="custom" value="" options=";foreignKey=1000"/>
+```
+
+It is also possible to implement recursive linking, in which case the table will have a column with a foreign key to itself. This can be required for specific aggregate actions in EPM environments, for example in case there is a list of amplifiers in a table, but all amplifiers are connected to each other, and a count needs to be done for the number of amplifiers connected from a certain starting point.
 
 ```xml
 <Param id="300" trending="false">

--- a/develop/devguide/Connector/UIComponentsTableForeignKeys.md
+++ b/develop/devguide/Connector/UIComponentsTableForeignKeys.md
@@ -13,7 +13,8 @@ One column of table 2 has to contain references (keys) to information stored in 
 ```xml
 <ColumnOption idx="9" pid="2010" type="custom" value="" options=";foreignKey=1000"/>
 ```
-It is possible to have multiple columns in a table that are foreign keys to the same table, but referencing a different key. Based on the previous example, you can add another Column with the Foreign Key to table 1000. 
+
+It is possible to have multiple columns in a table that are foreign keys to the same table, but referencing a different key. Based on the previous example, you can add another column with a foreign key to table 1000.
 
 ```xml
 <ColumnOption idx="10" pid="2011" type="custom" value="" options=";foreignKey=1000"/>


### PR DESCRIPTION
…multiple columns having foreign keys to the same table

I'm not sure if this is completely clear on how I wrote it, but I learned recently while working on a DVE that you can have multiple columns in the same table which reference the same foreign key. In our case this is useful since we have a "Source Network" and a "Destination Network" which both reference the same "Network" table. Let me know if I can adjust anything to explain this idea better.