### PR TITLE
Revert "Fix deploy to blob storage"

### DIFF
--- a/.github/workflows/azure-static-web-apps-victorious-sea-0e7978f03.yml
+++ b/.github/workflows/azure-static-web-apps-victorious-sea-0e7978f03.yml
@@ -65,13 +65,6 @@ jobs:
           tar -xvf downloadazcopy-v10-linux
           sudo cp ./azcopy_linux_amd64_*/azcopy /usr/bin/
           azcopy --version
-          az version
-          # --- temporary downgrade Azure CLI (START) --- Issue: https://github.com/azure/azure-cli/issues/32048
-          AZ_CLI_DIST=$(lsb_release -cs)
-          AZ_CLI_VER=2.76.0
-          sudo apt-get install azure-cli=${AZ_CLI_VER}-1~${AZ_CLI_DIST} --allow-downgrades
-          az version
-          # --- temporary downgrade Azure CLI (END) ---
           az storage blob sync \
             --source _site \
             --container docs
@@ -107,13 +100,6 @@ jobs:
           tar -xvf downloadazcopy-v10-linux
           sudo cp ./azcopy_linux_amd64_*/azcopy /usr/bin/
           azcopy --version
-          az version
-          # --- temporary downgrade Azure CLI (START) --- Issue: https://github.com/azure/azure-cli/issues/32048
-          AZ_CLI_DIST=$(lsb_release -cs)
-          AZ_CLI_VER=2.76.0
-          sudo apt-get install azure-cli=${AZ_CLI_VER}-1~${AZ_CLI_DIST} --allow-downgrades
-          az version
-          # --- temporary downgrade Azure CLI (END) ---
           az storage blob sync \
             --source _site \
             --container '$web'
@@ -142,4 +128,3 @@ jobs:
         azure-search-indexer: indexer-1745835640388
         # Admin key used to connect to Azure Cognitive Search instance
         azure-search-admin-key: ${{ secrets.AZURE_SEARCH_KEY }}
-


### PR DESCRIPTION
Reverts SkylineCommunications/dataminer-docs#5223

Since `azure-cli v2.78.0` is being shipped with the latest release of the `ubuntu-latest` runner, we can try to remove the temporary change to fix deployment to the blob storage.