### PR TITLE
Two-site redundant indexing clusters no longer supported

### DIFF
--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/Elasticsearch/dedicated_clustered_storage/Configuring_database/Configuring_multiple_datacenter_Elasticsearch_clusters.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/Elasticsearch/dedicated_clustered_storage/Configuring_database/Configuring_multiple_datacenter_Elasticsearch_clusters.md
@@ -6,7 +6,7 @@ keywords: allocation awareness, elasticsearch
 # Configuring a multiple data center Elasticsearch cluster
 
 > [!IMPORTANT]
-> Elasticsearch is **only supported up to version 6.8**, which is no longer supported by Elastic. We therefore recommend using [Storage as a Service](xref:STaaS) instead, or if you do want to continue using self-managed storage even though this is not recommended, using [OpenSearch](xref:OpenSearch_database).
+> Two-site redundant indexing clusters are no longer supported. For optimal redundancy, we recommend switching to [Storage as a Service](xref:STaaS).
 
 When the nodes in the Elasticsearch cluster are hosted in different data centers, racks, or zones, you should use **allocation awareness**. This will ensure that the data is correctly spread between the different locations and that you will still have all your data in case the connection to a location is lost.
 

--- a/user-guide/Advanced_Functionality/Databases/Indexing_database/OpenSearch_Database/Configuring_multiple_datacenter_OpenSearch_cluster.md
+++ b/user-guide/Advanced_Functionality/Databases/Indexing_database/OpenSearch_Database/Configuring_multiple_datacenter_OpenSearch_cluster.md
@@ -5,6 +5,9 @@ keywords: allocation awareness, opensearch
 
 # Configuring a multiple data center OpenSearch cluster
 
+> [!IMPORTANT]
+> Two-site redundant indexing clusters are no longer supported. For optimal redundancy, we recommend switching to [Storage as a Service](xref:STaaS).
+
 When the nodes in the OpenSearch cluster are hosted in different data centers, racks, or zones, you should use **allocation awareness**. This will ensure that the data is correctly spread between the different locations and that you will still have all your data in case the connection to a location is lost.
 
 There are two kinds of allocation awareness: shard allocation awareness and forced awareness. The difference between these two is the way they handle the shards when a location is suddenly unreachable. **Shard allocation awareness** will assign the shards of the missing replicas nodes that can still be reached in the other locations. This can cause a big load on those nodes. If your nodes would not be able to handle this, you can solve this by using **forced awareness** instead. Forced awareness will never allow copies of the same shard to be allocated to the same locations.


### PR DESCRIPTION
Added “End of Support” notes about two-site redundant indexing clusters, as requested by @SLC-Laurens-Vercruysse.