### PR TITLE
Small swarming faq clarification

### DIFF
--- a/user-guide/Advanced_Functionality/Swarming/SwarmingFAQ.md
+++ b/user-guide/Advanced_Functionality/Swarming/SwarmingFAQ.md
@@ -44,7 +44,7 @@ If you have a perpetual-use license, there is a limit to how many elements can b
 
 ## How do I know why my element is not swarmable?
 
-The only way to see this in the UI at present is to attempt to swarm the element and look at the error message.
+The only way to see this at present is to attempt to swarm the element via the Automation API and look at the error message.
 
 ## How do Agents know which elements to host when starting up?
 


### PR DESCRIPTION
Commit updated this faq answer with wrong info:

[Swarming - FAQ by RobbeDGH · Pull Request #4471 · SkylineCommunications/dataminer-docs](https://github.com/SkylineCommunications/dataminer-docs/pull/4471/commits/98a6e8fe29a2208464e2090956f3dc8c46ee3b1c)

In above pull request the info was changed.
It mentions to swarm the element via the UI in cube and look at the error.
However, elements which are not swarmable are not possbile to swarm via the UI, they are hidden in the swarming pop up window in system center.
You can only trigger the swarming flow for these elements via the API. The returned error message contains the reason its not swarmable.