### PR TITLE
Update docs for communicationgateway 5.3.0 and openconfig 7.1.0

### DIFF
--- a/release-notes/Code_Libraries/Skyline.DataMiner.DataSources.OpenConfig/Skyline.DataMiner.DataSources.OpenConfig.Gnmi_7.x.md
+++ b/release-notes/Code_Libraries/Skyline.DataMiner.DataSources.OpenConfig/Skyline.DataMiner.DataSources.OpenConfig.Gnmi_7.x.md
@@ -10,7 +10,7 @@ uid: Skyline.DataMiner.DataSources.OpenConfig.Gnmi_7.x
 
 Previously, the `Get`, `Set`, and `Capabilities` calls on a GnmiClient always used a fixed timeout of 5 seconds. These timeout values can now be configured individually per request. If no custom timeout is specified, the default of 5 seconds still applies.
 
-Alongside this change, The OpenConfig library has been updated to the latest *Skyline.DataMiner.DataSources.CommunicationGatewayMiddleware.OpenConfig* version (i.e. 5.3.0).
+Minimum required version: [CommunicationGateway 5.3.0](xref:CommunicationGateway_change_log#17-september-2025---enhancement---communicationgateway-530---configurable-grpc-call-timeouts-id-43460).
 
 ## 7.0.0
 

--- a/release-notes/DxMs/CommunicationGateway_change_log.md
+++ b/release-notes/DxMs/CommunicationGateway_change_log.md
@@ -8,6 +8,9 @@ uid: CommunicationGateway_change_log
 
 gRPC calls no longer use a fixed 5-second timeout. You can now define a custom timeout for each request. If no timeout is specified, the default remains 5 seconds.
 
+> [!NOTE]
+> To configure these timeouts, connectors must reference [Skyline.DataMiner.DataSources.OpenConfig.Gnmi 7.1.0](xref:Skyline.DataMiner.DataSources.OpenConfig.Gnmi_7.x#add-support-for-configurable-timeouts-to-gnmiclient-operations-id-43460) or higher.
+
 #### 13 February 2025 - Enhancement - CommunicationGateway 5.2.0 - Circuit breaker for repeated gRPC stream failures [ID 41971]
 
 A circuit breaker mechanism has been implemented to prevent excessive resource consumption when a gRPC stream repeatedly fails. Previously, the system would continuously attempt to restore a stream, even if failures were caused by persistent issues such as invalid UTF-8 characters in messages. With this update, if a stream fails 5 times within 60 seconds, the circuit breaker will activate, halting further reconnection attempts. This enhancement improves system stability and reduces unnecessary processing.


### PR DESCRIPTION
The link between the new release of both versions was not clearly stated.
The updated docs more clearly show the minimum required versions, similar to how this was done in the past.