### PR TITLE
CICD - Update info about new versions of .NET tools

### DIFF
--- a/develop/CICD/Command Line/CICD_Command_Line_Examples.md
+++ b/develop/CICD/Command Line/CICD_Command_Line_Examples.md
@@ -72,13 +72,13 @@ dotnet tool install -g Skyline.DataMiner.CICD.Tools.DataMinerDeploy
 
 dataminer-package-create dmapp "C:\PathToDirectoryOfSolution" --name HelloFromPowershell --output "C:\CreatedPackages" --type automation
 $id = dataminer-catalog-upload --path-to-artifact "C:\CreatedPackages\HelloFromPowershell.dmapp" --dm-catalog-token 1234567
-dataminer-package-deploy from-catalog --artifact-id "$id" --dm-catalog-token 1234567
+dataminer-package-deploy from-volatile --artifact-id "$id" --dm-system-token 1234567
 
 ```
 
 ### Ubuntu terminal
 
-Prerequisites on Ubuntu/Linux: you need dotnet-sdk-6.0.
+Prerequisites on Ubuntu/Linux: you need dotnet-sdk-8.0.
 
 ```bash
 # Get Ubuntu version
@@ -96,7 +96,7 @@ rm packages-microsoft-prod.deb
 # Update packages
 sudo apt update
 
-sudo apt install dotnet-sdk-6.0
+sudo apt install dotnet-sdk-8.0
 ```
 
 You will need to restart your session or log out and back in before the next part.

--- a/develop/CICD/GitHub/CICD_GitHub_Examples.md
+++ b/develop/CICD/GitHub/CICD_GitHub_Examples.md
@@ -176,6 +176,6 @@ jobs:
         echo "${{ steps.UploadDMPROTOCOL.outputs.uploadOutput }}"
         
     - name: Deploy DMAPP
-      run: dataminer-package-deploy from-catalog --artifact-id "${{ steps.UploadDMPROTOCOL.outputs.uploadOutput }}" --dm-catalog-token "${{ secrets.DATAMINER_DEPLOY_KEY }}"
+      run: dataminer-package-deploy from-volatile --artifact-id "${{ steps.UploadDMPROTOCOL.outputs.uploadOutput }}" --dm-system-token "${{ secrets.DATAMINER_DEPLOY_KEY }}"
       shell: bash
 ```

--- a/develop/CICD/GitHub/GitHubReusableWorkflows/GitHub_Reusable_Workflows.md
+++ b/develop/CICD/GitHub/GitHubReusableWorkflows/GitHub_Reusable_Workflows.md
@@ -67,7 +67,7 @@ jobs:
       sonarCloudProjectName: TODO: Go to 'https://sonarcloud.io/projects/create' and create a project. Then enter the id of the project as mentioned in the SonarCloud project URL here.
       # The API-key: generated in the dataminer.services Admin app (https://admin.dataminer.services/) as authentication for a certain DataMiner System.
     secrets:
