### PR TITLE
Update terminology from 'tool' to 'platform' in DoD doc

### DIFF
--- a/develop/TOOLS/DefinitionOfDone/About_DoD.md
+++ b/develop/TOOLS/DefinitionOfDone/About_DoD.md
@@ -2,7 +2,7 @@
 uid: About_DoD
 ---
 
-# Definition of Done (DoD)
+# Definition of Done (DoD) platform
 
 The Definition of Done (DoD) platform is a web application that helps development teams ensure all necessary steps are completed before a task is marked as done. It automates and streamlines task workflows, improves quality assurance, and simplifies documentation and collaboration.
 

--- a/develop/toc.yml
+++ b/develop/toc.yml
@@ -6418,7 +6418,7 @@ items:
           topicUid: Notifications
         - name: Viewing test results
           topicUid: Viewing_test_results
-    - name: Definition of Done (DoD)
+    - name: Definition of Done (DoD) Platform
       topicUid: About_DoD
     - name: Third-party Tools
       topicUid: ThirdPartyTools


### PR DESCRIPTION
Feedback from Abel: people tend to be allergic to the word "tool". Therefore, I tried to removing it where not necessary and to replace it by platform where simply removing it didn't make sense.

It allowed me to spot and fix an inconsistency between "The DoD Tool header bar" title vs "Checklist table" and "Smart Actions" ones. Indeed, for consistency, either they should all start with "The DoD Tool ...." or none of them should. I went ahead with second option for simplicity