### PR TITLE
Fallback search results on 404

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,25 +12,33 @@
     <link rel="shortcut icon" href="favicon.ico">
 </head>
 
-<body>
+<body onload="onLoad()">
     <div class="container py-5 row">
         <div class="wp-block-column">
-            <center>
-                <h1 class="pageNotFound">404</h1>
-                <p class="lead">Looks like this page went missing.</p>
-                <p>Maybe you'll find what you're looking for via our <a href="https://docs.dataminer.services/">home
-                        page</a>.</p>
-            </center>
+            <img alt="Something went wrong, page not found" class="inline-image" src="https://skyline.be/img/404.png">
         </div>
         <div class="wp-block-column">
-            <div class="wp-block-drupalmedia-drupal-media-entity">
-                <div class="contextual-region">
-                    <img alt="Something went wrong, page not found" class="inline-image"
-                        src="https://skyline.be/img/404.png">
-                </div>
-            </div>
+            <h1 class="pageNotFound">404</h1>
+            <p class="lead">Looks like this page went missing.</p>
+            <p>Maybe you'll find what you're looking for via our <a href="https://docs.dataminer.services/">home
+                    page</a> or one of the search results below.</p>
         </div>
     </div>
+    <script type="text/javascript">
+        function onLoad() {
+            if (document.getElementById('search-results'))
+                return;
+
+            const errorPath = window.location.pathname;
+            if (!errorPath)
+                return;
+
+            const fallback = document.createElement('iframe');
+            fallback.id = 'search-results';
+            fallback.src = `/?embed=true&q=${errorPath}`;
+            document.body.append(fallback);
+        }
+    </script>
 </body>
 <style>
     body {
@@ -40,12 +48,25 @@
         font-weight: 400;
         line-height: 1.5;
         color: #212529;
+        background-color: #fafafa;
         text-align: left;
+        display: flex;
+        height: 100dvh;
+        flex-direction: column;
+    }
+
+    #search-results {
+        width: 100dvw;
+        display: block;
+        margin: auto;
+        flex: 1 0 auto;
+        border: none;
+        border-top: 4px solid #337ab7;
     }
 
     .container {
         margin: 50px auto auto auto;
-        padding: 0 20px;
+        padding: 0 60px;
         width: 100%;
         max-width: 1340px;
         flex-direction: row
@@ -59,18 +80,9 @@
     }
 
     .py-5 {
-        padding-bottom: 3rem !important;
-    }
-
-    .contextual-region {
-        position: relative;
-    }
-
-    .contextual {
-        position: absolute;
-        z-index: 500;
-        top: 6px;
-        right: 0;
+        padding-bottom: 0;
+        box-sizing: border-box;
+        margin-top: 16px;
     }
 
     .wp-block-column {
@@ -81,9 +93,15 @@
         flex-direction: column;
         flex-basis: 100%;
         flex: 1;
+        position: relative;
+
+        &:has(.pageNotFound) {
+            flex: 2;
+        }
     }
 
     .pageNotFound {
+        margin-top: 0;
         font-size: 3.5rem;
         line-height: 1.1;
         margin-bottom: 1rem;
@@ -100,58 +118,41 @@
     p {
         margin-top: 0;
         margin-bottom: 1rem;
-    }
-
-    .btn {
-        white-space: normal;
-        display: inline-block;
-        font-weight: 400;
-        color: #212529;
-        text-align: center;
-        vertical-align: middle;
-        cursor: pointer;
-        user-select: none;
-        background-color: transparent;
-        border: 1px solid transparent;
-        padding: 0.375rem 0.95rem;
-        font-size: 1rem;
-        line-height: 1.5;
-        border-radius: 0.25rem;
-        transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-    }
-
-    .btn-lg,
-    .btn-group-lg>.btn {
-        font-weight: bold;
-    }
-
-    .btn-lg,
-    .btn-group-lg>.btn {
-        padding: 0.5rem 1rem;
-        font-size: 1.25rem;
-        line-height: 1.5;
-        border-radius: 0.3rem;
-    }
-
-    .btn-secondary {
-        color: #fff;
-        background-color: #00aeef;
-        border-color: #00aeef;
-        text-decoration: none;
+        max-width: 460px;
     }
 
     .inline-image {
-        width: 100%;
-        height: auto;
-        max-width: 1038;
-        max-height: 711;
+        max-height: 30dvh;
+        width: auto;
+        float: right;
+        transform: translateY(3px);
+        vertical-align: bottom;
+        position: absolute;
+        bottom: 0;
+        right: 0;
+        height: 100%;
+        border-style: none;
     }
 
-    img {
-        vertical-align: middle;
-        border-style: none;
-        max-width: 1038px;
-        max-height: 711px;
+    @media screen and (max-width: 768px) {
+        p {
+            font-size: 80%;
+            max-width: auto;
+        }
+
+        .lead {
+            font-size: 1.2rem;
+        }
+
+        .container {
+            flex-direction: column;
+            padding: 0 60px;
+        }
+
+        .wp-block-column:has(img) {
+            min-height: 16dvh;
+            margin-bottom: -60px;
+        }
     }
 </style>
 

--- a/404.html
+++ b/404.html
@@ -35,7 +35,7 @@
 
             const fallback = document.createElement('iframe');
             fallback.id = 'search-results';
-            fallback.src = `/?embed=true&q=${errorPath}`;
+            fallback.src = `/?embed=true&search=${errorPath}`;
             document.body.append(fallback);
         }
     </script>

--- a/404.html
+++ b/404.html
@@ -146,7 +146,7 @@
 
         .container {
             flex-direction: column;
-            padding: 0 60px;
+            padding: 0 20px;
         }
 
         .wp-block-column:has(img) {

--- a/templates/skyline/layout/_master.tmpl
+++ b/templates/skyline/layout/_master.tmpl
@@ -151,13 +151,22 @@
     </footer>
 
     <script type="text/javascript">
-      const embedFlag = new URLSearchParams(window.location.search)?.get('embed') ?? '';
+      const params = new URLSearchParams(window.location.search);
+      const embedFlag = params?.get('embed') ?? '';
       if (embedFlag === 'true') {
         document.querySelector('head base')?.setAttribute('target', '_parent');
         document.body.classList.add('embed');
       } else {
         document.querySelector('head base')?.removeAttribute('target');
         document.body.classList.remove('embed');
+      }
+      const searchQuery = params?.get('search') ?? '';
+      if (searchQuery) {
+        var searchResults = document.getElementById('search-results-new');
+        if (searchResults) {
+          document.getElementById("main").style.display = "none";
+          searchResults.style.display = "block";
+        }
       }
     </script>
   </body>

--- a/templates/skyline/layout/_master.tmpl
+++ b/templates/skyline/layout/_master.tmpl
@@ -11,6 +11,7 @@
     {{/redirect_url}}
     {{^redirect_url}}
       <title>{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}</title>
+      <base>
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <meta name="title" content="{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}">
       <meta name="generator" content="docfx {{_docfxVersion}}">
@@ -148,6 +149,17 @@
 		<div><span class="pull-right"><a class="backtotoplink" href="#top">Back to top</a></span></div>
       </div>
     </footer>
+
+    <script type="text/javascript">
+      const embedFlag = new URLSearchParams(window.location.search)?.get('embed') ?? '';
+      if (embedFlag === 'true') {
+        document.querySelector('head base')?.setAttribute('target', '_parent');
+        document.body.classList.add('embed');
+      } else {
+        document.querySelector('head base')?.removeAttribute('target');
+        document.body.classList.remove('embed');
+      }
+    </script>
   </body>
   {{/redirect_url}}
 </html>

--- a/templates/skyline/public/main.css
+++ b/templates/skyline/public/main.css
@@ -865,3 +865,17 @@ a.backtotoplink:hover
   padding: 15px;
   border-bottom: 1px solid #ddd;
 }
+
+body.embed {
+  footer,
+  header {
+    display: none !important;
+  }
+
+  #search-results-new {
+    margin-top: 16px !important;
+    #search-box, #filters {
+      display: none !important;
+    }
+  }
+}

