### PR TITLE
Write RN for communicationGateway 5.3.2 release

### DIFF
--- a/release-notes/DxMs/CommunicationGateway_change_log.md
+++ b/release-notes/DxMs/CommunicationGateway_change_log.md
@@ -6,9 +6,9 @@ uid: CommunicationGateway_change_log
 
 #### 8 October 2025 - Enhancement - CommunicationGateway 5.3.2 - Increased maximum gRPC response size [ID 43865]
 
-The maximum allowed response size for gRPC calls has been increased from 4 MB to 12 MB. This enhancement enables the CommunicationGateway to handle larger payloads.
+The maximum allowed response size for gRPC calls has been increased from 4 MB to 12 MB. This enhancement enables Communication Gateway to handle larger payloads.
 
-As before, if a response exceeds the configured limit, a RequestFailedException will be thrown with status code 8 (Resource exhausted).
+As before, if a response exceeds the configured limit, a RequestFailedException will be thrown with status code 8 (resource exhausted).
 
 #### 23 September 2025 - Fix - CommunicationGateway 5.3.1 - Installer incorrectly selected DVD drive for log files [ID 43714]
 


### PR DESCRIPTION
The maximum allowed response size for gRPC calls has been increased for communication gateway 5.3.2. This PR adds a RN for this release to the docs.

See [RN43865](https://collaboration.dataminer.services/releasenotes/43865)
