### PR TITLE
Enhance STaaS features documentation with Size Tool info

### DIFF
--- a/dataminer/Administrator_guide/Databases/STaaS/STaaS_features.md
+++ b/dataminer/Administrator_guide/Databases/STaaS/STaaS_features.md
@@ -74,7 +74,7 @@ From DataMiner 10.4.0 [CU14]/10.5.0 [CU2]/10.5.5 onwards<!-- RN 42387 -->, when 
 
 ![ThrottlingAlarmExample](~/dataminer/images/throttling_alarm_example.png)
 
-If you encounter such an alarm, to ensure smooth operation of your DataMiner System, try to identify and resolve the root cause of this higher load. You can run the [DataMiner Size Tool](xref:DataMinerSizeTool) to get details on the database usage for each element on your DataMiner System.
+If you encounter such an alarm, to ensure smooth operation of your DataMiner System, try to identify and resolve the root cause of this higher load. For assistance with this investigation, please contact <support@dataminer.services>.
 
 ## Limitations
 


### PR DESCRIPTION
Added information about using the DataMiner Size Tool for database usage details as it is currently not clear to an user what the next steps they should take when running into this STaaS issue.

Let me know if what I suggested is inefficient or would put the user in the wrong area for debugging this issue please. 