### PR TITLE
Removing limitations on the field ID

### DIFF
--- a/user-guide/Advanced_Modules/Data_Sources/Data_API.md
+++ b/user-guide/Advanced_Modules/Data_Sources/Data_API.md
@@ -63,7 +63,7 @@ The Data API translates JSON arrays from the HTTP body into a table in the corre
 }
 ```
 
-This JSON array is transformed into a table called "People" with columns *ID*, *Name*, *Age*, and *Height*. The field *Id* always serves as the primary key for the table.
+This JSON array is transformed into a table called "People" with columns *ID*, *Name*, *Age*, and *Height*. If a field named *Id* (case-insensitive) is specified, it will serve as the primary key for the table. Otherwise, an auto-increment value will be used as the primary key.
 
 The Data API also supports nested arrays, transforming them into multiple tables connected through a foreign key.
 

--- a/user-guide/Advanced_Modules/Data_Sources/Data_Sources_Limitations.md
+++ b/user-guide/Advanced_Modules/Data_Sources/Data_Sources_Limitations.md
@@ -24,8 +24,6 @@ When working with the [Data API](xref:Data_API) and [scripted connectors](xref:S
 
   - Rejects requests from external systems.
 
-  - Requires a field "Id" in JSON arrays, serving as the primary key in the element's table.
-
   - Supports a nested table structure with multiple child tables pointing to a single parent table, does not currently support a child table with foreign key relations to multiple parent tables.
 
 - Parameters in auto-generated connectors:


### PR DESCRIPTION
Since its first release, Data API did not have the limitation that an ID field is required in arrays.