### PR TITLE
Update Creating_an_information_template.md To Include Description Details When Renaming Table Column

### DIFF
--- a/user-guide/Basic_Functionality/Protocols_and_templates/Information_templates/Creating_an_information_template.md
+++ b/user-guide/Basic_Functionality/Protocols_and_templates/Information_templates/Creating_an_information_template.md
@@ -22,8 +22,9 @@ To create an information template:
    - **Description**: The parameter display name that will appear in the user interface instead of the display name defined in the protocol.
 
      > [!NOTE]
-     > - The actual parameter name in the protocol is an internal identifier only, and cannot be modified in an information template.
-     > - If you're trying to change the **Description** for a Parameter representing a Table Column, you may need to also include a parenthesis with the table name in order to make sure the other table column's names don't change. For example, If you're trying to rename "IP Address" on a table named "Information" to "Main IP Address", you'll need to put it in the "Description" section of the Information Template as "Main IP Address (Information)". 
+     >
+     > - The actual parameter name in the protocol is an internal identifier only and cannot be modified in an information template.
+     > - When you change the description for a parameter representing a **table column**, you may also need to **include the table name in parentheses** to make sure the other table column names do not change. For example, to rename "IP Address" in a table named "Information" to "Main IP Address", change the description in the information template to "Main IP Address (Information)".
 
    - **Detailed description**: The parameter description that will be displayed in the parameter details.
 


### PR DESCRIPTION
We ran into an issue recently where a table that had the rest of its columns include the table name in parenthesis for the Description (Ex: <Description>Primary Key (Information Table)</Description>), you'll need to make sure to keep that table name for your rename in the information template unless the rest of the columns will start to display the Parenthesis section. 