### PR TITLE
Update SLNetClientTest_configuring_SMTP.md

### DIFF
--- a/dataminer/DataMiner_Tools/SLNetClientTest_tool/SLNetClientTest_tool_advanced_procedures/SLNetClientTest_configuring_SMTP.md
+++ b/dataminer/DataMiner_Tools/SLNetClientTest_tool/SLNetClientTest_tool_advanced_procedures/SLNetClientTest_configuring_SMTP.md
@@ -8,7 +8,7 @@ A DMS can be configured to send out email notifications and reports via an SMTP 
 
 1. [Connect to the DMA using the SLNetClientTest tool](xref:Connecting_to_a_DMA_with_the_SLNetClientTest_tool).
 
-1. Go to the *Build Message* tab and select *UpdateSmtpConfigMessage* in the drop-down box at the top.
+1. Go to the *Build Message* tab located at the bottom left of the SLNetClientTest tool window and select *UpdateSmtpConfigMessage* in the drop-down box at the top.
 
 1. Specify the necessary SMTP settings. See [SMTP server settings](xref:Configuring_outgoing_email#smtp-server-settings).
 


### PR DESCRIPTION
Added clarification to where the Build Message tab is located (especially since it isn't the normal location for a tab)