### PR TITLE
Tweaks to the DOM docs related to data storage and cleanup

### DIFF
--- a/user-guide/Advanced_Modules/DOM/DOM.md
+++ b/user-guide/Advanced_Modules/DOM/DOM.md
@@ -9,9 +9,7 @@ From DataMiner 10.1.2/10.2.0 onwards, DataMiner Object Models can be used for th
 A DataMiner Object Model is a generic data storage system that makes it possible to quickly create new applications or solutions. It consists of a collection of [generic objects](xref:DOM_objects) and a [generic DOM manager](xref:DOM_managers). Create, read, update, and delete (CRUD) actions can be executed on these objects in a script or application using the [DomHelper](xref:DomHelper_class). Data is [stored in an indexing database](xref:DOM_data_storage).
 
 > [!NOTE]
->
-> - DOM data can be displayed in dashboards and applications from DataMiner 10.1.7 onwards. In versions prior to DataMiner 10.3.6/10.4.0, this feature is in soft launch, so you will need to activate the *DOMManager* [soft-launch option](xref:SoftLaunchOptions) to use it.  
-> - The DataMiner Jobs module functions in a similar way as a DOM manager. The main difference is in the naming of the objects used. In addition, multiple DOM manager instances can run at the same time, while there can only be one Jobs module.
+> DOM data can be displayed in dashboards and applications from DataMiner 10.1.7 onwards. In versions prior to DataMiner 10.3.6/10.4.0, this feature is in soft launch, so you will need to activate the *DOMManager* [soft-launch option](xref:SoftLaunchOptions) to use it.
 
 > [!TIP]
 > To visualize and control your DataMiner Object Model (DOM) definitions and instances, the [DOM Viewer](xref:domviewer_about) application can come in very handy.

