### PR TITLE
Changes to account for DevCenter's disappearance

### DIFF
--- a/dataminer/Administrator_guide/DataMiner_Agents/Restoring_a_DMA/Preparing_the_destination_server_for_a_DMA_restoration.md
+++ b/dataminer/Administrator_guide/DataMiner_Agents/Restoring_a_DMA/Preparing_the_destination_server_for_a_DMA_restoration.md
@@ -66,21 +66,11 @@ To prepare the destination server, there are **several possibilities**:
 
   1. For a DMA using a Cassandra database:
 
-     1. Open DevCenter, by going to `C:\Program Files\Cassandra\DevCenter\Run DevCenter.lnk`.
+     1. Using the query tool of your choice, connect to the database (default login and password: *root*) and drop the *SLDMADB* keyspace.
 
-     1. In the *Connections* pane, click the icon to create a new connection.
+     1. Stop the *Cassandra* service.
 
-     1. In the *New Connection* window, insert the Agent IP in the *Contact hosts* box and click *Add*.
-
-     1. Click *Next* to go to the next step of the wizard.
-
-     1. In both the *Login* and the *Password* box, insert *root*, and then click *Finish*.
-
-     1. In the *Schema* pane of DevCenter, right-click *SLDMADB* and select *Drop Keyspace*.
-
-     1. Open Windows Task Manager and stop the Cassandra service.
-
-     1. Delete the content of the folder *D:\\ProgramData\\Cassandra\\SLDMADB*.
+     1. Remove the content from the folder *D:\\ProgramData\\Cassandra\\SLDMADB*.
 
      Alternatively, for a DMA using a legacy MySQL database:
 

--- a/dataminer/Administrator_guide/Databases/Configuring_dedicated_clustered_storage/Migrating_existing_systems/Migrating_the_general_database_to_a_DMS_Cassandra_cluster.md
+++ b/dataminer/Administrator_guide/Databases/Configuring_dedicated_clustered_storage/Migrating_existing_systems/Migrating_the_general_database_to_a_DMS_Cassandra_cluster.md
@@ -32,7 +32,7 @@ The Cassandra Cluster Migrator tool (called *SLCCMigrator.exe*) is available on 
 
 > [!NOTE]
 >
-> - The **migration will not clear any existing data from the given Cassandra cluster**. This means that any data that might conflict with the migrated data should first be deleted manually. We recommend that you make sure the target Cassandra cluster is clean before you proceed with the migration. You can use DevCenter to inspect the data in the cluster and any existing keyspaces and/or tables can be dropped.
+> - The **migration will not clear any existing data from the given Cassandra cluster**. This means that any data that might conflict with the migrated data should first be deleted manually. We recommend that you make sure the target Cassandra cluster is clean before you proceed with the migration.
 > - If there is an **existing OpenSearch/Elasticsearch cluster** connected to the DMS, this cluster will be reused and any given input regarding this cluster will be disregarded. In the existing cluster, alarms will be deleted and migrated again from the DMS. Jobs, ticketing, and SRM information will not be migrated, as this is expected to already be present in the OpenSearch/Elasticsearch cluster. If this is not the case, migrate this data first through DataMiner Cube (see [Configuring indexing settings in System Center](xref:Configuring_DataMiner_Indexing)).
 
 ## Stages of the migration

