### PR TITLE
Add basic filter functionality to search

### DIFF
--- a/templates/skyline/public/main.css
+++ b/templates/skyline/public/main.css
@@ -652,23 +652,46 @@ a.backtotoplink:hover
   padding: 0 1.5rem;
 }
 
-#search-result-items .result {
-  margin-bottom: 18px;
-  overflow: hidden;
+#search-result-items .result .result-content {
+  /*overflow: hidden;*/
+  display: flex;
+    align-items: center; /* Aligns category label with text */
+    justify-content: space-between; /* Puts label on the right */
 }
 
-#search-result-items .result:hover .title {
+#search-result-items .result .result-content .result-text {
+    flex: 1; /* Fills available space */
+    min-width: 0; /* Allows wrapping */
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+#search-result-items .result .result-content .result-text:hover .title {
+    flex: 1;
+    min-width: 0;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+#search-result-items .result .result-content:hover .url {
+    flex: 1;
+    min-width: 0;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+#search-result-items .result .result-content :hover .title {
   text-decoration: underline;
 }
 
-#search-result-items .result > a {
+#search-result-items .result .result-content .result-text > a {
   padding: 6px 7px;
   display: flex;
   flex-direction: column;
   text-decoration: none;
 }
 
-#search-result-items .result .url {
+#search-result-items .result .result-content .url {
   font-size: 11px;
   color: #878787;
   overflow: hidden;
@@ -676,7 +699,7 @@ a.backtotoplink:hover
   white-space: nowrap;
 }
 
-#search-result-items .result .title {
+#search-result-items .result .result-content .title {
   font-size: 18px;
   font-weight: 600;
   word-break: break-word;
@@ -797,6 +820,9 @@ a.backtotoplink:hover
     flex: 50%;
     max-width: 50%;
   }
+  .category-label {
+    display: none;
+  }
 }
 
 /* Responsive layout - makes the 2 columns stack on top of each other instead of next to each other */
@@ -811,4 +837,31 @@ a.backtotoplink:hover
     flex: 100%;
     max-width: 100%;
   }
+  .category-label {
+    display: none;
+  }
+}
+
+.result-content {
+    display: flex;
+    align-items: center; /* Aligns items vertically */
+    justify-content: space-between; /* Keeps category label on the right */
+    gap: 10px; /* Adds spacing */
+}
+
+.category-label {
+    background-color: #172554;
+    color: white;
+    padding: 5px 10px;
+    border-radius: 12px;
+    font-size: 10px;
+    /*font-weight: bold;*/
+    white-space: nowrap;
+}
+
+.result
+{
+  position: relative;
+  padding: 15px;
+  border-bottom: 1px solid #ddd;
 }


### PR DESCRIPTION
The search has been extended with basic filter functionality, allowing to see only results from the following categories:
User Guide, Dev Guide, Connector Docs, Release Notes. By default all categories (All) is selected. When selecting one (or more) other categories, the search results are filtered to only show the selected results.
Some other small changes:
- increased debounce time to 350 ms to reduce number of call to search API while still busy typing.
- Search API call now requests top 300 results.
- The serach results no longer show ending " | DataMiner docs" in title.
- Category labels are added to search results to indicate to which category a search result belongs (e.g. in case multiple categories are selected or All is selected).

See also feature request: [https://community.dataminer.services/new-feature-suggestions/dataminer-docs-search-only-in-fixed-part-of-docs/](https://community.dataminer.services/new-feature-suggestions/dataminer-docs-search-only-in-fixed-part-of-docs/)