### PR TITLE
Update Profile_migration_to_elastic.md

### DIFF
--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Profile_migration_to_elastic.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Profile_migration_to_elastic.md
@@ -54,8 +54,6 @@ To migrate the profiles, you will need to use the SLNetClientTest tool. Note tha
 
 1. Check whether in the *MigrationStatus* table, the migration of profile instances, definitions, and parameters has the status completed, and there are no error messages.
 
-   If this is the case, the migration is complete.
-
    > [!TIP]
    > If you see errors, refer to the [Troubleshooting](#troubleshooting) section below.
 


### PR DESCRIPTION
Several colleagues/customers have reported their upgrade to 10.4 failed because their Profiles were still stored in XML, even though they had followed our guide (e.g. DCP265080). It turns out they just missed step 5. I believe removing this line on step 4 will be enough to make everything clearer.