### PR TITLE
Fix deploy to blob storage

### DIFF
--- a/.github/workflows/azure-static-web-apps-victorious-sea-0e7978f03.yml
+++ b/.github/workflows/azure-static-web-apps-victorious-sea-0e7978f03.yml
@@ -65,6 +65,13 @@ jobs:
           tar -xvf downloadazcopy-v10-linux
           sudo cp ./azcopy_linux_amd64_*/azcopy /usr/bin/
           azcopy --version
+          az version
+          # --- temporary downgrade Azure CLI (START) --- Issue: https://github.com/azure/azure-cli/issues/32048
+          AZ_CLI_DIST=$(lsb_release -cs)
+          AZ_CLI_VER=2.76.0
+          sudo apt-get install azure-cli=${AZ_CLI_VER}-1~${AZ_CLI_DIST} --allow-downgrades
+          az version
+          # --- temporary downgrade Azure CLI (END) ---
           az storage blob sync \
             --source _site \
             --container docs
@@ -100,6 +107,13 @@ jobs:
           tar -xvf downloadazcopy-v10-linux
           sudo cp ./azcopy_linux_amd64_*/azcopy /usr/bin/
           azcopy --version
+          az version
+          # --- temporary downgrade Azure CLI (START) --- Issue: https://github.com/azure/azure-cli/issues/32048
+          AZ_CLI_DIST=$(lsb_release -cs)
+          AZ_CLI_VER=2.76.0
+          sudo apt-get install azure-cli=${AZ_CLI_VER}-1~${AZ_CLI_DIST} --allow-downgrades
+          az version
+          # --- temporary downgrade Azure CLI (END) ---
           az storage blob sync \
             --source _site \
             --container '$web'
@@ -128,3 +142,4 @@ jobs:
         azure-search-indexer: indexer-1745835640388
         # Admin key used to connect to Azure Cognitive Search instance
         azure-search-admin-key: ${{ secrets.AZURE_SEARCH_KEY }}
+


### PR DESCRIPTION
Downgrade Azure CLI to `2.76.0` because `2.77.0` contains an issue to authenticate.