-      api-key: ${{ secrets.DATAMINER_DEPLOY_KEY }}
+      api-key: ${{ secrets.DATAMINER_TOKEN }}
       sonarCloudToken: ${{ secrets.SONAR_TOKEN }}
 ```
 

--- a/develop/CICD/GitHub/GitHubReusableWorkflows/GitHub_Reusable_Workflows_Automation_Master_Workflow.md
+++ b/develop/CICD/GitHub/GitHubReusableWorkflows/GitHub_Reusable_Workflows_Automation_Master_Workflow.md
@@ -32,7 +32,7 @@ Only when the actions above and the "Artifact Creation" job have been successful
 > This workflow makes use of the [GitHub to Catalog tool](xref:github_reusable_workflows#github-to-catalog-tool). For this tool to work, the GitHub repository must infer the Catalog item type using either naming conventions or GitHub topics.
 
 > [!IMPORTANT]
-> This workflow can run for both development or release cycles. A development cycle is any run that triggered from a change to a branch. A release cycle is any run that triggered from adding a tag with format `A.B.C.D` or `A.B.C`. During a development cycle, only the quality control actions are performed and artifact uploading is ignored (this means the secret "DATAMINER_DEPLOY_KEY" is optional). During a release cycle, an actual artifact is created and uploaded to the Catalog (this means the secret "DATAMINER_DEPLOY_KEY" is required). A release cycle can also be a pre-release with versions of format `A.B.C.D-text` or `A.B.C-text`.
+> This workflow can run for both development or release cycles. A development cycle is any run that triggered from a change to a branch. A release cycle is any run that triggered from adding a tag with format `A.B.C.D` or `A.B.C`. During a development cycle, only the quality control actions are performed and artifact uploading is ignored (this means the secret "DATAMINER_TOKEN" is optional). During a release cycle, an actual artifact is created and uploaded to the Catalog (this means the secret "DATAMINER_TOKEN" is required). A release cycle can also be a pre-release with versions of format `A.B.C.D-text` or `A.B.C-text`.
 
 ## Prerequisites
 
@@ -42,7 +42,7 @@ Only when the actions above and the "Artifact Creation" job have been successful
 
 - Part of our quality control involves static code analysis through SonarCloud as a mandatory step. If you want to use this reusable workflow, you will need to have a SonarCloud organization setup, linked to your GitHub organization as described in the [SonarCloud help files](https://docs.sonarsource.com/sonarcloud/getting-started/github/).
 
-- Creating a GitHub release or tag will attempt to register your item as a private item in the Catalog. For this, the repository must have access to a DATAMINER_DEPLOY_KEY. For more information, see [GitHub secrets and tokens](xref:GitHub_Secrets).
+- Creating a GitHub release or tag will attempt to register your item as a private item in the Catalog. For this, the repository must have access to a DATAMINER_TOKEN. For more information, see [GitHub secrets and tokens](xref:GitHub_Secrets).
 
 ## How to use
 
@@ -77,7 +77,7 @@ jobs:
       sonarCloudProjectName: TODO: Go to 'https://sonarcloud.io/projects/create' and create a project. Then enter the id of the project as mentioned in the SonarCloud project URL here.
       # The API-key: generated in the dataminer.services Admin app (https://admin.dataminer.services/) as authentication for a certain DataMiner System.
     secrets:
-      api-key: ${{ secrets.DATAMINER_DEPLOY_KEY }}
+      api-key: ${{ secrets.DATAMINER_TOKEN }}
       sonarCloudToken: ${{ secrets.SONAR_TOKEN }}
 ```
 