--- a/user-guide/Advanced_Modules/DOM/DOM_best_practices.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_best_practices.md
@@ -211,10 +211,10 @@ You can also keep your CRUD scripts fast by using the ['FullCrudMeta' variant](x
 
 ### Watch out for race conditions when updating DOM instances
 
-Since updates to a DOM instance can be executed on any agent in the cluster, it is possible for the same DOM instance to be modified at nearly the same time by different agents. This can lead to a race condition, where one agent's updates may unintentionally overwrite changes made by another. To minimize the risk of this happening:
+Since updates to a DOM instance can be executed on any Agent in a cluster, it is possible for the same DOM instance to be modified at nearly the same time by different Agents. This can lead to a race condition, where one Agent's updates may unintentionally overwrite changes made by another. To minimize the risk of this happening:
 
-- Restrict updates to a single agent per module. e.g., by implementing this logic in an element or by ensuring these requests are only sent to the same agent.
-- Reduce the time between retrieving and updating a DOM instance to narrow the window in which another conflicting update could occur.
+- Restrict updates to a single Agent per module, for example by implementing this logic in an element or by ensuring these requests are only sent to the same Agent.
+- Reduce the time between retrieving and updating a DOM instance to narrow the window in which another, conflicting update could occur.
 
 ## UI and GQI
 

--- a/user-guide/Advanced_Modules/DOM/DOM_best_practices.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_best_practices.md
@@ -209,6 +209,13 @@ When defining [CRUD scripts](xref:ExecuteScriptOnDomInstanceActionSettings) or [
 
 You can also keep your CRUD scripts fast by using the ['FullCrudMeta' variant](xref:ExecuteScriptOnDomInstanceActionSettings#full-crud-meta-type) of the CRUD scripts. This way, you already have access to the full `DomInstance` instead of having to retrieve it from DataMiner inside the script. This saves a lot of time and allows your script to more efficiently retrieve the information from the `DomInstance` that is required.
 
+### Watch out for race conditions when updating DOM instances
+
+Since updates to a DOM instance can be executed on any agent in the cluster, it is possible for the same DOM instance to be modified at nearly the same time by different agents. This can lead to a race condition, where one agent's updates may unintentionally overwrite changes made by another. To minimize the risk of this happening:
+
+- Restrict updates to a single agent per module. e.g., by implementing this logic in an element or by ensuring these requests are only sent to the same agent.
+- Reduce the time between retrieving and updating a DOM instance to narrow the window in which another conflicting update could occur.
+
 ## UI and GQI
 
 ### Avoid using DOM data on the right side of a join in GQI

--- a/user-guide/Advanced_Modules/DOM/DOM_data_storage.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_data_storage.md
@@ -33,9 +33,9 @@ From DataMiner 10.3.9/10.4.0 onwards<!-- RN 36412 -->, a full cache of the DOM c
 ## Cleaning up DOM data from the database
 
 To clean up a DOM manager and remove all DOM data, each DOM object needs to be deleted. This can be done in a custom script using the DOM helper, or via the ["Delete DOM Manager" feature](xref:SLNetClientTest_removing_DOM_Manager) in the DOM window of SLNetClientTest tool. This tool can be used to delete managers with up to 10&thinsp;000 instances. To clean up larger DOM managers, use the script approach first to remove the DOM instances.
-
+<!-- 
 > [!NOTE]
-> From DataMiner 10.5.6/10.6.0 onwards<!-- RN TBD -->, it is possible to use the SLNetClientTest tool to clean up larger managers with up to 100&thinsp;000 DOM instances.
+> From DataMiner 10.5.6/10.6.0 onwards, it is possible to use the SLNetClientTest tool to clean up larger managers with up to 100&thinsp;000 DOM instances. -->
 
 When using a self-managed database (Elasticsearch or OpenSearch), you will need to remove the indices in the database as well. This is not needed for a DMS using STaaS.
 

--- a/user-guide/Advanced_Modules/DOM/DOM_data_storage.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_data_storage.md
@@ -4,7 +4,9 @@ uid: DOM_data_storage
 
 # DOM data storage
 
-All DOM data are stored in an [indexing database](xref:Indexing_Database). Data for each object are stored in a separate index. Currently, the following indices are in use:
+All DOM data are stored in an [indexing database](xref:Indexing_Database). For the fastest and easiest deployment, we recommend using [Storage as a Service (STaaS)](xref:STaaS).
+
+In a self-managed OpenSearch or Elasticsearch database, the data for each object is stored in a separate index. Currently, the following indices are in use:
 
 | Object name | Index name |
 |--|--|
@@ -15,6 +17,10 @@ All DOM data are stored in an [indexing database](xref:Indexing_Database). Data 
 | [DomBehaviorDefinition](xref:DomBehaviorDefinition) | cdombehaviordefinition_{moduleId} |
 | [HistoryChange](xref:DOM_history#historychange) | chistory_dominstance_{moduleId} |
 
+## Backups
+
+When using [Storage as a Service (STaaS)](xref:STaaS), all DOM data is automatically backed up. For more information on self-managed database backups, see [Configuring OpenSearch backups](xref:Configuring_OpenSearch_Backups) or [Configuring Elasticsearch backups](xref:Configuring_Elasticsearch_backups).
+
 ## Caching
 
 From DataMiner 10.3.9/10.4.0 onwards<!-- RN 36412 -->, a full cache of the DOM configuration objects (`SectionDefinition`, `DomDefinition`, and `DomBehaviorDefinition`) is present by default. This means that all of these objects are stored in memory to improve the performance of the DOM manager. These caches are kept in sync across the cluster using the [DOM events](xref:DOM_events).
@@ -23,3 +29,61 @@ From DataMiner 10.3.9/10.4.0 onwards<!-- RN 36412 -->, a full cache of the DOM c
 >
 > - Correct delivery of the DOM events is important to keep these caches in sync. If the DMS is unstable and Agents frequently lose connection to each other, we recommend disabling the caches. You can do so using the [caching settings](xref:DOM_StorageSettings#cachingsettings) in the `ModuleSettings`.
 > - If a DOM configuration object event is lost, the cache may not reflect the correct state. This will be automatically fixed at midnight, as the "midnight sync" will ensure that the caches are correct by comparing them with the database. You can also trigger this sync manually in the SLNetClientTest tool. For more information, see [Triggering a midnight sync for a DOM manager](xref:SLNetClientTest_triggering_DOM_midnight_sync).
+
+## Cleaning up DOM data from the DB
+
+To cleanup a DOM manager and remove all DOM data, each DOM object needs to be deleted. This can be done in a custom script using the DOM helper, or via the ['Delete DOM Manager' feature](xref:SLNetClientTest_removing_DOM_Manager) in the DOM window of the SLNetClientTest tool. This tool can be used to delete managers with up to 10,000 instances. To cleanup larger DOM managers, use the script approach first to remove the DOM instances.
+
+> [!NOTE]
+> From DataMiner 10.5.6/10.6.0 onwards<!-- RN TBD -->, it is possible to use the SLNetClientTest to cleanup larger managers with up to 100,000 DOM instances.
+
+When using a self-managed database (Elasticsearch or OpenSearch), you will need to remove the indices in the database as well. This is not needed for a DMS using STaaS.
+
+### Removing DOM Indices in Elasticsearch or OpenSearch
+
+For each DOM manager, multiple indices are created in the database to store various DOM objects. Specifically, the DOM instance index mapping contains linking information between FieldDescriptor IDs and types. This can prevent redeployment of a modified model with the same module ID if the mappings no longer match.
+
+To avoid potential mapping conflicts, it is recommended to delete these indices entirely before redeployment. This can be done using the Elasticsearch or OpenSearch REST API by sending a delete request for all associated indices. However, the simplest approach is to use the database management tool **Elasticvue**.
+
+> [!NOTE]
+> After removing the indices from the database, restart your DMS to apply the changes.
+
+> [!WARNING]
+> Incorrectly modifying database content can result in data loss or corrupted configurations. Double-check all operations before proceeding.
+
+Follow these steps to remove the relevant indices using Elasticvue:
+
+1. Install the [Elasticvue tool](https://elasticvue.com/installation) as a desktop application or as a browser extension.
+
+1. Open Elasticvue and click **'Add Elasticsearch Cluster'**. (This also works with OpenSearch clusters.)
+
+1. Ensure the **URI** and **port** are correctly entered.
+
+    The IP address can be found in the `Skyline DataMiner\DB.xml` file. If authentication is required, configure **Basic Auth** accordingly.
+
+1. Click **'Connect'** to establish a connection with the cluster.
+
+    If the connection is successful, cluster statistics should be displayed.
+
+1. Navigate to the **'Indices'** tab in the top-right menu.
+
+1. Enter the **module ID** of the DOM manager in the filter box at the top right.
+
+    The following six indices should be listed:
+
+    - `dms-cdombehaviordefinition_...`
+    - `dms_cdomdefinition_...`
+    - `dms_cdominstance_...`
+    - `dms_cdomsectiondefinition_...`
+    - `dms_cdomtemplate_...`
+    - `dms_chistory_dominstance_...`
+
+1. Select all six indices by checking the box next to each name.
+
+1. Click the green **'Bulk Actions'** button in the bottom-left corner and select **'Delete 6 Indices'**.
+
+1. Verify the indices listed in the confirmation pop-up and click **'OK'** if they are correct.
+
+1. Restart your DMS to ensure the changes take effect and the system correctly detects the removed indices.
+
+Once these steps are completed, the indices will be removed from the cluster, allowing you to redeploy a DOM module with the same ID and an updated configuration.

--- a/user-guide/Advanced_Modules/DOM/DOM_data_storage.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_data_storage.md
@@ -30,20 +30,20 @@ From DataMiner 10.3.9/10.4.0 onwards<!-- RN 36412 -->, a full cache of the DOM c
 > - Correct delivery of the DOM events is important to keep these caches in sync. If the DMS is unstable and Agents frequently lose connection to each other, we recommend disabling the caches. You can do so using the [caching settings](xref:DOM_StorageSettings#cachingsettings) in the `ModuleSettings`.
 > - If a DOM configuration object event is lost, the cache may not reflect the correct state. This will be automatically fixed at midnight, as the "midnight sync" will ensure that the caches are correct by comparing them with the database. You can also trigger this sync manually in the SLNetClientTest tool. For more information, see [Triggering a midnight sync for a DOM manager](xref:SLNetClientTest_triggering_DOM_midnight_sync).
 
-## Cleaning up DOM data from the DB
+## Cleaning up DOM data from the database
 
-To cleanup a DOM manager and remove all DOM data, each DOM object needs to be deleted. This can be done in a custom script using the DOM helper, or via the ['Delete DOM Manager' feature](xref:SLNetClientTest_removing_DOM_Manager) in the DOM window of the SLNetClientTest tool. This tool can be used to delete managers with up to 10,000 instances. To cleanup larger DOM managers, use the script approach first to remove the DOM instances.
+To clean up a DOM manager and remove all DOM data, each DOM object needs to be deleted. This can be done in a custom script using the DOM helper, or via the ["Delete DOM Manager" feature](xref:SLNetClientTest_removing_DOM_Manager) in the DOM window of SLNetClientTest tool. This tool can be used to delete managers with up to 10&thinsp;000 instances. To clean up larger DOM managers, use the script approach first to remove the DOM instances.
 
 > [!NOTE]
-> From DataMiner 10.5.6/10.6.0 onwards<!-- RN TBD -->, it is possible to use the SLNetClientTest to cleanup larger managers with up to 100,000 DOM instances.
+> From DataMiner 10.5.6/10.6.0 onwards<!-- RN TBD -->, it is possible to use the SLNetClientTest tool to clean up larger managers with up to 100&thinsp;000 DOM instances.
 
 When using a self-managed database (Elasticsearch or OpenSearch), you will need to remove the indices in the database as well. This is not needed for a DMS using STaaS.
 
-### Removing DOM Indices in Elasticsearch or OpenSearch
+### Removing DOM indices in Elasticsearch or OpenSearch
 
 For each DOM manager, multiple indices are created in the database to store various DOM objects. Specifically, the DOM instance index mapping contains linking information between FieldDescriptor IDs and types. This can prevent redeployment of a modified model with the same module ID if the mappings no longer match.
 
-To avoid potential mapping conflicts, it is recommended to delete these indices entirely before redeployment. This can be done using the Elasticsearch or OpenSearch REST API by sending a delete request for all associated indices. However, the simplest approach is to use the database management tool **Elasticvue**.
+To avoid potential mapping conflicts, we recommend deleting these indices entirely before redeployment. This can be done using the Elasticsearch or OpenSearch REST API by sending a delete request for all associated indices. However, the simplest approach is to use the database management tool **Elasticvue**.
 
 > [!NOTE]
 > After removing the indices from the database, restart your DMS to apply the changes.
@@ -55,35 +55,35 @@ Follow these steps to remove the relevant indices using Elasticvue:
 
 1. Install the [Elasticvue tool](https://elasticvue.com/installation) as a desktop application or as a browser extension.
 
-1. Open Elasticvue and click **'Add Elasticsearch Cluster'**. (This also works with OpenSearch clusters.)
+1. Open Elasticvue and click *Add Elasticsearch Cluster*. (This also works with OpenSearch clusters.)
 
 1. Ensure the **URI** and **port** are correctly entered.
 
-    The IP address can be found in the `Skyline DataMiner\DB.xml` file. If authentication is required, configure **Basic Auth** accordingly.
+   You can find the IP address in the `C:\Skyline DataMiner\DB.xml` file. If authentication is required, configure *Basic Auth* accordingly.
 
-1. Click **'Connect'** to establish a connection with the cluster.
+1. Click *Connect* to establish a connection with the cluster.
 
-    If the connection is successful, cluster statistics should be displayed.
+   If the connection is successful, cluster statistics should be displayed.
 
-1. Navigate to the **'Indices'** tab in the top-right menu.
+1. Navigate to the *Indices* tab in the top-right menu.
 
-1. Enter the **module ID** of the DOM manager in the filter box at the top right.
+1. Enter the **module ID** of the DOM manager in the filter box in the top-right corner.
 
-    The following six indices should be listed:
+   The following six indices should be listed:
 
-    - `dms-cdombehaviordefinition_...`
-    - `dms_cdomdefinition_...`
-    - `dms_cdominstance_...`
-    - `dms_cdomsectiondefinition_...`
-    - `dms_cdomtemplate_...`
-    - `dms_chistory_dominstance_...`
+   - `dms-cdombehaviordefinition_...`
+   - `dms_cdomdefinition_...`
+   - `dms_cdominstance_...`
+   - `dms_cdomsectiondefinition_...`
+   - `dms_cdomtemplate_...`
+   - `dms_chistory_dominstance_...`
 
-1. Select all six indices by checking the box next to each name.
+1. Select all six indices by selecting the box next to each name.
 
-1. Click the green **'Bulk Actions'** button in the bottom-left corner and select **'Delete 6 Indices'**.
+1. Click the green *Bulk Actions* button in the lower left corner and select *Delete 6 Indices*.
 
-1. Verify the indices listed in the confirmation pop-up and click **'OK'** if they are correct.
+1. Verify the indices listed in the confirmation box and click *OK* if they are correct.
 
-1. Restart your DMS to ensure the changes take effect and the system correctly detects the removed indices.
+1. Restart your DMS to ensure that the changes take effect and the system correctly detects the removed indices.
 
-Once these steps are completed, the indices will be removed from the cluster, allowing you to redeploy a DOM module with the same ID and an updated configuration.
+Once these steps have been completed, the indices will be removed from the cluster, allowing you to redeploy a DOM module with the same ID and an updated configuration.

--- a/user-guide/Advanced_Modules/DOM/DOM_managers.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_managers.md
@@ -11,11 +11,11 @@ The DOM manager handles every request related to a specific set of models, logic
 > [!NOTE]
 >
 > - Logging for each DOM manager is done in a separate log file with the name "SLDomManager_{moduleId}", e.g. "SLDomManager_my_module.txt".
-> - See the [DOM storage](xref:DOM_data_storage#backups) page for more info on backing up the data of a DOM manager.
+> - For more information on backing up the data of a DOM manager, refer to [DOM data storage](xref:DOM_data_storage#backups).
 
 ## Module ID
 
-To create a DOM manager, you first need to create a [ModuleSettings](xref:DOM_ModuleSettings) object, which includes a **unique module ID** that is used to identify the DOM manager instance in the DMS. In the module settings, you can also configure the behavior of the DOM manager. You can for example define the scripts that will be executed on every create action, or you can enable information events. See the different sub pages under the ModuleSettings page for more info on these different features.
+To create a DOM manager, you first need to create a [ModuleSettings](xref:DOM_ModuleSettings) object, which includes a **unique module ID** that is used to identify the DOM manager instance in the DMS. In the module settings, you can also configure the behavior of the DOM manager. You can for example define the scripts that will be executed on every create action, or you can enable information events. For more information on these different features, refer to the subpages under [DOM module settings](xref:DOM_ModuleSettings).
 
 ## Creation and startup logic
 

--- a/user-guide/Advanced_Modules/DOM/DOM_managers.md
+++ b/user-guide/Advanced_Modules/DOM/DOM_managers.md
@@ -6,16 +6,16 @@ uid: DOM_managers
 
 A DOM manager manages create, read, update, and delete (CRUD) actions performed on DOM objects. Multiple DOM manager instances can be used at the same time in a DMS, for instance for invoicing, planned maintenance, etc.
 
-A DOM manager sends out various [events](xref:DOM_events) when actions are done on the DOM objects and tracks the [history](xref:DOM_history) of all changes done to the field values of a DOM instance. It also allows you to configure the [status system](xref:DOM_status_system) for a DOM definition.
+The DOM manager handles every request related to a specific set of models, logically grouped in a module and identified by a module ID. The manager for example also sends out various [events](xref:DOM_events) when actions are done on the DOM objects and tracks the [history](xref:DOM_history) of all changes done to the field values of a DOM instance. It contains the checking logging that ensures instance updates adhere to the model definition and ensures the timely execution of CRUD scripts.
 
 > [!NOTE]
 >
 > - Logging for each DOM manager is done in a separate log file with the name "SLDomManager_{moduleId}", e.g. "SLDomManager_my_module.txt".
-> - A backup of all DOM manager data can be taken using the backup option *Create a backup of the database* > *Include all DomManager data in backup*. This is by default enabled in the backup preset *Full Backup*. See [Configuring the DataMiner backups](xref:Backing_up_a_DataMiner_Agent_in_DataMiner_Cube#configuring-the-dataminer-backups).
+> - See the [DOM storage](xref:DOM_data_storage#backups) page for more info on backing up the data of a DOM manager.
 
 ## Module ID
 
-To create a DOM manager, you first need to create a [ModuleSettings](xref:DOM_ModuleSettings) object, which includes a **unique module ID** that is used to identify the DOM manager instance in the DMS. In the module settings, you can also configure the behavior of the DOM manager. You can for example define the permissions that will be needed for the various script actions, or you can enable information events.
+To create a DOM manager, you first need to create a [ModuleSettings](xref:DOM_ModuleSettings) object, which includes a **unique module ID** that is used to identify the DOM manager instance in the DMS. In the module settings, you can also configure the behavior of the DOM manager. You can for example define the scripts that will be executed on every create action, or you can enable information events. See the different sub pages under the ModuleSettings page for more info on these different features.
 
 ## Creation and startup logic
 

--- a/user-guide/Advanced_Modules/toc.yml
+++ b/user-guide/Advanced_Modules/toc.yml
@@ -807,6 +807,8 @@ items:
   - name: DataMiner Object Models (DOM)
     topicUid: DOM
     items:
+      - name: DOM managers
+        topicUid: DOM_managers
       - name: DOM objects
         topicUid: DOM_objects
         items:
@@ -846,18 +848,8 @@ items:
             topicUid: DomTemplate
           - name: DomBehaviorDefinition object
             topicUid: DomBehaviorDefinition
-      - name: DOM managers
-        topicUid: DOM_managers
       - name: DOM helper class
         topicUid: DomHelper_class
-      - name: DOM events
-        topicUid: DOM_events
-      - name: DOM history
-        topicUid: DOM_history
-      - name: DOM status system
-        topicUid: DOM_status_system
-      - name: DOM actions
-        topicUid: DOM_actions
       - name: DOM module settings
         topicUid: DOM_ModuleSettings
         items:
@@ -881,10 +873,16 @@ items:
             topicUid: DOM_DomInstanceHistorySettings
           - name: StorageSettings
             topicUid: DOM_StorageSettings
+      - name: DOM events
+        topicUid: DOM_events
+      - name: DOM history
+        topicUid: DOM_history
+      - name: DOM status system
+        topicUid: DOM_status_system
+      - name: DOM actions
+        topicUid: DOM_actions
       - name: DOM data storage
         topicUid: DOM_data_storage
-      - name: Best practices
-        topicUid: DOM_best_practices
       - name: DOM examples
         items:
           - name: Invoice app example
@@ -940,6 +938,8 @@ items:
             topicUid: DOM_Remove_FieldDescriptor_Definition
           - name: Generating code with the DOM Editor
             topicUid: DOM_Generating_code_with_the_DOM_editor
+      - name: Best practices
+        topicUid: DOM_best_practices
   - name: Experience and Performance Management (EPM)
     topicUid: EPM
     items:

--- a/user-guide/Advanced_Modules/toc.yml
+++ b/user-guide/Advanced_Modules/toc.yml
@@ -924,6 +924,8 @@ items:
                 topicUid: DOM_editor_deleting_section
               - name: Naming a DOM instance
                 topicUid: DOM_editor_naming_instance
+      - name: Best practices
+        topicUid: DOM_best_practices
       - name: Tutorials
         items:
           - name: Getting started with DOM
@@ -938,8 +940,6 @@ items:
             topicUid: DOM_Remove_FieldDescriptor_Definition
           - name: Generating code with the DOM Editor
             topicUid: DOM_Generating_code_with_the_DOM_editor
-      - name: Best practices
-        topicUid: DOM_best_practices
   - name: Experience and Performance Management (EPM)
     topicUid: EPM
     items:

--- a/user-guide/Reference/DataMiner_Tools/SLNetClientTest_tool/SLNetClientTest_tool_advanced_procedures/SLNetClientTest_removing_DOM_Manager.md
+++ b/user-guide/Reference/DataMiner_Tools/SLNetClientTest_tool/SLNetClientTest_tool_advanced_procedures/SLNetClientTest_removing_DOM_Manager.md
@@ -33,7 +33,7 @@ To do so:
 1. Click *OK*.
 
 > [!IMPORTANT]
-> Removing the DOM manager will not remove the corresponding indices from the Elasticsearch database. These indices have to be deleted manually. If you do not delete them manually, make sure you do not reuse the module ID, as this could cause configuration conflicts. See the [DOM storage docs](xref:DOM_data_storage#removing-dom-indices-in-elasticsearch-or-opensearch) for more info.
+> Removing the DOM manager will not remove the corresponding indices from the Elasticsearch database. These indices have to be deleted manually. If you do not delete them manually, make sure you do not reuse the module ID, as this could cause configuration conflicts. For more information, see [Removing DOM indices in Elasticsearch or OpenSearch](xref:DOM_data_storage#removing-dom-indices-in-elasticsearch-or-opensearch).
 
 > [!WARNING]
 > Always be extremely careful when using the SLNetClientTest tool, as it can have far-reaching consequences on the functionality of your DataMiner System.

--- a/user-guide/Reference/DataMiner_Tools/SLNetClientTest_tool/SLNetClientTest_tool_advanced_procedures/SLNetClientTest_removing_DOM_Manager.md
+++ b/user-guide/Reference/DataMiner_Tools/SLNetClientTest_tool/SLNetClientTest_tool_advanced_procedures/SLNetClientTest_removing_DOM_Manager.md
@@ -33,7 +33,7 @@ To do so:
 1. Click *OK*.
 
 > [!IMPORTANT]
-> Removing the DOM manager will not remove the corresponding indices from the Elasticsearch database. These indices have to be deleted manually. If you do not delete them manually, make sure you do not reuse the module ID, as this could cause configuration conflicts.
+> Removing the DOM manager will not remove the corresponding indices from the Elasticsearch database. These indices have to be deleted manually. If you do not delete them manually, make sure you do not reuse the module ID, as this could cause configuration conflicts. See the [DOM storage docs](xref:DOM_data_storage#removing-dom-indices-in-elasticsearch-or-opensearch) for more info.
 
 > [!WARNING]
 > Always be extremely careful when using the SLNetClientTest tool, as it can have far-reaching consequences on the functionality of your DataMiner System.


### PR DESCRIPTION
Changes include:
- Reordered some DOM pages for a more logic order in the sidebar
- Removed the reference to the Jobs module since it is obsolete
- Added an extra best practice concerning race conditions
- Extended the data storage with references to STaaS, backups and how to clear data for a DOM manager.
- Some tweaks to the DOM managers page, which was a bit out of date