### PR TITLE
Update DataMiner_Cube_deployment_methods.md

### DIFF
--- a/user-guide/Getting_started/Accessing_DataMiner/Accessing_DataMiner_Cube/Installing_DataMiner_Cube/DataMiner_Cube_deployment_methods.md
+++ b/user-guide/Getting_started/Accessing_DataMiner/Accessing_DataMiner_Cube/Installing_DataMiner_Cube/DataMiner_Cube_deployment_methods.md
@@ -80,7 +80,7 @@ Below you can find an overview of the different methods that can be used to depl
 
 - No support for automatic updates.
 
-- The `CubeVersion.msi` packages contain the following optional features (which are not exposed in the UI wizard):
+- The `DataMiner Cube.msi` packages contain the following optional features (which are not exposed in the UI wizard):
 
   - *MainFeature*: CubeLauncher + one Cube version (mandatory).
   - *Autorun*: Adds a registry key to show the CubeLauncher icon in the notification area (i.e. "systray") at logon for all users.
@@ -102,7 +102,7 @@ Below you can find an overview of the different methods that can be used to depl
   msiexec /i CubeVersion-10.2.1.msi ADDLOCAL=ALL
   ```
 
-  Installing multiple `CubeVersion.msi` packages side-by-side will keep the latest version of DataMinerCube.exe (i.e. the launcher) in place:
+  Installing multiple `DataMiner Cube.msi` packages side-by-side will keep the latest version of DataMinerCube.exe (i.e. the launcher) in place:
 
   - Installing an older version after a newer version will not overwrite the launcher.
   - Uninstalling the newest version will not roll back the launcher to the previously installed version.


### PR DESCRIPTION
replaced CubeVersion.msi by DataMiner Cube.msi, as cubeversion.msi only exists in test packages, not in release packages.