### PR TITLE
Update Catalog Link for Regression Test Management

### DIFF
--- a/solutions/custom_solutions/Regression_Test_Management/Installing_the_Regression_Test_Management_Solution.md
+++ b/solutions/custom_solutions/Regression_Test_Management/Installing_the_Regression_Test_Management_Solution.md
@@ -16,7 +16,7 @@ Before deploying this solution, ensure the following:
 
 ## Deploying the solution from the Catalog
 
-1. In the DataMiner Catalog, go to the [Regression Test Management package](https://catalog.dataminer.services/details/74ddb623-f9fb-4a99-acee-0965ba495e2d).
+1. In the DataMiner Catalog, go to the [Regression Test Management package](https://catalog.dataminer.services/details/27636bb4-e3ce-4a2a-bd28-fe514a4ac5e7).
 
 1. Click *Deploy*, and then select the DataMiner System you want to deploy the package to.
 

--- a/solutions/custom_solutions/Regression_Test_Management/Regression_Test_Management.md
+++ b/solutions/custom_solutions/Regression_Test_Management/Regression_Test_Management.md
@@ -8,7 +8,7 @@ The Regression Test Management Solution allows you to centrally organize, config
 
 This solution includes a dedicated connector, visual overview, and reusable Automation script that together help teams automate and track the execution of regression test scripts. Results are visualized, emailed, and stored historically for auditing and reporting purposes.
 
-Deployed as a [Catalog package](https://catalog.dataminer.services/details/74ddb623-f9fb-4a99-acee-0965ba495e2d), the solution installs everything needed to start managing your regression tests immediately.
+Deployed as a [Catalog package](https://catalog.dataminer.services/details/27636bb4-e3ce-4a2a-bd28-fe514a4ac5e7), the solution installs everything needed to start managing your regression tests immediately.
 
 ## Key capabilities
 


### PR DESCRIPTION
Updated the catalog link in two places to point to the existing Catalog item for consistency and backward compatibility.
The new catalog item will be removed.