### PR TITLE
CorrectedDisplayKeyOnNaming (RN 27191)

### DIFF
--- a/dataminer/Reference/Soft-launch_options/Overview_of_Soft_Launch_Options.md
+++ b/dataminer/Reference/Soft-launch_options/Overview_of_Soft_Launch_Options.md
@@ -59,7 +59,7 @@ Allows you to disable the ClusterEndpointsManager. This can prevent possible iss
 
 ### CorrectedDisplayKeyOnNaming
 
-Takes exception values into account for display key generation.
+Takes exception values into account for display key generation. See [CorrectedDisplayKeyOnNaming soft-launch option](xref:UIComponentsTableDisplayKeys#correcteddisplaykeyonnaming-soft-launch-option)
 
 This option is enabled by default when DataMiner is deployed in the cloud ([DaaS](xref:Creating_a_DMS_in_the_cloud)).
 

--- a/develop/devguide/Connector/UIComponentsTableDisplayKeys.md
+++ b/develop/devguide/Connector/UIComponentsTableDisplayKeys.md
@@ -114,6 +114,14 @@ Using the displayColumn attribute, you can specify that values of a particular c
 > - The column referred to in the *displayColumn* attribute must never be the column holding the primary key, as this would result in the creation of an unnecessary mapping between primary key and display key.
 > - For performance reasons, using either the "naming" option or *NamingFormat* tag is favored over using the *displayColumn* attribute for new protocols.
 
+## CorrectedDisplayKeyOnNaming soft-launch option
+
+By default, if one of the columns used to create the display key contains an exception value, this value is ignored, and the raw value is used in the display key instead. If the exception is defined on a discrete parameter, the value is dropped from the display key entirely.
+
+You can alter this behavior by enabling the [CorrectedDisplayKeyOnNaming](xref:Overview_of_Soft_Launch_Options#correcteddisplaykeyonnaming) soft-launch option. This will cause display keys to be formatted with the exception display value instead. Because altering the display key could break existing fixed uses of display keys, this behavior is currently only available via the soft-launch option.
+
+Note that empty display values for exceptions and discrete parameters will result in the raw parameter value being used in the display key in some cases.
+
 ## See also
 
 - [Protocol.Params.Param.ArrayOptions.NamingFormat](xref:Protocol.Params.Param.ArrayOptions.NamingFormat)


### PR DESCRIPTION
Because the CorrectedDisplayKeyOnNaming soft-launch option is by default enabled on DaaS systems, I've added some more information about this option to the documentation. @PedroDebevere, could you check if everything still makes sense, given that this is a fairly old release note? 