### PR TITLE
Update DB_xml.md

### DIFF
--- a/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/DB_xml.md
+++ b/user-guide/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/DB_xml.md
@@ -435,7 +435,7 @@ To support the offload of files to a file cache instead of to a MySQL, MSSQL, or
    For example:
 
    ```xml
-   <DataBase active="true" local = "false">
+   <DataBase active="true" local="false" type="MySQL">
     <FileCache enabled="true">
     <MaxSizeKB>10000</MaxSizeKB>
     </FileCache>


### PR DESCRIPTION
Up for discussion because of DCP266793
If the type="MySQL" is not there, there will be errors during startup while parsing the db.xml 

Using the UI to configure it, this will not be an issue but if via file change (db.xml) could be misleading. 
@DieterDegrande