### PR TITLE
Clarify SSL certificate error handling in NATS

### DIFF
--- a/dataminer/Troubleshooting/Procedures/Investigating_NATS_Issues.md
+++ b/dataminer/Troubleshooting/Procedures/Investigating_NATS_Issues.md
@@ -109,8 +109,7 @@ Check the following log files in the order listed:
 - **Connection refused errors**: Suggest firewall or antivirus issues. This can also mean that the NATS service is not running.
 - **Cluster formation errors**: Point to configuration mismatches between nodes.
 
-- Seeing the following logline in processes: "Failed setting up NATS session: Exception caught in fields fetching: Failed to fetch fields: Remote SSL certificate error. Does the hostname and SSL certificate match?: SSL peer certificate or SSH remote key was not OK": This means that the certificate used by the site binding of IIS is invalid. Make sure the correct certificate is used by IIS.
-See [Setting up HTTPS on a DMA](xref:Setting_up_HTTPS_on_a_DMA#configuring-the-https-binding-in-iis) on how to check and set the IIS HTTPS certificate.
+Note that if the logging for processes includes the line `Failed setting up NATS session: Exception caught in fields fetching: Failed to fetch fields: Remote SSL certificate error. Does the hostname and SSL certificate match?: SSL peer certificate or SSH remote key was not OK"`, this indicates that the certificate used by the site binding of IIS is invalid. Make sure the correct certificate is used by IIS. For more information on how to check and set the IIS HTTPS certificate, see [Setting up HTTPS on a DMA](xref:Setting_up_HTTPS_on_a_DMA#configuring-the-https-binding-in-iis).
 
 ## Check the configuration files
 


### PR DESCRIPTION
Added clarification on SSL certificate errors related to NATS sessions and provided a reference for checking IIS HTTPS certificate.