### PR TITLE
GQI Scaling Example - Ignore case when comparing usernames

### DIFF
--- a/develop/devguide/GQI_Extensions/Ad_hoc_data/Examples/Scaling_Ad_hoc_Data_Source.md
+++ b/develop/devguide/GQI_Extensions/Ad_hoc_data/Examples/Scaling_Ad_hoc_Data_Source.md
@@ -140,7 +140,9 @@ public class Results : IGQIDataSource, IGQIOnInit
         }
 
         var securityResponse = responses?.OfType<GetUserInfoResponseMessage>().FirstOrDefault();
-        var userGroups = securityResponse?.Users?.Where(u => u.Name == userName).FirstOrDefault()?.Groups?.OrderBy(x => x)?.ToArray() ?? new int[0];
+        var userGroups = securityResponse?.Users?
+            .Where(u => String.Equals(u.Name, userName, StringComparison.InvariantCultureIgnoreCase))
+            .FirstOrDefault()?.Groups?.OrderBy(x => x)?.ToArray() ?? new int[0];
         if (userGroups.Length == 0)
         {
             logger.Error("User is not part of any group.");


### PR DESCRIPTION
Sometimes the username you get back from the GetUserFullNameResponse is not the exact same as the one in the GetUserInfoResponseMessage. 
Sometimes the name you get back is "skyline2\ArneMA" while it expects "SKYLINE2\ArneMA" causing the Where clause to not return any results even though the user is in the list.