--- a/templates/skyline/public/search.js
+++ b/templates/skyline/public/search.js
@@ -8,6 +8,30 @@ function initSearch() {
 
   createSearchResultsNewHtml();
   initEventHandlersCloseOpenSearch();
+  tryHandleURL();
+
+  function tryHandleURL() {
+    const searchQuery = new URLSearchParams(window.location.search)?.get('q') ?? '';
+    if (!searchQuery)
+      return;
+
+    const words = new Set(searchQuery
+      .split('/')
+      .slice(-1)
+      .map(part => part.replace(/\.[^/.]+$/, '').replace(/[_\-]/g, ' ').replace(/([A-Z][a-z])/g, ' $1'))
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+      .split(/\s+/));
+
+    if (!words.size)
+      return;
+
+    const query = Array.from(words).join(' ');
+    showSearch(true);
+    document.getElementById("search-input").value = query;
+    doGetHttpRequest(query);
+  }
 
   function debounce(func, wait, immediate) {
     var timeout;

--- a/templates/skyline/public/search.js
+++ b/templates/skyline/public/search.js
@@ -11,7 +11,7 @@ function initSearch() {
   tryHandleURL();
 
   function tryHandleURL() {
-    const searchQuery = new URLSearchParams(window.location.search)?.get('q') ?? '';
+    const searchQuery = new URLSearchParams(window.location.search)?.get('search') ?? '';
     if (!searchQuery)
       return;
 


### PR DESCRIPTION
- Added embed url support to hide footer and header
- Modified 404 page to embed the search results for the path that lead to a 404

The search query will contain the latest part of the path, split into separate words. For example: '/dataminer/Swarming/Tutorials/EnableSwarmingTutorial.html' will show the results when you would search for "enable swarming tutorial".

<img width="1082" height="2402" alt="mobile light" src="https://github.com/user-attachments/assets/f7d328f3-768a-4d93-9c18-0b0dab91a90f" />
<img width="3840" height="2160" alt="desktop light" src="https://github.com/user-attachments/assets/75690ee2-4360-455d-81d9-b9fca34a6694" />
<img width="3840" height="2160" alt="desktop dark" src="https://github.com/user-attachments/assets/becc8d51-2a7a-4c1f-be2d-8fcfdf1d7802" />
<img width="1082" height="2402" alt="mobile dark" src="https://github.com/user-attachments/assets/49495a0f-780c-44e5-886f-d00dd00a9f86" />
