### PR TITLE
Update Visualizing_Starlink_Location_History_in_DataMiner.md

### DIFF
--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Dashboards_app/Tutorials/Visualizing_Starlink_Location_History_in_DataMiner.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Dashboards_app/Tutorials/Visualizing_Starlink_Location_History_in_DataMiner.md
@@ -11,6 +11,10 @@ Expected duration: 30 minutes
 > [!NOTE]
 > The content and screenshots for this tutorial have been created with the DataMiner 10.5.3 web apps.
 
+> [!NOTE]
+> The *Location History Tracking* feature is now included by default in the latest Starlink Enterprise package (since v2.0.0 and higher).
+> You can still create your own history page and rebuild the functionality step by step. This remains a valuable exercise to deepen your understanding of low-code apps and MAP integrations.
+
 > [!TIP]
 > See also: [Kata #59: Visualizing Starlink location history in DataMiner](https://community.dataminer.services/courses/kata-59/) on DataMiner Dojo ![Video](~/dataminer/images/video_Duo.png)
 
@@ -35,10 +39,6 @@ Expected duration: 30 minutes
 
 1. Go to the [Starlink Enterprise](https://catalog.dataminer.services/details/66a4c259-0fb1-4c27-aede-8bbd3a4925d0) solution in the Catalog.
 
-<!-- 1. Go to the *Versions* tab and expand version 1.0.2-CU12, so you can see the *Deploy* button for this specific version.
-
-   This version of the app contains everything you need to be able to follow this tutorial.
- -->
 1. Click the *Deploy* button to deploy the package on your DMA.
 
 1. When the package has been deployed, go to the root page of your DataMiner System, for example by clicking the *Home* button for your DMS on the [dataminer.services page](https://dataminer.services/).

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Dashboards_app/Tutorials/Visualizing_Starlink_Location_History_in_DataMiner.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Dashboards_app/Tutorials/Visualizing_Starlink_Location_History_in_DataMiner.md
@@ -9,11 +9,9 @@ In this tutorial, you will explore how to leverage the Starlink Enterprise solut
 Expected duration: 30 minutes
 
 > [!NOTE]
-> The content and screenshots for this tutorial have been created with the DataMiner 10.5.3 web apps.
-
-> [!NOTE]
-> The *Location History Tracking* feature is now included by default in the latest Starlink Enterprise package (since v2.0.0 and higher).
-> You can still create your own history page and rebuild the functionality step by step. This remains a valuable exercise to deepen your understanding of low-code apps and MAP integrations.
+>
+> - In the latest versions of the Starlink Enterprise package (v2.0.0 and higher), the *Location History Tracking* feature is already included by default. This means that you can take a look at the configuration of this feature in the *Starlink Enterprise* app and then follow this tutorial to try to build it yourself step by step, as a valuable exercise to deepen your understanding of low-code apps and map integrations.
+> - The content and screenshots for this tutorial have been created with the DataMiner 10.5.3 web apps.
 
 > [!TIP]
 > See also: [Kata #59: Visualizing Starlink location history in DataMiner](https://community.dataminer.services/courses/kata-59/) on DataMiner Dojo ![Video](~/dataminer/images/video_Duo.png)


### PR DESCRIPTION
Added a note to indicate that the current install package already contains the outcome of this KATA exercise. Still people could follow the steps to create their own page & queries, and build something custom to learn & experience the features.

I also removed the comment that was still unpublished, where we had the intention to let people start from an older package version (which would be the latest before the official release that contains the history location features.

Due to STaaS load problems, we have brought all these past package versions (1.0.X range) offline and set these as unlisted. 

The KATA exercise is not exactly longer an exact 1-to-1 on what you can or should do...
If you have any questions, feel free to reach out to me (Thijs V.) Thanks.