### PR TITLE
Hardening guide: indicate HTTPS is enabled by default

### DIFF
--- a/dataminer/Administrator_guide/DataMiner_Agents/Configuring_a_DMA/Setting_up_HTTPS_on_a_DMA.md
+++ b/dataminer/Administrator_guide/DataMiner_Agents/Configuring_a_DMA/Setting_up_HTTPS_on_a_DMA.md
@@ -13,12 +13,21 @@ To securely host your DataMiner Agent, we recommend that you make sure HTTPS con
 ## Configuring the HTTPS binding in IIS
 
 1. Open IIS manager. It can be found under *Administrative Tools* in the *Control Panel* of your computer.
+
 1. In the *Connections* pane on the left, select the computer name, and double-click *Server Certificates* in the pane on the right.
+
 1. Right-click in the *Server Certificates* list, and select *Import*.
+
 1. Browse to your certificate, and click *OK*.
+
 1. In the *Connections* pane on the left, right-click the website, and select *Edit Bindings*.
-1. In the *Add Site Binding* window, add an HTTPS binding with the selected certificate. If an HTTPS binding already exists, you can update the certificate by editing the existing binding.
+
+1. In the *Add Site Binding* window, add an HTTPS binding with the selected certificate.
+
+   If an HTTPS binding already exists, you can update the certificate by editing the existing binding.
+
 1. Ensure sure that *inbound* traffic on TCP port **443** is allowed through the Windows Firewall.
+
 1. Optionally (though **recommended**), enable [HTTP Strict Transport Security](xref:HTTP_Headers#hsts---strict-transport-security) (*HSTS*).
 
 > [!TIP]

--- a/dataminer/Administrator_guide/Security/DataMiner_hardening_guide.md
+++ b/dataminer/Administrator_guide/Security/DataMiner_hardening_guide.md
@@ -111,7 +111,9 @@ To disable the v0 API:
 
 ### HTTPS
 
-By default, DataMiner serves web applications over HTTP, and since DataMiner 10.3 [CU0] <!-- RN 31142 --> also over HTTPS using a self-signed certificate. HTTP is unencrypted and vulnerable to man-in-the-middle attacks, so we highly recommend [configuring HTTPS](xref:Setting_up_HTTPS_on_a_DMA) with a trusted certificate and to [configure HTTPS in DataMiner](xref:Setting_up_HTTPS_on_a_DMA#configuring-https-in-dataminer). It is also highly recommended to either disable HTTP or [set up a redirect to HTTPS](xref:Setting_up_HTTPS_on_a_DMA#configuring-http-to-https-redirection).
+By default, DataMiner serves web applications over HTTP, and starting from DataMiner 10.2.1/10.3.0<!-- RN 31142 --> also over HTTPS using a self-signed certificate.
+
+HTTP is unencrypted and vulnerable to man-in-the-middle attacks, so we highly recommend [configuring HTTPS](xref:Setting_up_HTTPS_on_a_DMA) with a trusted certificate and [configuring HTTPS in DataMiner](xref:Setting_up_HTTPS_on_a_DMA#configuring-https-in-dataminer). We also highly recommend either disabling HTTP or [setting up a redirect to HTTPS](xref:Setting_up_HTTPS_on_a_DMA#configuring-http-to-https-redirection).
 
 ### HTTP headers
 


### PR DESCRIPTION
HTTPS was already enabled by default for a long time, but this was not clear from the hardening guide.