### PR TITLE
Improve explanation for Q16

### DIFF
--- a/develop/devguide/Connector/QuestionsAndAnswers.md
+++ b/develop/devguide/Connector/QuestionsAndAnswers.md
@@ -177,7 +177,15 @@ uid: QuestionsAndAnswers
 
 1. *Can you name one or more reasons for the problem "Too many groups on the protocol stacks"? How can this be solved?*
 
-    This occurs when the last group in a timer is of type "Action" or "Trigger" or when a trigger executes a group of those two types. This is because the system does not wait for "Action" or "Trigger" groups to be finished before continuing. It can be solved by using type "poll action" or "poll trigger", or by putting a poll group after the group.
+   This issue occurs when the last group in a timer is of type "Action" or "Trigger", or when a "Trigger" group calls other groups of these types. To understand why this causes problems, consider how timers work: a timer restarts only when all its scheduled groups have completed. However, the system determines this based on the last group in the timer.
+    
+   The key issue is that "Action" and "Trigger" groups are not enqueued on the main protocol thread like "Poll" groups are. They are executed immediately on the timer thread. This can cause the last group to complete before other earlier groups (like poll groups) have even started or finished, since those are still waiting in the main thread queue.
+    
+   As a result, the timer assumes all groups are done and restarts prematurely, before the previous ones have finished. This means it is possible that the timer can continue adding its poll groups to the main protocol thread execution queue before the poll groups from the previous cycle are completed. Over time, this causes a buildup, leading to the problem of having "too many groups on the protocol stacks". This problem is further amplified by the fact that timers have the lowest priority when placing groups on the execution queue, meaning their poll groups may be delayed even more, making it even more likely that the last "Action" or "Trigger" group finishes first and causes an early timer restart.
+    
+   Solutions:
+   * Use "Poll Action" or "Poll Trigger" types instead. These variants behave like poll groups and are queued on the main thread, avoiding premature timer restarts.
+   * Ensure the last group in the timer is a "Poll" group. This guarantees the timer won’t restart until the main thread has completed execution of all its groups.
 
 1. *What is the difference between starting a Trigger -> Action with a SetParameter and a CheckTrigger?*
 


### PR DESCRIPTION
While resolving a DIS validator warning about a timer ending with a non-poll group, I came across the related QnA. However, the explanation provided was too vague and lacked the necessary technical depth to fully understand the root cause.

Specifically, it did not explain:
- How the system determines when a timer is considered "finished"
- The significance of "Action" and "Trigger" groups running on the timer thread
- The impact of timer group execution order and thread priority

I have improved the explanation for the issue, but it would be good to have this information vetted. I have spoken to @ThomasW-Skyline about this.