### PR TITLE
Add documentation about using both serial and smart serial connections

### DIFF
--- a/develop/devguide/Connector/ConnectionsSmartSerial.md
+++ b/develop/devguide/Connector/ConnectionsSmartSerial.md
@@ -12,6 +12,8 @@ In this section:
 - <xref:ConnectionsSmartSerialServer>
 - <xref:ConnectionsSmartSerialBehaviorAfterDisconnect>
 - <xref:ConnectionsSmartSerialLogging>
+- <xref:ConnectionsSmartSerialDynamicPolling>
+- <xref:ConnectionsSmartSerialCommonPitfalls>
 
 ## See also
 

--- a/develop/devguide/Connector/ConnectionsSmartSerialCommonPitfalls.md
+++ b/develop/devguide/Connector/ConnectionsSmartSerialCommonPitfalls.md
@@ -1,0 +1,17 @@
+---
+uid: ConnectionsSmartSerialCommonPitfalls
+---
+
+# Common pitfalls
+
+This section describes common pitfalls when using smart serial connections.
+
+## Serial in combination with smart serial
+Serial and smart serial should never be combined to connect to **the same port of a device** (same IP address, same port) as the device will not know that the unsolicited messages should be sent via the smart serial connection.  
+To achieve the combination of both handling unsolicited messages and command-response pairs only a smart-serial connection should be set up that handles both types of messages.
+
+## Handling both unsolicited messages and command-response pairs
+When handling both unsolicited messages and command-response pairs on the same connection, it is important to be aware of when unsolicited messages can enter.  
+If these can enter simultaneously with a response that belongs to a command, the pair tag should only contain the command (no response).  
+To receive the response: handle it like it is an unsolicited message, and then determine if it is your expected response, or an actual unsolicited message.
+This is necessary, as it is possible that the unsolicited message enters just after sending the command which will cause the response tag to try and match this unsolicited message instead of the actual response.

--- a/develop/devguide/Connector/ConnectionsSmartSerialCommonPitfalls.md
+++ b/develop/devguide/Connector/ConnectionsSmartSerialCommonPitfalls.md
@@ -4,14 +4,16 @@ uid: ConnectionsSmartSerialCommonPitfalls
 
 # Common pitfalls
 
-This section describes common pitfalls when using smart serial connections.
+This section describes common pitfalls when using smart-serial connections.
 
 ## Serial in combination with smart serial
-Serial and smart serial should never be combined to connect to **the same port of a device** (same IP address, same port) as the device will not know that the unsolicited messages should be sent via the smart serial connection.  
-To achieve the combination of both handling unsolicited messages and command-response pairs only a smart-serial connection should be set up that handles both types of messages.
+
+Serial and smart-serial connections should never be combined to connect to **the same port of a device** (i.e. using the same IP address and port). If you do combine these, the device will not know that the unsolicited messages should be sent via the smart-serial connection.
+
+To be able to combine handling unsolicited messages and command-response pairs, only a smart-serial connection should be set up that handles both types of messages.
 
 ## Handling both unsolicited messages and command-response pairs
-When handling both unsolicited messages and command-response pairs on the same connection, it is important to be aware of when unsolicited messages can enter.  
-If these can enter simultaneously with a response that belongs to a command, the pair tag should only contain the command (no response).  
-To receive the response: handle it like it is an unsolicited message, and then determine if it is your expected response, or an actual unsolicited message.
-This is necessary, as it is possible that the unsolicited message enters just after sending the command which will cause the response tag to try and match this unsolicited message instead of the actual response.
+
+When handling both unsolicited messages and command-response pairs on the same connection, it is important to be aware of when unsolicited messages can enter. If these can enter simultaneously with a response that belongs to a command, the pair tag should only contain the command (no response). To receive the response, handle it as if it is an unsolicited message, and then determine if it is your expected response or an actual unsolicited message.
+
+This is necessary because it is possible that the unsolicited message enters just after the command is sent, which will cause the response tag to try and match this unsolicited message instead of the actual response.

--- a/develop/toc.yml
+++ b/develop/toc.yml
@@ -435,6 +435,8 @@ items:
           topicUid: ConnectionsSmartSerialLogging
         - name: Dynamic polling
           topicUid: ConnectionsSmartSerialDynamicPolling
+        - name: Common pitfalls
+          topicUid: ConnectionsSmartSerialCommonPitfalls
       - name: HTTP
         topicUid: ConnectionsHttp
         items:


### PR DESCRIPTION
Belongs to [DCP265549](https://collaboration.dataminer.services/task/265549).

This PR adds documentation about using both serial and smart-serial to communicate with a device as it is important to know that  both cannot be used together on the same port of a device.

In the "overview" of the section I also added the link to the "Dynamic Polling" page as that was missing in the overview even though it was part of the "folder" structure.