### PR TITLE
Update DataMiner_Compute_Requirements.md

### DIFF
--- a/user-guide/Reference/DataMiner_Compute_Requirements.md
+++ b/user-guide/Reference/DataMiner_Compute_Requirements.md
@@ -14,8 +14,7 @@ To make sure your DataMiner System performs optimally, it is important that suff
 Minimum requirements are displayed in gray, default requirements in light blue, and requirements for high-end applications in dark blue. Below this, you will find more detailed information on the requirements.
 
 > [!TIP]
->
-> - For all information on client requirements, see [DataMiner Client Requirements](xref:DataMiner_Client_Requirements).
+> For all information on client requirements, see [DataMiner Client Requirements](xref:DataMiner_Client_Requirements).
 
 > [!NOTE]
 > While this is not recommended, you can run DataMiner, Cassandra, and OpenSearch on a single server. In that case, the hardware requirements mentioned below need to be added up. For example, for RAM, you would need a minimum of 96 GB (32 GB for DataMiner, 32 GB for Cassandra, and 32 GB for OpenSearch).

--- a/user-guide/Reference/DataMiner_Compute_Requirements.md
+++ b/user-guide/Reference/DataMiner_Compute_Requirements.md
@@ -15,7 +15,6 @@ Minimum requirements are displayed in gray, default requirements in light blue, 
 
 > [!TIP]
 >
-> - To estimate how many nodes your DMS will need and what the specifications of these nodes should be, you can use the [DataMiner Node Calculator](https://community.dataminer.services/calculator/)
 > - For all information on client requirements, see [DataMiner Client Requirements](xref:DataMiner_Client_Requirements).
 
 > [!NOTE]


### PR DESCRIPTION
Removing the link to the node calculator from here. Node calculator is not taking into account smaller 4 or 8 vCPU nodes, and is more focused on Cassandra/OpenSearch. So, it can be removed from here.