### PR TITLE
Add a warning message for library names

### DIFF
--- a/develop/devguide/GQI_Extensions/GQI_Extensions_Best_Practices.md
+++ b/develop/devguide/GQI_Extensions/GQI_Extensions_Best_Practices.md
@@ -32,6 +32,11 @@ Remember to **compile the script as a library**. You can configure this in your 
 </DMSScript>
 ```
 
+> ⚠️ **Warning:**
+> Do **not** use dots (`.`) in your library name.  
+> This can potentially cause the error:  
+> `GQI error: Could not create instance of datasource`.
+
 ## Do not use Skyline.DataMiner.Automation
 
 Never use references to the Skyline.DataMiner.Automation namespace in your GQI extension code.

--- a/develop/devguide/GQI_Extensions/GQI_Extensions_Best_Practices.md
+++ b/develop/devguide/GQI_Extensions/GQI_Extensions_Best_Practices.md
@@ -32,10 +32,8 @@ Remember to **compile the script as a library**. You can configure this in your 
 </DMSScript>
 ```
 
-> ⚠️ **Warning:**
-> Do **not** use dots (`.`) in your library name.  
-> This can potentially cause the error:  
-> `GQI error: Could not create instance of datasource`.
+> [!CAUTION]
+> Do **not** use dots (`.`) in your library name. This can potentially cause the error `GQI error: Could not create instance of datasource`.
 
 ## Do not use Skyline.DataMiner.Automation
 


### PR DESCRIPTION
Add a warning message for library names (no dots in names).

We wasted a lot of time trying to understand that the errors I had (see screenshots) came from there.

<img width="1615" height="304" alt="image" src="https://github.com/user-attachments/assets/4082f6c4-6514-4534-ab67-4022ba45a533" />

<img width="1759" height="601" alt="image" src="https://github.com/user-attachments/assets/5bb8120d-acee-40bc-b4c2-750ed44fe5ad" />
