### PR TITLE
Update documentation of http parameter.

### DIFF
--- a/develop/devguide/Connector/ConnectionsHttpImplementing.md
+++ b/develop/devguide/Connector/ConnectionsHttpImplementing.md
@@ -36,21 +36,22 @@ The following example shows an implementation of an HTTP request:
 </Request>
 ```
 
-Using the verb attribute, the request defines which HTTP method (or verb) is to be used, e.g. "GET", "POST", "PUT", etc.
+Using the *verb* attribute, the request defines which HTTP method (or verb) is to be used, e.g. "GET", "POST", "PUT", etc.
 
-The url attribute defines the path, optionally including a query string and/or fragment string.
+The *url* attribute defines the path, optionally including a query string and/or fragment string.
 
 > [!NOTE]
 >
-> - Instead of using the url attribute, you can specify the ID of a parameter that holds the request path. This is done using the pid attribute:
+> - Instead of using the *url* attribute, you can specify the ID of a parameter that holds the request path. This is done using the *pid* attribute:
 >
 >   ```xml
 >   <Request verb="GET" url="/barco-webservice/rest/NetworkWall/alarm">
 >   <Request verb="GET" pid="5045"> <!-- content parameter 5045: "barco-webservice/rest/NetworkWall/alarm" -->
 >   ```
 >
->   - In case the pid attribute is used, parameter 5045 does not need a leading slash ("/").
->   - In case both the url and pid attributes are specified, the pid attribute will be ignored. Typically, only one of these attributes is specified.
+>   - In case the *pid* attribute is used, parameter 5045 does not need a leading slash ("/").
+>   - The parameter referred to in the *pid* attribute must be of type `string`.
+>   - In case both the *url* and *pid* attributes are specified, the *pid* attribute will be ignored. Typically, only one of these attributes is specified.
 >
 > - It is also possible to specify an absolute URL (e.g. `http://google.com`), which possibly specifies another host (or IP address/port) than the one specified in the corresponding element connection.
 
@@ -64,7 +65,7 @@ By using either Data or Parameters, you can send data along with the HTTP reques
 > DataMiner does not perform any encoding on the provided data. Therefore, if you are, for example, building a URL for a GET request with a query string or the body of a POST request with content type "application/x-www-form-urlencoded", you must ensure that the data is using [percent-encoding](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1) (also known as URL encoding) to avoid misinterpretation of the provided data. Otherwise, the provided data might be misinterpreted by the server in case the data contains characters from the [reserved character set](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) (e.g. '&amp;').
 
 > [!NOTE]
-> Either Parameters or Data should be used, not both. If both are used together, only the content of Parameters will be included in the request.
+> Either *Parameters* or *Data* should be used, not both. If both are used together, only the content of *Parameters* will be included in the request.
 
 The content specified in Data will either be appended unaltered to the URL (in case of GET request) or put in the body (POST request).
 

--- a/develop/schemadoc/Protocol/Protocol.HTTP.Session.Connection.Request.Parameters.Parameter.md
+++ b/develop/schemadoc/Protocol/Protocol.HTTP.Session.Connection.Request.Parameters.Parameter.md
@@ -27,6 +27,9 @@ Via HTTP, this has to be done by means of key/value pairs.
 
 Contains a string that specifies the value of the parameter.
 
+> [!NOTE]
+> When providing the value to be sent through the pid of a parameter. That parameter needs to be of RawType `other` and Type `string`.
+
 > [!IMPORTANT]
 > DataMiner does not perform any encoding on the provided data. Therefore, if you are, for example, building a URL for a GET request with a query string or the body of a POST request with content type "application/x-www-form-urlencoded", you must ensure that the data is using [percent-encoding](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1) (also known as URL encoding) to avoid misinterpretation of the provided data. Otherwise, the provided data might be misinterpreted by the server in case the data contains characters from the [reserved character set](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) (e.g. '&amp;').
 

--- a/develop/schemadoc/Protocol/Protocol.HTTP.Session.Connection.Request.Parameters.Parameter.md
+++ b/develop/schemadoc/Protocol/Protocol.HTTP.Session.Connection.Request.Parameters.Parameter.md
@@ -28,7 +28,7 @@ Via HTTP, this has to be done by means of key/value pairs.
 Contains a string that specifies the value of the parameter.
 
 > [!NOTE]
-> When providing the value to be sent through the pid of a parameter. That parameter needs to be of RawType `other` and Type `string`.
+> When you provide the value to be sent through the PID of a parameter, that parameter needs to be of RawType `other` and Type `string`.
 
 > [!IMPORTANT]
 > DataMiner does not perform any encoding on the provided data. Therefore, if you are, for example, building a URL for a GET request with a query string or the body of a POST request with content type "application/x-www-form-urlencoded", you must ensure that the data is using [percent-encoding](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1) (also known as URL encoding) to avoid misinterpretation of the provided data. Otherwise, the provided data might be misinterpreted by the server in case the data contains characters from the [reserved character set](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) (e.g. '&amp;').

--- a/develop/schemadoc/Protocol/Protocol.HTTP.Session.Connection.Request.Parameters.Parameter.md
+++ b/develop/schemadoc/Protocol/Protocol.HTTP.Session.Connection.Request.Parameters.Parameter.md
@@ -28,7 +28,7 @@ Via HTTP, this has to be done by means of key/value pairs.
 Contains a string that specifies the value of the parameter.
 
 > [!NOTE]
-> When you provide the value to be sent through the PID of a parameter, that parameter needs to be of RawType `other` and Type `string`.
+> When you provide the value to be sent through the PID of a parameter, that parameter needs to be of type `string`.
 
 > [!IMPORTANT]
 > DataMiner does not perform any encoding on the provided data. Therefore, if you are, for example, building a URL for a GET request with a query string or the body of a POST request with content type "application/x-www-form-urlencoded", you must ensure that the data is using [percent-encoding](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1) (also known as URL encoding) to avoid misinterpretation of the provided data. Otherwise, the provided data might be misinterpreted by the server in case the data contains characters from the [reserved character set](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) (e.g. '&amp;').


### PR DESCRIPTION
The updated documentation reflects that the parameter of the provided pid should be of rawtype other and type string.
Otherwise, the value is not read out of the parameter to be put in the http parameter.