### PR TITLE
Enhance documentation for resource exclusion properties

### DIFF
--- a/dataminer/Frameworks/SRM/Interacting_with_SRM_using_code/srm_using_resourcemanagerhelper.md
+++ b/dataminer/Frameworks/SRM/Interacting_with_SRM_using_code/srm_using_resourcemanagerhelper.md
@@ -207,7 +207,7 @@ context.RequiredCapabilitiesOrFiltered.Add(requestedCapabilityHD);
 context.RequiredCapabilitiesOrFiltered.Add(requestedCapabilityUHD); 
 ```
 
-The *ReservationIdToIgnore* and *NodeIdToIgnore* properties can be used to exclude an already booked resource. If the *TimeRange* property was not set on the context, the timing of the ignored booking will also be used to calculate the available resources. This can be useful in scenarios where the available resources for a node you want to swap need to be calculated.
+The *ReservationIdToIgnore* and *NodeIdToIgnore* properties can be used to exclude an already booked resource. This means the resource - assigned to that node - will still be included in the result set, since it will be treated as if it is not currently assigned to that booking. If the *TimeRange* property was not set on the context, the timing of the ignored booking will also be used to calculate the available resources. This can be useful in scenarios where the available resources for a node you want to swap need to be calculated.
 
 > [!NOTE]
 >


### PR DESCRIPTION
Clarified explanation of ReservationIdToIgnore and NodeIdToIgnore properties in resource management context.

This is a follow-up to this Dojo question, to avoid misinterpretation: [Behavior of ReservationIdToIgnore in resource eligibility logic - DataMiner Dojo](https://community.dataminer.services/question/behavior-of-reservationidtoignore-in-resource-eligibility-logic/). 