### PR TITLE
Update Failover configuration instructions for DataMiner

### DIFF
--- a/dataminer/Administrator_guide/Failover/Configuring_Failover/Failover_configuration_in_Cube.md
+++ b/dataminer/Administrator_guide/Failover/Configuring_Failover/Failover_configuration_in_Cube.md
@@ -39,7 +39,7 @@ To enable Failover using DataMiner version **10.1.8 or higher**:
 
       Once you have completed the configuration, the IP addresses will be changed, which may take a while.
 
-   1. If you are running DataMiner 10.6.0 or higher, run NATSRepair to update your NATS credentials with the virtual IP. See [BrokerGateway Migration](xref:BrokerGateway_Migration).
+   1. If you are using DataMiner 10.6.0/10.6.1 or higher, or if your system has been [migrated to BrokerGateway](xref:BrokerGateway_Migration), run NATSRepair to update your NATS credentials with the virtual IP.
 
    > [!IMPORTANT]
    > Always configure Failover with virtual IP addresses for DataMiner Systems that already contain a Failover pair configured with virtual IP addresses.
@@ -56,7 +56,7 @@ To enable Failover using DataMiner version **10.1.8 or higher**:
 
    1. Click *Apply* or *OK* to save the configuration (depending on your DataMiner version).
 
-   1. If you are running DataMiner 10.6.0 or higher, run NATSRepair to update your NATS credentials with the new hostname. See [BrokerGateway Migration](xref:BrokerGateway_Migration).
+   1. If you are using DataMiner 10.6.0/10.6.1 or higher, or if your system has been [migrated to BrokerGateway](xref:BrokerGateway_Migration), run NATSRepair to update your NATS credentials with the new hostname.
 
    > [!IMPORTANT]
    > Always configure Failover with a shared hostname for DataMiner Systems that already contain a Failover pair configured with a shared hostname or that contain a DataMiner Agent that was added by hostname.


### PR DESCRIPTION
Setting up a Failover requires the NATS credentials to be reset when running BrokerGateway. Since this is enforced in 10.6, it should become a default step when setting up a failover.