### PR TITLE
Fix link for Generic Kafka Consumer connector

### DIFF
--- a/solutions/standard_solutions/EPM/EPM_GPON/GPON_components.md
+++ b/solutions/standard_solutions/EPM/EPM_GPON/GPON_components.md
@@ -30,7 +30,7 @@ For an overview of the available collector connectors, see [Supported technologi
 
 To gather the ONT operative data, the default method is a Kafka data stream provided by a third party. Usually this is an ACS if the xPON implementation has multiple vendors deployed (i.e. one vendor for the OLT and multiple vendors for the ONT).
 
-A [Generic Kafka Consumer](https://catalog.dataminer.services/details/172dd90c-5324-45c7-980f-df51d327d91c) connector is available, which is able to retrieve information from any stream, as it does not process any of the received data. It only polls the data, ensures that its formatting is consistent, and stores it in a defined location:
+A [Generic Kafka Consumer](https://catalog.dataminer.services/details/ed00ca53-7d1a-4bf0-88f8-7bb2a457f697) connector is available, which is able to retrieve information from any stream, as it does not process any of the received data. It only polls the data, ensures that its formatting is consistent, and stores it in a defined location:
 
 For EPM xPON to function properly, however, the source for the Kafka stream needs to use the [Standard ONT JSON definition](xref:xPON_ONT_Json_definition). If your ONT operative data source does not use the defined format, contact the Skyline Sales team.
 


### PR DESCRIPTION
Updated the link for the Generic Kafka Consumer connector in the documentation.