### PR TITLE
Update DevOps_Points.md

### DIFF
--- a/dataminer-overview/DevOps/DataMiner_Devops_Professionals/DevOps_Points.md
+++ b/dataminer-overview/DevOps/DataMiner_Devops_Professionals/DevOps_Points.md
@@ -71,16 +71,15 @@ In general, the more active you are in the DataMiner Dojo community and the more
     > [!NOTE]
     > This action needs to be repeated each year to continue earning points.
 
-    If DataMiner is mentioned in the job title in your email signature, we will hit you up with another 250 points per year.
+  - If DataMiner is mentioned in the **job title in your email signature**, we will hit you up with another 250 points per year.
 
   - You can earn 100 points by **sharing your DevOps attestation on LinkedIn**. Make sure to:
 
-    -  Mention `@skyline-communications`
+    - Mention `@skyline-communications`
 
-    -  Use the hashtag `#dataminerdevops`.
-    
-   Email the link to your post to [devops@skyline.be](mailto:devops@skyline.be) and we will award your points.
+    - Use the hashtag `#dataminerdevops`.
 
+    Email the link to your post to [devops@skyline.be](mailto:devops@skyline.be) and we will award your points.
 
 - **Reward for outstanding DevOps mindset**: From time to time, Skyline staff members have the opportunity to nominate registered DataMiner DevOps Professionals who exemplify an exceptional DevOps mindset and demonstrate the effective application of associated best practices. Such recognition leads to the allocation of additional points in the range of 100 up to 750 on the recipient's DataMiner DevOps Professional account.
 


### PR DESCRIPTION
LinkedIn posts:
- removed points for LinkedIn posts using the # datminerdevops. Too time consuming to manually check LinkedIn and give points per person.
- added sharing devops attestation on LinkedIn