### PR TITLE
Update Setting_up_HTTPS_on_a_DMA.md

### DIFF
--- a/dataminer/Administrator_guide/DataMiner_Agents/Configuring_a_DMA/Setting_up_HTTPS_on_a_DMA.md
+++ b/dataminer/Administrator_guide/DataMiner_Agents/Configuring_a_DMA/Setting_up_HTTPS_on_a_DMA.md
@@ -52,10 +52,9 @@ To do so:
       This name **should also be configured in the DNS server** pointing to the IP address of the DMA, so that the DMA can be reached using the configured name.
 
       > [!IMPORTANT]
-      > Do not use wildcard certificates if you want to use your DataMiner Agent to connect your system to dataminer.services, as this is not supported. In that case, the certificate should be for the FQDN (e.g. "dma01.skyline.be").
-      
-      > [!IMPORTANT]
-      > If using a failover pair, ensure that you set the tag to the hostname for that specific DataMiner Agent. **Do not used the shared hostname** for that failover pair. 
+      >
+      > - **Do not use wildcard certificates** if you want to use your DataMiner Agent to connect your system to **dataminer.services**, as this is not supported. In that case, the certificate should be for the FQDN (e.g. "dma01.skyline.be").
+      > - If you are configuring an Agent in a **Failover** pair, ensure that you set the tag to the hostname for that specific Agent. **Do not used the shared hostname** for the Failover pair.
 
 1. Save the file and restart the DMA.
 


### PR DESCRIPTION
Added important notes regarding DNS configuration and wildcard certificates for HTTPS setup. 

This was found after finding that on admin.dataminer.services, we weren't seeing the failover status for the pair and the DataMiner Agent was connecting and disconnecting infrequently on dataminer.services. (https://collaboration.dataminer.services/task/284073)