--- a/develop/CICD/GitHub/GitHubReusableWorkflows/GitHub_Reusable_Workflows_Connector_Master_Workflow.md
+++ b/develop/CICD/GitHub/GitHubReusableWorkflows/GitHub_Reusable_Workflows_Connector_Master_Workflow.md
@@ -28,7 +28,7 @@ Only when the actions above and the "Artifact Creation" job have been successful
 > This workflow makes use of the [GitHub to Catalog tool](xref:github_reusable_workflows#github-to-catalog-tool). For this tool to work, the GitHub repository must infer the Catalog item type using either naming conventions or GitHub topics.
 
 > [!IMPORTANT]
-> This workflow can run for both development or release cycles. A development cycle is any run that triggered from a change to a branch. A release cycle is any run that triggered from adding a tag with format `A.B.C.D` or `A.B.C`. During a development cycle, only the quality control actions are performed and artifact uploading is ignored (this means the secret "DATAMINER_DEPLOY_KEY" is optional). During a release cycle, an actual artifact is created and uploaded to the Catalog (this means the secret "DATAMINER_DEPLOY_KEY" is required). A release cycle can also be a pre-release with versions of format `A.B.C.D-text` or `A.B.C-text`.
+> This workflow can run for both development or release cycles. A development cycle is any run that triggered from a change to a branch. A release cycle is any run that triggered from adding a tag with format `A.B.C.D` or `A.B.C`. During a development cycle, only the quality control actions are performed and artifact uploading is ignored (this means the secret "DATAMINER_TOKEN" is optional). During a release cycle, an actual artifact is created and uploaded to the Catalog (this means the secret "DATAMINER_TOKEN" is required). A release cycle can also be a pre-release with versions of format `A.B.C.D-text` or `A.B.C-text`.
 
 ## Prerequisites
 
@@ -36,7 +36,7 @@ Only when the actions above and the "Artifact Creation" job have been successful
 
 - Part of our quality control involves static code analysis through SonarCloud as a mandatory step. If you want to use this reusable workflow, you will need to have a SonarCloud organization setup, linked to your GitHub organization as described in the [SonarCloud help files](https://docs.sonarsource.com/sonarcloud/getting-started/github/).
 
-- Creating a GitHub release or tag will attempt to register your item as a private item in the Catalog. For this, the repository must have access to a DATAMINER_DEPLOY_KEY. For more information, see [GitHub secrets and tokens](xref:GitHub_Secrets).
+- Creating a GitHub release or tag will attempt to register your item as a private item in the Catalog. For this, the repository must have access to a DATAMINER_TOKEN. For more information, see [GitHub secrets and tokens](xref:GitHub_Secrets).
 
 ## How to use
 
@@ -71,7 +71,7 @@ jobs:
       sonarCloudProjectName: TODO: Go to 'https://sonarcloud.io/projects/create' and create a project. Then enter the id of the project as mentioned in the SonarCloud project URL here.
       # The API-key: generated in the dataminer.services Admin app (https://admin.dataminer.services/) as authentication for a certain DataMiner System.
     secrets:
-      api-key: ${{ secrets.DATAMINER_DEPLOY_KEY }}
+      api-key: ${{ secrets.DATAMINER_TOKEN }}
       sonarCloudToken: ${{ secrets.SONAR_TOKEN }}
 ```
 

--- a/develop/CICD/GitHub/GitHubReusableWorkflows/GitHub_Reusable_Workflows_NuGet_Solution_Master_Workflow.md
+++ b/develop/CICD/GitHub/GitHubReusableWorkflows/GitHub_Reusable_Workflows_NuGet_Solution_Master_Workflow.md
@@ -23,21 +23,11 @@ The goal of this workflow is to automatically create and upload reusable .NET li
   - [Analyze](#analyze)
   - [Quality gate](#quality-gate)
 
-  If the library passes these checks, the job will archive the created NuGet package and provide it as an artifact. The next job will attempt to sign the package.
-
-- Sign:
-
-  This job will use a provided .pfx certification that was BASE64-encoded as a GitHub secret to sign the created NuGet package. The job consists of the following steps:
-
-  - [Download unsigned NuGet](#download-unsigned-nuget)
-  - [Decrypt signature File](#decrypt-signature-file)
-  - [Sign NuGet package](#sign-nuget-package)
-
-  If signing is successful, the next job will attempt to push the package to [nuget.org](https://nuget.org).
+  If the library passes these checks, the job will archive the created NuGet package and provide it as an artifact. The next job will attempt to push the package.
 
 - Push:
 
-  - [Push to nuget.org](#push-to-nugetorg)
+  - [Push to GitHub NuGet registry](#push-to-github-nuget-registry)
 
 > [!IMPORTANT]
 > This workflow can run for both development or release cycles. A development cycle is any run that triggered from a change on a branch. A release cycle is any run that triggered from adding a tag with format A.B.C or A.B.C-text. During the development cycle, the version of an artifact automatically includes the run number. The .nupkg is available as artifact on GitHub. During the release cycle, the version of the artifact becomes the tag provided and the .nupkg is published on nuget.org. A release cycle can also release a pre-release version of a NuGet package. To do so, simply tag with format A.B.C-text. (e.g. 1.0.1-AlphaOne).
@@ -52,7 +42,7 @@ For example:
 jobs:
 
   CI:
-    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Automation Master Workflow.yml@main
+    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Internal NuGet Solution Master Workflow.yml@main
 ```
 
 For most reusable workflows, several arguments and secrets need to be provided. You can find out which arguments and secrets by opening the reusable workflow and looking at the "inputs:" and "secrets:" sections located at the top of the file.
@@ -67,7 +57,7 @@ For example:
 jobs:
 
   CI:
-    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Automation Master Workflow.yml@main
+    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Internal NuGet Solution Master Workflow.yml@main
     with:
       referenceName: ${{ github.ref_name }}
       runNumber: ${{ github.run_number }}
@@ -75,10 +65,9 @@ jobs:
       repository: ${{ github.repository }}
       owner: ${{ github.repository_owner }}
       sonarCloudProjectName: TODO: Go to 'https://sonarcloud.io/projects/create' and create a project. Then enter the id of the project as mentioned in the sonarcloud project URL here.
-      # The API-key: generated in the dataminer.services Admin app (https://admin.dataminer.services/) as authentication for a certain DataMiner System.
     secrets:
-      api-key: ${{ secrets.DATAMINER_DEPLOY_KEY }}
       sonarCloudToken: ${{ secrets.SONAR_TOKEN }}
+      nugetApiKey: ${{ secrets.NUGETAPIKEY_GITHUB }}
 ```
 
 ## Skyline quality gate
@@ -110,36 +99,10 @@ Performs static code analysis using [SonarCloud](https://www.sonarsource.com/pro
 
 Checks the results of all previous steps and combines them into a single result that will either block the workflow from continuing or allow it to continue to the next job.
 
-## Sign
-
-### Download unsigned NuGet
-
-Retrieves the artifact .nupkg created during the Skyline quality gate job.
-
-### Decrypt signature file
-
-Downloads a .pfx file stored as a BASE64-encrypted string, containing the certificate from the action secrets in GitHub, and decrypt this for use in signing.
-
-In order to make such a BASE64 string of a .pfx on a Windows machine:
-
-1. Run the following command in a command prompt or PowerShell prompt window:
-
-   `certutil -encode infile outfile`
-
-1. Open the "outfile" with a TXT editor and copy the string content.
-
-1. Paste that content into an action secret on GitHub called *PFX*.
-
-1. Add a second action secret on GitHub called *PFXPASSWORD*, containing the password of the PFX.
-
-### Sign NuGet package
-
-Uses the previously decrypted signature file and signs your NuGet packages.
-
 ## Push
 
-### Push to nuget.org
+### Push to GitHub NuGet registry
 
-If this is a release cycle, the NuGet packages are published to nuget.org.
+If this is a release cycle, the NuGet packages are published to the [Skyline Communications GitHub NuGet registry](https://github.com/orgs/SkylineCommunications/packages).
 
 These can be both stable releases (A.B.C) or pre-releases.(A.B.C-text).

--- a/develop/CICD/GitHub/GitHubReusableWorkflows/GitHub_Reusable_Workflows_Update_Catalog_Details.md
+++ b/develop/CICD/GitHub/GitHubReusableWorkflows/GitHub_Reusable_Workflows_Update_Catalog_Details.md
@@ -45,7 +45,7 @@ jobs:
     uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Update Catalog Details Workflow.yml@main
     secrets:
       # The API-key: generated in the dataminer.services Admin app (https://admin.dataminer.services/) as authentication for a certain DataMiner Organization or Agent.
-      api-key: ${{ secrets.DATAMINER_DEPLOY_KEY }}
+      api-key: ${{ secrets.DATAMINER_TOKEN }}
 ```
 
 ## Create or extend catalog.yml

--- a/develop/CICD/GitHub/GitHub_Secrets.md
+++ b/develop/CICD/GitHub/GitHub_Secrets.md
@@ -49,7 +49,7 @@ In the [Admin app](xref:About_the_Admin_app), two different types of keys can be
   - Name: DATAMINER_DEPLOY_KEY
   - Value: See [Managing dataminer.services keys](xref:Managing_dataminer_services_keys).
 
-- A dataminer.services **organization key** is scoped to the specific organization for which it was created and can  be used to perform uploads to and deploy from the Catalog. This includes uploading private artifacts to the Catalog that will only be accessible for the organization that your DMS belongs to. To upload and deploy items, you will need this key.
+- A dataminer.services **organization key** is scoped to the specific organization for which it was created and can be used to upload to and deploy from the Catalog. This includes uploading private artifacts to the Catalog that will only be accessible for the organization that your DMS belongs to. To upload and deploy items, you will need this key.
 
   - Name: DATAMINER_TOKEN
   - Value: See [Managing dataminer.services keys](xref:Managing_dataminer_services_keys).

--- a/develop/CICD/GitHub/GitHub_Secrets.md
+++ b/develop/CICD/GitHub/GitHub_Secrets.md
@@ -44,7 +44,7 @@ Several provided workflows may require static code analysis through SonarCloud i
 
 In the [Admin app](xref:About_the_Admin_app), two different types of keys can be created: system keys and organization keys. It is important that you use the correct key for specific actions.
 
-- A dataminer.services **system key** is scoped to the specific DMS for which it was created and can only be used for deployments to that DMS. It can also be used to upload private artifacts to the Catalog that will only be accessible for the organization that your DMS belongs to. To deploy connectors, you will need this key.
+- A dataminer.services **system key** is scoped to the specific DMS for which it was created and can only be used for volatile uploads and deployments to that DMS. All other uploads and deployments need to use the organization key.
 
   - Name: DATAMINER_DEPLOY_KEY
   - Value: See [Managing dataminer.services keys](xref:Managing_dataminer_services_keys).

--- a/develop/CICD/GitHub/GitHub_Secrets.md
+++ b/develop/CICD/GitHub/GitHub_Secrets.md
@@ -26,7 +26,7 @@ A key should be added as a secret in the repository, so that it is stored secure
 
 1. In the top-right corner, click *New repository secret*.
 
-1. Specify a name for your secret (e.g. `DATAMINER_DEPLOY_KEY`), paste the key as the value for the secret, and then save the secret.
+1. Specify a name for your secret (e.g. `DATAMINER_TOKEN`), paste the key as the value for the secret, and then save the secret.
 
    Once it is saved, your secret will be displayed in the *repository secrets*, and you will be able to use it in a workflow.
 
@@ -49,7 +49,7 @@ In the [Admin app](xref:About_the_Admin_app), two different types of keys can be
   - Name: DATAMINER_DEPLOY_KEY
   - Value: See [Managing dataminer.services keys](xref:Managing_dataminer_services_keys).
 
-- A dataminer.services **organization key** is scoped to the specific organization for which it was created and can **only be used to perform uploads to the Catalog**. This includes uploading private artifacts to the Catalog that will only be accessible for the organization that your DMS belongs to. To upload non-connector items, you will need this key.
+- A dataminer.services **organization key** is scoped to the specific organization for which it was created and can  be used to perform uploads to and deploy from the Catalog. This includes uploading private artifacts to the Catalog that will only be accessible for the organization that your DMS belongs to. To upload and deploy items, you will need this key.
 
   - Name: DATAMINER_TOKEN
   - Value: See [Managing dataminer.services keys](xref:Managing_dataminer_services_keys).

--- a/develop/CICD/GitHub/Marketplace_deployment_action.md
+++ b/develop/CICD/GitHub/Marketplace_deployment_action.md
@@ -16,9 +16,9 @@ To do so, you need to [create a dataminer.services key](#creating-a-dataminerser
 
 ## Creating a dataminer.services key
 
-A dataminer.services key is scoped to the specific DMS for which it was created and can only be used for deployments to that DMS.
+A dataminer.services key is scoped to the specific organization for which it was created and can only be used for uploads and deployments to that organization.
 
-For more information on how to create a dataminer.services key, refer to [Managing dataminer.services keys](xref:Managing_dataminer_services_keys).
+For more information on how to create a dataminer.services key, refer to [Managing dataminer.services keys](xref:Managing_dataminer_services_keys#organization-keys).
 
 ## Adding the key as a secret in the repository
 

--- a/develop/CICD/Skyline Communications/Troubleshooting/CICD_Troubleshooting_GitHubFailures.md
+++ b/develop/CICD/Skyline Communications/Troubleshooting/CICD_Troubleshooting_GitHubFailures.md
@@ -41,3 +41,11 @@ Once the setting is disabled, run your workflow again to verify if everything is
 This happens when you run the CI before you have created the SonarCloud project. This makes a SonarCloud project without the proper configuration.
 
 Contact the BOOST team so they can remove the project. You can then recreate the project with the correct settings.
+
+## Deploy Action
+
+### Error: 'agent-destination-id' must be provided for the Deploy stage.
+
+As of version 3 of the Deploy Action, the action uses organization keys instead of system keys. This means that a new input needs to be specified to which system the package needs to be deployed.
+
+More information about the 'agent-destination-id' can be found [here](https://github.com/SkylineCommunications/Skyline-DataMiner-Deploy-Action?tab=readme-ov-file#destination-agent-id).

--- a/develop/CICD/Skyline Communications/Troubleshooting/CICD_Troubleshooting_GitHubFailures.md
+++ b/develop/CICD/Skyline Communications/Troubleshooting/CICD_Troubleshooting_GitHubFailures.md
@@ -44,8 +44,8 @@ Contact the BOOST team so they can remove the project. You can then recreate the
 
 ## Deploy Action
 
-### Error: 'agent-destination-id' must be provided for the Deploy stage.
+### Error: 'agent-destination-id' must be provided for the Deploy stage
 
-As of version 3 of the Deploy Action, the action uses organization keys instead of system keys. This means that a new input needs to be specified to which system the package needs to be deployed.
+As of version 3 of the Deploy Action, the action uses organization keys instead of system keys. This means that a new input needs to be specified to determine the system to which the package needs to be deployed.
 
-More information about the 'agent-destination-id' can be found [here](https://github.com/SkylineCommunications/Skyline-DataMiner-Deploy-Action?tab=readme-ov-file#destination-agent-id).
+For more information about the *agent-destination-id*, refer to the [Deploy Action readme](https://github.com/SkylineCommunications/Skyline-DataMiner-Deploy-Action?tab=readme-ov-file#destination-agent-id).

--- a/develop/CICD/Tutorials/CICD_For_Connectors/CICD_Tutorial_GitHub_Register_Catalog_Version.md
+++ b/develop/CICD/Tutorials/CICD_For_Connectors/CICD_Tutorial_GitHub_Register_Catalog_Version.md
@@ -13,7 +13,7 @@ Expected duration: 10 minutes
 
 ## Prerequisites
 
-- An [organization key](xref:Managing_dataminer_services_keys#organization-keys) or [system key](xref:Managing_dataminer_services_keys#system-keys) or account with the *Owner* role in order to access/create keys.
+- An [organization key](xref:Managing_dataminer_services_keys#organization-keys) or account with the *Owner* role in order to access/create keys.
 
   > [!TIP]
   > See [Changing the role of a dataminer.services user](xref:Changing_the_role_of_a_dataminer_services_user)

--- a/user-guide/dataminer_services/Admin/Managing_dataminer_services_keys.md
+++ b/user-guide/dataminer_services/Admin/Managing_dataminer_services_keys.md
@@ -10,7 +10,7 @@ keywords: cloud keys
 
 ## System keys
 
-System keys can be used with the [GitHub action to deploy Automation scripts](xref:Marketplace_deployment_action) to a DMS that is connected to dataminer.services.
+System keys can be used with the [DataMinerDeploy .NET tool to deploy packages](https://github.com/SkylineCommunications/Skyline.DataMiner.CICD.Tools.DataMinerDeploy/tree/main/CICD.Tools.DataMinerDeploy#deploying-from-a-volatile-upload) to a DMS that is connected to dataminer.services.
 
 To view your system keys:
 


### PR DESCRIPTION
With the latest version of the upload & deploy tools, the organization key is now required (with the exception for volatile upload/deploy). In addition, certain calls that relied on a system key have been removed.