### PR TITLE
Adding Information on Description Rename for Table Column 

### DIFF
--- a/user-guide/Basic_Functionality/Protocols_and_templates/Information_templates/Editing_an_information_template.md
+++ b/user-guide/Basic_Functionality/Protocols_and_templates/Information_templates/Editing_an_information_template.md
@@ -45,7 +45,7 @@ To make changes to the information template for one particular parameter:
 
 1. Click *Update Information Template* to save your changes.
 
-   > [!NOTE]
-   >
-   > - The template will be updated for all elements that use it. These are listed for reference at the bottom of the *Information* window.
-   > - If you use this procedure for an element that was using the default information template, a new template will be created with the changes you entered for this parameter.
+> [!NOTE]
+> - The template will be updated for all elements that use it. These are listed for reference at the bottom of the *Information* window.
+> - If you use this procedure for an element that was using the default information template, a new template will be created with the changes you entered for this parameter.
+> - If you're trying to change the **Description** for a Parameter representing a Table Column, you may need to also include a parenthesis with the table name in order to make sure the other table column's names don't change. For example, If you're trying to rename "IP Address" on a table named "Information" to "Main IP Address", you'll need to put it in the "Description" section of the Information Template as "Main IP Address (Information)". 


### PR DESCRIPTION
We ran into an issue recently where a table that had the rest of its columns include the table name in parenthesis for the Description (Ex: <Description>Primary Key (Information Table)</Description>), you'll need to make sure to keep that table name for your rename in the information template unless the rest of the columns will start to display the Parenthesis section. Let me know if this clarifies the workaround enough or if we can go into more detail. 