--- a/dataminer/Administrator_guide/Failover/Ending_a_Failover_configuration.md
+++ b/dataminer/Administrator_guide/Failover/Ending_a_Failover_configuration.md
@@ -17,7 +17,7 @@ In case you use a self-managed storage setup with [Cassandra storage per DMA](xr
 
 To verify this:
 
-1. Execute the following query on the database (e.g. using [DevCenter](xref:DataStax_DevCenter)):
+1. Execute the following query on the database using your preferred query tool:
 
    `Select keyspace_name, replication from system_schema.keyspaces where keyspace_name IN('SLDMADB','system_auth');`
 

--- a/dataminer/Administrator_guide/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Cassandra_authentication.md
+++ b/dataminer/Administrator_guide/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Cassandra_authentication.md
@@ -13,7 +13,7 @@ By default, DataMiner installs Cassandra with the PasswordAuthenticator enabled.
 
 We highly recommend that you configure more secure passwords for the default user. Preferably, these passwords should be randomly generated and stored in a password vault.
 
-You can do so by executing the following queries (using *cqlsh* in a Linux environment, or your preferred query tool):
+You can do so by executing the following queries (using *cqlsh*, or your preferred query tool):
 
 `ALTER ROLE cassandra WITH PASSWORD = '<NEW PASSWORD>';`
 

--- a/dataminer/Administrator_guide/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Cassandra_authentication.md
+++ b/dataminer/Administrator_guide/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Cassandra_authentication.md
@@ -13,7 +13,7 @@ By default, DataMiner installs Cassandra with the PasswordAuthenticator enabled.
 
 We highly recommend that you configure more secure passwords for the default user. Preferably, these passwords should be randomly generated and stored in a password vault.
 
-You can do so by executing the following queries (using *cqlsh* in a Linux environment, DevCenter in Windows, or your preferred query tool):
+You can do so by executing the following queries (using *cqlsh* in a Linux environment, or your preferred query tool):
 
 `ALTER ROLE cassandra WITH PASSWORD = '<NEW PASSWORD>';`
 

--- a/dataminer/Administrator_guide/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Cassandra_authorization.md
+++ b/dataminer/Administrator_guide/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Cassandra_authorization.md
@@ -19,7 +19,7 @@ To enable the *CassandraAuthorizer* in Cassandra:
 
 1. Now **restart** the Cassandra service to enable the *CassandraAuthorizer*.
 
-1. Grant your DataMiner database user full permissions on the DataMiner keyspaces. You can do so by executing the following queries (e.g. using [DevCenter](xref:DataStax_DevCenter)):
+1. Grant your DataMiner database user full permissions on the DataMiner keyspaces. You can do so by executing the following queries using your preferred query tool:
 
    `GRANT CREATE ON ALL KEYSPACES TO <YOUR DATABASE USER/ROLE>;`
 

--- a/dataminer/Administrator_guide/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Cassandra_updating.md
+++ b/dataminer/Administrator_guide/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Cassandra_updating.md
@@ -74,7 +74,7 @@ To update the Cassandra version:
 1. Copy the **old** *Java* folder from `C:\Program Files\Cassandra_bak\Java` to `C:\Program Files\Cassandra`.
 1. Copy the **old** *cassandra.yaml* file from `C:\Program Files\Cassandra_bak\conf\cassandra.yaml` to `C:\Program Files\Cassandra\conf`.
 1. Copy the **old** *daemon* folder from `C:\Program Files\Cassandra_bak\bin\daemon` to `C:\Program Files\Cassandra\bin`.
-1. Copy the **old** *DevCenter* folder from `C:\Program Files\Cassandra_bak\DevCenter` to `C:\Program Files\Cassandra`.
+1. Copy the **old** *DevCenter* folder (if present) from `C:\Program Files\Cassandra_bak\DevCenter` to `C:\Program Files\Cassandra`.
 1. Create a new folder named *logs* in `C:\Program Files\Cassandra`.
 1. To enable the use of *nodetool*, set the system-wide environment variables *JAVA_HOME* and *CASSANDRA_HOME* to the correct locations by executing the following PowerShell commands:
 

--- a/dataminer/Administrator_guide/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Security_Cassandra_TLS.md
+++ b/dataminer/Administrator_guide/Security/Advanced_security_configuration/Database_security/Security_Cassandra_general/Security_Cassandra_TLS.md
@@ -186,29 +186,11 @@ To enable inter-node TLS encryption:
 
 1. Save the changes in the *cassandra.yaml* and **restart** the Cassandra service.
 
-## Connecting with DevCenter
-
-1. To be able to connect over TLS with DevCenter, install the Java Cryptography Extensions (JCE). For more information, see [Connecting DevCenter to an SSL/TLS-enabled Cassandra](https://www.datastax.com/blog/connecting-datastax-devcenter-ssl-enabled-apache-cassandra-or-datastax-enterprise).
-
-1. Create a truststore that contains the *rootCa.crt* certificate:
-
-   ```txt
-   keytool -keystore rootCa-truststore.jks -storetype JKS -importcert -file rootCa.crt -keypass <STRONG PASSWORD> -storepass <STRONG PASSWORD> -alias rootCa -noprompt
-   ```
-
-1. Start DevCenter by executing `C:\Program Files\Cassandra\DevCenter\Run DevCenter.lnk`.
-
-1. In DevCenter, open your connection properties.
-
-1. Go to *Advanced* and select *This cluster requires SSL*.
-
-1. Point it towards your *rootCa.jks* truststore file and use the password you used to generate it.
-
 ## Connecting with DataMiner
 
-1. Ensure TLS encryption is working by connecting to the Cassandra database through DevCenter.
+1. Ensure TLS encryption is working by connecting to the Cassandra database using the query tool of your choice.
 
-1. Stop the DataMiner agent.
+1. Stop the DataMiner Agent.
 
 1. In the `C:\Skyline DataMiner` folder, open *DB.xml*.
 

--- a/dataminer/DataMiner_Tools/Cassandra_Clone.md
+++ b/dataminer/DataMiner_Tools/Cassandra_Clone.md
@@ -27,40 +27,6 @@ The tool duplicates tables, which is different from taking a snapshot (i.e. a ba
    > [!TIP]
    > For more information on creating an empty keyspace, see [Cassandra - Creating Keyspace](https://www.tutorialspoint.com/cassandra/cassandra_create_keyspace.htm).
 
-   To clone an existing keyspace:
-
-   1. Open DevCenter, by going to `C:\Program Files\Cassandra\DevCenter\Run DevCenter.lnk`.
-
-      > [!TIP]
-      > For more information on DevCenter, see [DataStax DevCenter](xref:DataStax_DevCenter).
-
-   1. In the *Connections* pane, click the icon to create a new connection.
-
-   1. In the *New Connection* window, insert the IP or hostname of the node you want to connect to in the *Contact hosts* box and click *Add*.
-
-   1. Click *Next* to go to the next step of the wizard.
-
-   1. Set the *Login* and *Password* to the credentials configured for the node (default: root) and click *Finish*.
-
-      > [!NOTE]
-      > You can find these credentials in `C:\Skyline DataMiner\Db.xml`, in the *Database.UID* and *Database.PWD* tags for the Cassandra database.
-
-   1. In the central pane of DevCenter, select the connection you have just created in the box at the top
-
-   1. In the *Schema* pane, right-click the existing keyspace and select *Clone Keyspace*.
-
-   1. In the pop-up window, check and adapt the settings if necessary:
-
-      - **Keyspace name**: Adjust this name to your preferences.
-
-      - **Replication strategy**: Should be set to *SimpleStrategy*.
-
-      - **Replication factor**: Should be 1 for a regular DMA and 2 for a Failover DMA.
-
-      - **Durable writes**: This option should be selected.
-
-   1. Click *Next* and *Finish* to clone the keyspace.
-
 1. If you want to clone the table to a keyspace that already exists, specify a name for the cloned table. To do so, create a file named *tables.txt* in the root directory of the tool. In the file, add a line for each table that needs to be cloned, separating the source and destination table names using tabs.
 
    For example:

--- a/dataminer/DataMiner_Tools/Standalone_Cassandra_Cluster_Installer.md
+++ b/dataminer/DataMiner_Tools/Standalone_Cassandra_Cluster_Installer.md
@@ -5,7 +5,7 @@ uid: Standalone_Cassandra_Cluster_Installer
 # Standalone Cassandra Cluster installer
 
 > [!NOTE]
-> This tool is intended for installation of a Cassandra Cluster on Windows only. However, we highly recommend that you install Cassandra on Linux instead.
+> This tool is intended for installation of a Cassandra Cluster on Windows only, which is **no longer supported as of Cassandra 4.x**. We highly recommend using [STaaS](xref:STaaS) for your DataMiner storage instead, or else installing Cassandra on Linux.
 
 ## About this tool
 

--- a/dataminer/Reference/MOPs/MOP_Changing_the_default_password_for_Cassandra.md
+++ b/dataminer/Reference/MOPs/MOP_Changing_the_default_password_for_Cassandra.md
@@ -41,7 +41,7 @@ The previous requirements are met.
     create role newUserName with superuser=true and login=true and password='newUserPassword’;
     ```
 
-1. Edit the localhost connection to use the new username and password, and confirm that this works.
+1. Reconnect using the new username and password, and confirm that this works.
 
 1. Optionally, remove the old "root" user. To do so, first make sure the database connection uses the new credentials, and then use the following command:
 

--- a/dataminer/Reference/MOPs/MOP_Changing_the_default_password_for_Cassandra.md
+++ b/dataminer/Reference/MOPs/MOP_Changing_the_default_password_for_Cassandra.md
@@ -25,8 +25,7 @@ Access to the servers with administrator rights. This requires a connection dedi
 
 1. Connect to the system via the designated VPN or host PC.
 1. Test if you can access DataMiner Cube.
-1. Go to `C:\ProgramFiles\Cassandra\Devcenter\Run DevCenter` and open *DevCenter*.
-1. Create a new connection with the address "localhost", the username "root", and the password "root".
+1. Use a query tool of your choice to connect to the database, using the address "localhost", the username "root", and the password "root".
 
 ### Create a database user with administrator permissions
 
@@ -42,9 +41,9 @@ The previous requirements are met.
     create role newUserName with superuser=true and login=true and password='newUserPassword’;
     ```
 
-1. Edit the localhost connection in *DevCenter* to use the new username and password, and confirm that this works.
+1. Edit the localhost connection to use the new username and password, and confirm that this works.
 
-1. Optionally, remove the old "root" user. To do so, first make sure the *DevCenter* database connection uses the new credentials, and then use the following command:
+1. Optionally, remove the old "root" user. To do so, first make sure the database connection uses the new credentials, and then use the following command:
 
     ```txt
     DROP USER root;
@@ -62,7 +61,7 @@ The previous requirements are met.
 
 #### Steps
 
-1. Execute the following query on the database (e.g. using [DevCenter](xref:DataStax_DevCenter)):
+1. Execute the following query on the database:
 
     ```txt
     select * from system_schema.tables where keyspace_name='SLDMADB';

--- a/dataminer/Troubleshooting/Known_issues/KI_RTE_with_SLAnalytics_when_upgrading.md
+++ b/dataminer/Troubleshooting/Known_issues/KI_RTE_with_SLAnalytics_when_upgrading.md
@@ -18,7 +18,7 @@ Either downgrade to 10.2.7 and then upgrade to DataMiner 10.2.8 (CU2), or run th
 
 ## Workaround
 
-Open DevCenter and run the command `ALTER TABLE analytics_parameterinfo_v1 add cr int;`.  
+Using a query tool of your choice, run the command `ALTER TABLE analytics_parameterinfo_v1 add cr int;`.
 
 ## Issue description
 

--- a/dataminer/Troubleshooting/Procedures/Cassandra_expired_blocking_SSTables.md
+++ b/dataminer/Troubleshooting/Procedures/Cassandra_expired_blocking_SSTables.md
@@ -73,7 +73,7 @@ To enable this option, follow the steps below. These steps are intended for a **
 
    To find out what the PREFIXPLACEHOLDER is, navigate to the `/data/cassandra/data` folder and check the name used in that folder.
 
-1. Open a connection to the Cassandra nodes via DevCenter.
+1. Open a connection to the Cassandra nodes using a query tool of your choice.
 
 1. Execute the following queries one by one and save the contents of the "compaction" column:
 

--- a/dataminer/Troubleshooting/Procedures/Troubleshooting_Cassandra.md
+++ b/dataminer/Troubleshooting/Procedures/Troubleshooting_Cassandra.md
@@ -56,10 +56,9 @@ To do so, in DataMiner Cube, go to *System Center* > *Database* > *Type*:
   - Trending must be enabled.
   - Can be used to detect memory leaks.
 
-- DevCenter
+- A query tool of your choice.
 
-  - Allows you to manually query the database.
-  - Can be found in `C:\Program Files\Cassandra\DevCenter\Run DevCenter` (*Cassandra Single*) or can be downloaded from the Apache or DataStax websites.
+  In legacy systems, DevCenter is typically used, but this tool is no longer supported. [DbVisualizer](https://www.dbvis.com/) is a possible alternative.
 
 - Notepad++ (optional)
 

--- a/dataminer/Troubleshooting/Troubleshooting_Flowcharts/Troubleshooting_Startup_Issues.md
+++ b/dataminer/Troubleshooting/Troubleshooting_Flowcharts/Troubleshooting_Startup_Issues.md
@@ -296,10 +296,9 @@ DataMiner is unable to establish a connection to the database. This can be cause
    - UN (or up/normal): The node is running fine.
    - DN: The node is down. In some cases, this can mean data loss is occurring.
 
-1. If the node is up or you do not have access to the database server, check if you can connect with Cassandra using the DevCenter tool.
+1. If the node is up or you do not have access to the database server, check if you can connect with Cassandra using a query tool of your choice.
 
-   - You can find this tool in `C:\Program Files\Cassandra\DevCenter\Run DevCenter` (if storage per DMA is used instead of dedicated clustered storage), or it can be downloaded from the Apache or DataStax websites.
-   - You can find the IP of the database in *DB.xml*, in the *DBServer* tag.
+   You can find the IP of the database in *DB.xml*, in the *DBServer* tag.
 
    If you can connect to Cassandra:
 

--- a/develop/TOOLS/ThirdPartyTools/DataStax_DevCenter.md
+++ b/develop/TOOLS/ThirdPartyTools/DataStax_DevCenter.md
@@ -5,48 +5,9 @@ description: DataStax DevCenter allows you to perform CQL queries or run scripts
 
 # DataStax DevCenter
 
-> [!NOTE]
-> The recommended setup for DataMiner storage is [Storage as a Service](xref:STaaS).
+> [!IMPORTANT]
+> This tool is **no longer supported**. We recommend using a different query tool of your choice, e.g. [DbVisualizer](https://www.dbvis.com/).
 
-This tool allows you to perform CQL queries or run scripts on a Cassandra database. It can be used on any server using a Cassandra database.
+This deprecated tool was used to perform CQL queries or run scripts on a Cassandra database on any server. It was included in legacy DataMiner installers prior to v10.2.
 
-Older DataMiner installers included this tool, but recent DataMiner installers (v10.2 or higher) do not deploy this tool and do not set the JAVA_HOME variable during installation, which means you will need to install it yourself and [set the JAVA_HOME variable](#setting-the-java_home-variable).
-
-> [!TIP]
->
-> - To install this tool, see [Installing DataStax DevCenter](https://docs.datastax.com/en/archived/developer/devcenter/doc/devcenter/dcInstallation.html).
-> - For general information on how to use this tool, see [Using DataStax DevCenter](https://docs.datastax.com/en/archived/developer/devcenter/doc/devcenter/dcToc.html).
-
-If the tool has been installed on the DMA, to open the tool, go to the folder `C:\Program Files\Cassandra\DevCenter\` and double-click *Run DevCenter.lnk*.
-
-![DataStax_DevCenter](~/develop/images/DataStax_DevCenter.png)
-
-## Setting the JAVA_HOME variable
-
-To be able to use this tool, the JAVA_HOME variable must be set. You can set this variable by either [creating a shortcut](#creating-a-shortcut) or [changing the system variable](#changing-the-system-variable).
-
-### Creating a shortcut
-
-1. Create a shortcut of `C:\Program Files\Cassandra\DevCenter\DevCenter.exe`.
-
-1. In the properties of that shortcut, fill in the following target:
-
-   ```txt
-   %windir%\System32\cmd.exe /c "set JAVA_HOME=C:\PROGRA~1\CASSAN~1\Java && set PATH=C:\PROGRA~1\CASSAN~1\Java\bin;%PATH% && start C:\PROGRA~1\CASSAN~1\DEVCEN~1\DEVCEN~1.EXE"
-   ```
-
-### Changing the system variable
-
-1. Open a command prompt as administrator and set the environment variable as follows:
-
-   ```txt
-   setx /m JAVA_HOME "C:\Program Files\Cassandra\Java"
-   ```
-
-1. Verify if the system variable has been set correctly by opening a new command prompt and entering the following command:
-
-   ```txt
-   echo %JAVA_HOME%
-   ```
-
-   The result should show the configured path.
+If the tool has been installed on the DMA, you can open it by going to the folder `C:\Program Files\Cassandra\DevCenter\` and double-clicking *Run DevCenter.lnk*.

--- a/develop/TOOLS/ThirdPartyTools/Logging_queries.md
+++ b/develop/TOOLS/ThirdPartyTools/Logging_queries.md
@@ -10,7 +10,7 @@ To log queries, the trace probability can be configured:
 nodetool settraceprobability -- 1.0
 ```
 
-Traces can be retrieved from the sessions table in the "system_traces" keyspace. By exporting the table content in DevCenter, the incoming queries can be investigated.
+Traces can be retrieved from the sessions table in the "system_traces" keyspace. By exporting the table content using a query tool, the incoming queries can be investigated.
 
 > [!CAUTION]
 > This should only be used for local debugging purposes (not for production environments). Disable the tracing (nodetool settraceprobability -- 0.0) after debugging.

--- a/develop/TOOLS/ThirdPartyTools/ThirdPartyTools.md
+++ b/develop/TOOLS/ThirdPartyTools/ThirdPartyTools.md
@@ -8,7 +8,7 @@ The following table lists some development tools that can be very useful while d
 
 |Tool  |Description  |Category  |
 |---------|---------|---------|
-|[DataStax DevCenter](xref:DataStax_DevCenter)     |This tool allows you to perform CQL queries or run scripts on a Cassandra database.         |Database         |
+|[DataStax DevCenter](xref:DataStax_DevCenter)     | **No longer supported.** Used to perform CQL queries or run scripts on a Cassandra database.         |Database         |
 |[dnSpy](xref:dnSpy)     |dnSpy is a debugger and .NET assembly editor.        |Debugger         |
 |[dotPeek](xref:dotPeek)     |dotPeek is a free .NET decompiler and assembly browser.     | Decompiler         |
 |[EBU LIST](xref:EBU_Live_IP_Software_Toolkit_LIST)     |EBU LIST is a freely available suite of software tools that can be used to check the state of IP-based networks and their high-bitrate media traffic.         |Network         |


### PR DESCRIPTION
As DevCenter is no longer supported and no longer available for download, it had to be removed from our procedures.