### PR TITLE
Clarify Dashboard Gateway connectivity requirements

### DIFF
--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Dashboards_app/Dashboard_Gateway_installation.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Dashboards_app/Dashboard_Gateway_installation.md
@@ -33,7 +33,7 @@ There are two main reasons to consider a Dashboard Gateway setup:
 
   - Permission to create, edit and delete dashboards.
 
-- The Dashboard Gateway web server(s) must be able to communicate with a DataMiner Agent using an HTTP(S) connection (port 80 or 443, depending on the DataMiner Agent's HTTP(S) configuration). If .NET Remoting is still active (default prior to DataMiner 10.5.10/10.6.0 [CU0] or when enforced by the DMA), that port must also be accessible.
+- The Dashboard Gateway web server(s) must be able to communicate with a DataMiner Agent using an HTTP(S) connection (port 80 or 443, depending on the DataMiner Agent's HTTP(S) configuration). If .NET Remoting is still active (default prior to DataMiner 10.5.10/10.6.0, or when enforced by the DMA), that port must also be accessible. (See [Overview of IP ports used in a DMS](xref:Configuring_the_IP_network_ports#overview-of-ip-ports-used-in-a-dms).)
 
 > [!IMPORTANT]
 > Always make sure your Dashboard Gateway's web application folders are in sync with the DataMiner server. This means that when you upgrade your DataMiner software, you must make sure the folders for the web apps are also up to date. See [DataMiner upgrades](#dataminer-upgrades)


### PR DESCRIPTION
Updated instructions to specify that Dashboard Gateway web servers must use HTTP(S) to communicate with DataMiner Agents, and clarified .NET Remoting requirements for older or enforced configurations.