### PR TITLE
Add upgrade instructions for Dashboard Gateway

### DIFF
--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Dashboards_app/Dashboard_Gateway_installation.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Dashboards_app/Dashboard_Gateway_installation.md
@@ -196,7 +196,7 @@ To do so, after the DataMiner upgrade, copy the following folders from the DataM
 - `C:\Skyline DataMiner\Webpages\Ticketing`
 - `C:\Skyline DataMiner\Webpages\SharedComponents`
 - `C:\Skyline DataMiner\Webpages\Auth` (from DataMiner 10.3.5 onwards)
-- `C:\Skyline DataMiner\Webpages\API` (make sure not to overwrite the existing web.config file. Copy all other files and folders, but keep the existing web.config in place.)
+- `C:\Skyline DataMiner\Webpages\API` (Make sure not to overwrite the existing web.config file. Copy all other files and folders, but keep the existing web.config in place.)
 
 > [!IMPORTANT]
 > Always ensure that the web application folders on the Dashboard Gateway are in sync with the DataMiner Agent. Running different web versions may cause compatibility issues or prevent the web applications from loading correctly.


### PR DESCRIPTION
Added a new section detailing steps to update the Dashboard Gateway after a DataMiner Agent upgrade, including which folders to copy and a warning to keep web application versions in sync to avoid compatibility issues. Also improved clarity in configuration steps and folder lists.