### PR TITLE
Add keywords to DataMiner processes documentation

### DIFF
--- a/dataminer/Administrator_guide/DataMiner_Systems/About_DataMiner_Systems/DataMiner_processes.md
+++ b/dataminer/Administrator_guide/DataMiner_Systems/About_DataMiner_Systems/DataMiner_processes.md
@@ -1,5 +1,6 @@
 ---
 uid: DataMiner_processes
+keywords: SL,SLElement,SLDataMiner,SLProtocol,SLNet,SLNetComService,SLDMS,SLPort,SLSNMPManager,SLWatchdog,SLLog,SLDataGateway
 ---
 
 # DataMiner processes


### PR DESCRIPTION
Added keywords for better searchability and categorization due to difficulties finding information about the uses for specific SL Processes.