### PR TITLE
GQI - Improve docs on changing the minimum log level

### DIFF
--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/GQI/GQI_DxM.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/GQI/GQI_DxM.md
@@ -69,9 +69,11 @@ The GQI DxM comprises multiple processes that work together to handle GQI reques
 
 ## Configuration
 
-Below you can find an overview of the different settings you can configure in the file `C:\Program Files\Skyline Communications\DataMiner GQI\appsettings.custom.json`.
+The GQI DxM can be configured via json configuration files. The default configuration can be found in `C:\Program Files\Skyline Communications\DataMiner GQI\appsettings.json`. Do **not** use this file to change settings because it will be overwritten whenever a new version of the GQI DxM is installed.
 
-Do not edit the file *appsettings.json*, because that file gets overwritten when a new version of the GQI DxM is installed.
+To change configuration settings, create a new configuration file named `appsettings.custom.json` in `C:\Program Files\Skyline Communications\DataMiner GQI\appsettings.json` if it does not exist yet.
+
+Below you can find an overview of the settings that can be configured in this file.
 
 ### Logging
 

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/GQI/GQI_Logging.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/GQI/GQI_Logging.md
@@ -58,11 +58,13 @@ You can change the minimum log level to include less or more information in the 
 
 From DataMiner 10.4.6/10.5.0 onwards<!--RN 39355-->, when you change the minimum log level to *Debug* or lower, information about requests sent to SLNet is also logged.
 
-### Changing the minimum log level (GQI DxM)
+### Changing the minimum log level
 
-If it does not exist yet, create the file `C:\Program Files\Skyline Communications\DataMiner GQI\appsettings.custom.json`.
+This section shows how to change the log level for the GQI DxM logic itself. In order to change the minimum log level for GQI extensions, see [GQI extension logging](xref:GQI_Extensions_Logging#changing-the-minimum-log-level).
 
-Add the following configuration:
+#### [GQI DxM](#tab/gqi-dxm)
+
+In the [app settings](xref:GQI_DxM#configuration), add the following:
 
 ```json
 {
@@ -73,18 +75,11 @@ Add the following configuration:
         "Microsoft": "Information",
       }
     }
-  },
-  "GQIOptions": {
-    "Extensions": {
-      "Logging": {
-        "MinimumLogLevel": "Information"
-      }
-    }
   }
 }
 ```
 
-### Changing the minimum log level (SLHelper)
+#### [GQI in SLHelper](#tab/gqi-slhelper)
 
 Change the configuration in the *appSettings* section in `C:\Skyline DataMiner\Files\SLHelper.exe.config`. For example:
 
@@ -103,3 +98,5 @@ For some requests, from DataMiner 10.4.0 [CU3]/10.4.5 onwards<!-- RN 39098 -->, 
 
 > [!NOTE]
 > Any changes to the configuration file *SLHelper.exe.config* are reset after a full DataMiner upgrade or downgrade.
+
+***

--- a/develop/devguide/GQI Extensions/GQI_Extensions_Logging.md
+++ b/develop/devguide/GQI Extensions/GQI_Extensions_Logging.md
@@ -104,6 +104,47 @@ Example:
 
 ***
 
+## Changing the minimum log level
+
+The minimum log level determines which log entries are included in the log files based on their [log level](xref:GQI_GQILogLevel). This can be used to increase or decrease the amount of log entries for example while debugging without having to edit the code.
+
+### [GQI DxM](#tab/gqi-dxm)
+
+The minimum log level is determined by a combination of
+
+1. The global [GQI extension settings](xref:GQI_Logging#changing-the-minimum-log-level)
+1. The [MinimumLogLevel](xref:GQI_IGQILogger#properties) property of the extension instance
+
+By default, both of these are set to the `Information` log level.
+
+> [!NOTE]
+> The effective minimum log level will be the highest of these. For example, if the minimum log level in the global settings is set to `Warning` and the minimum log level on the extension instance is set to `Debug`, then only log entries with level `Warning` or higher will be logged.
+
+The global minimum log level for GQI extensions can be configured in the [application settings](xref:GQI_DxM#configuration):
+
+```json
+{
+  "GQIOptions": {
+    "Extensions": {
+      "Logging": {
+        "MinimumLogLevel": "Debug"
+      }
+    }
+  }
+}
+```
+
+### [GQI in SLHelper](#tab/gqi-slhelper)
+
+The minimum log level is determined by a combination of
+
+1. The global [GQI log settings](xref:GQI_Logging#changing-the-minimum-log-level)
+1. The [MinimumLogLevel](xref:GQI_IGQILogger#properties) property of the extension instance
+
+By default, the global minimum log level is set to the `Information` log level. This global minimum log level can be dynamically overwritten for each individual extension instance by modifying the [MinimumLogLevel](xref:GQI_IGQILogger#properties) property.
+
+***
+
 ## Example
 
 The following example showcases a custom operator that logs every cell value of a specified column.


### PR DESCRIPTION
- GQI DxM: Improved explanation on the configuration files
- GQI Logging:
  - Move docs for DxM and SLHelper to separate tabs
  - For GQI DxM: link to configuration files
  - For GQI DxM: remove log settings for the GQI extensions
- GQI extension logging:
  - Add a new section "Changing the minimum log level"
    - Add explanation for DxM and SLHelper in separate tabs
    - Link back to global GQI settings for changing the minimum log level
    - Link to the MinimumLogLevel property on the IGQILogger
    - Explain the behavior of how the settings and property interact