### PR TITLE
Update documentation for UIResults.WasOnFilter

### DIFF
--- a/src/DataMiner/SLManagedAutomation/UIResults.cs
+++ b/src/DataMiner/SLManagedAutomation/UIResults.cs
@@ -254,7 +254,7 @@ namespace Skyline.DataMiner.Automation
 		/// <remarks>
 		/// <para>Applicable only in case <see cref="Type"/> is set to <see cref="UIBlockType.DropDown"/>.</para>
 		/// <para>For <see cref="GetFilterString"/> to work, <see cref="UIBlockDefinition.WantsOnFilter"/> has to be set to true and <see cref="WasOnFilter"/> for the current result should return true.</para>
-		/// <note type="note">Available from DataMiner 10.5.8/10.6.0 onwards, in Automation scripts launched from web apps and the <see href="xref:Skyline.DataMiner.Automation.Engine.WebUIVersion">WebUIVersion</see> is WebUIVersion.V2.</note> <!-- RN 42808 / RN 42845 -->
+		/// <note type="note">Available from DataMiner 10.5.8/10.6.0 onwards, in Automation scripts launched from web apps, if the <see href="xref:Skyline.DataMiner.Automation.Engine.WebUIVersion">WebUIVersion</see> is WebUIVersion.V2.</note> <!-- RN 42808 / RN 42845 -->
 		/// <note type="important">When the options are filtered, the currently selected option (if still relevant) needs to be inserted as an option, regardless of whether the filter matches. Otherwise, the dropdown will consider that value incorrect, and the dropdown will be cleared.</note>
 		/// <note type="tip">Consider only filtering the display value of the options and, if possible, ensure that the filter is not case-sensitive.</note>
 		/// </remarks>
@@ -492,7 +492,7 @@ namespace Skyline.DataMiner.Automation
 		/// </example>
 		/// <remarks>
 		/// <para>Applicable only in case <see cref="Type"/> is set to <see cref="UIBlockType.DropDown"/>.</para>
-		/// <note type="note">Available from DataMiner 10.5.8/10.6.0 onwards, in Automation scripts launched from web apps and the <see href="xref:Skyline.DataMiner.Automation.Engine.WebUIVersion">WebUIVersion</see> is WebUIVersion.V2.</note> <!-- RN 42808 / RN 42845 -->
+		/// <note type="note">Available from DataMiner 10.5.8/10.6.0 onwards, in Automation scripts launched from web apps, if the <see href="xref:Skyline.DataMiner.Automation.Engine.WebUIVersion">WebUIVersion</see> is WebUIVersion.V2.</note> <!-- RN 42808 / RN 42845 -->
 		/// <para>For <see cref="WasOnFilter"/> to work, <see cref="UIBlockDefinition.WantsOnFilter"/> has to be set to true. Use <see cref="GetFilterString"/> to get the filter value. See example.</para>
 		/// <note type="important">When the options are filtered, the currently selected option (if still relevant) needs to be inserted as an option, regardless of whether the filter matches. Otherwise, the dropdown will consider that value incorrect, and the dropdown will be cleared.</note>
 		/// <note type="tip">Consider only filtering the display value of the options and, if possible, ensure that the filter is not case-sensitive.</note>


### PR DESCRIPTION
Same as [UIBlockDefinition.WantsOnFilter](https://github.com/SkylineCommunications/dataminer-docs/blob/f7ca9fc6e17402ea936123ce031d030be01a2d69/src/DataMiner/SLManagedAutomation/UIBlockDefinition.cs#L971C15-L971C29) changed the notes that it requires WebVersion.V2.