### PR TITLE
GQI - Architecture - Add more details about the extension worker processes (RN43770)

### DIFF
--- a/develop/devguide/GQI_Extensions/GQI_Extensions_Architecture.md
+++ b/develop/devguide/GQI_Extensions/GQI_Extensions_Architecture.md
@@ -30,7 +30,7 @@ Each [extension library](xref:GQI_Extension_Libraries) runs in its own child pro
 
 The worker process exists as long as it is being used by at least one active query session, and it will remain available if there are no active query sessions until it expires. See [Termination of idle child processes](xref:GQI_DxM#termination-of-idle-child-processes).
 
-The worker process can be terminated manually using Task Manager in case an extension is using too much resources or has an issue. In that case, all dependent query sessions will become invalid and will respond with a "*Extension worker for 'ExtensionLibrary' has exited.*" message when attempting to interact with the session.
+The worker process can be terminated manually using Task Manager in case an extension is using too many resources or has an issue. In that case, all dependent query sessions will become invalid and will respond with the message "*Extension worker for 'ExtensionLibrary' has exited.*" when you attempt to interact with them.<!-- RN 43770-->
 
 ## Communication process
 


### PR DESCRIPTION
This pull request updates the documentation to clarify the behavior and management of GQI extension worker processes. The main focus is to provide more details on process lifecycle, manual termination, and the impact on active query sessions.

Enhancements to worker process documentation:

* Renamed the section from "Child processes" to "Extension worker processes" to better reflect its purpose.
* Added an explanation of the worker process lifecycle, including how long it remains available and a reference to the termination policy for idle processes.
* Documented the impact and procedure for manually terminating a worker process, including the resulting message for affected query sessions.