### PR TITLE
Id field in JSON array is no hard requirement

### DIFF
--- a/user-guide/Advanced_Modules/Data_Sources/Data_Sources_Limitations.md
+++ b/user-guide/Advanced_Modules/Data_Sources/Data_Sources_Limitations.md
@@ -24,8 +24,6 @@ When working with the [Data API](xref:Data_API) and [scripted connectors](xref:S
 
   - Rejects requests from external systems.
 
-  - Requires a field "Id" in JSON arrays, serving as the primary key in the element's table.
-
   - Supports a nested table structure with multiple child tables pointing to a single parent table, does not currently support a child table with foreign key relations to multiple parent tables.
 
 - Parameters in auto-generated connectors:


### PR DESCRIPTION
Not sure in which version this got changed but double checked it with the team and it's no longer a hard requirement. In the [changelog](https://docs.dataminer.services/release-notes/DxMs/DataAPI_change_log.html#12-september-2024---fix---dataapi-123---auto-increment-column-duplicated-when-id-column-was-specified-in-new-request-id-40187) this is also mentioned:

> _When DataAPI generates a table, it uses the ID column from the request as the index. **If the request does not include an ID column, DataAPI creates an Idx column with auto-incremented values**._

However, as that changelog entry seems to describe a bug with that feature, the limitation should already longer be lifted. I did not find an entry specifically describing removing this limitation.

@MariekeGO, should I try to find out in which this got removed so the limitations page can mention this or is it sufficient to just list the limitations that are present in the latest released version?

