### PR TITLE
Add version test & http header info to align with security advisory bpa update

### DIFF
--- a/dataminer/Administrator_guide/DataMiner_Systems/BPA_tests/BPA_Security_Advisory.md
+++ b/dataminer/Administrator_guide/DataMiner_Systems/BPA_tests/BPA_Security_Advisory.md
@@ -9,7 +9,7 @@ This BPA will run a collection of checks to see if the system is configured as s
 Currently, the following parts of the system are covered:
 
 - DMA
-  - DMA Version: Verifies if the system was upgraded in the last 6 months (only from DataMiner 1.6.3/10.6 [CU0]/10.5 [CU12] onwards) <!-- RN 44566 -->.
+  - DMA Version: Verifies if the system has been upgraded in the last 6 months. This check is included from DataMiner 10.5.0 [CU12]/10.6.3 onwards.<!-- RN 44566 -->
   - gRPC: Verifies if the system is configured to use gRPC for the communication between Cube and the DMA and for inter-DMA communication (only from DataMiner 10.3.2/10.3.0 onwards).
   - Legacy components: Verifies if the v0 web API, the legacy Reporter and Dashboards module, and the legacy Annotations module are disabled.
   - NATS: Verifies if NATS is configured to use TLS (only from DataMiner 10.4.3 onwards).

--- a/dataminer/Administrator_guide/Security/Advanced_security_configuration/WebServer_security/HTTP_Headers.md
+++ b/dataminer/Administrator_guide/Security/Advanced_security_configuration/WebServer_security/HTTP_Headers.md
@@ -16,7 +16,7 @@ The X-Frame-Options header controls which other websites can embed the DataMiner
 
 1. In the *Connections* pane on the left, select *Default Web Site*.
 
-1. In the middle pane, double-click *HTTP Reponse Headers*.
+1. In the middle pane, double-click *HTTP Response Headers*.
 
 1. In the *Actions* pane, click *Add*.
 
@@ -34,7 +34,7 @@ The X-Content-Type-Options header dictates how the browser should handle MIME ty
 
 1. In the *Connections* pane on the left, select *Default Web Site*.
 
-1. In the middle pane, double-click *HTTP Reponse Headers*.
+1. In the middle pane, double-click *HTTP Response Headers*.
 
 1. In the *Actions* pane, click *Add*.
 
@@ -46,13 +46,13 @@ The X-Content-Type-Options header dictates how the browser should handle MIME ty
 
 ### Referrer-Policy
 
-The Referrer-Policy header dictates how much referrer information should be included in the Referer <!-- not a typo, it's actually misspelled like this --> header.
+The Referrer-Policy header dictates how much referrer information should be included in the *Referer*<!-- sic --> header.
 
 1. Open *IIS Manager*.
 
 1. In the *Connections* pane on the left, select *Default Web Site*.
 
-1. In the middle pane, double-click *HTTP Reponse Headers*.
+1. In the middle pane, double-click *HTTP Response Headers*.
 
 1. In the *Actions* pane, click *Add*.
 
@@ -96,7 +96,7 @@ To enable *Strict Transport Security*:
 
 1. In the *Connections* pane on the left, select *Default Web Site*.
 
-1. In the middle pane, double-click *HTTP Reponse Headers*.
+1. In the middle pane, double-click *HTTP Response Headers*.
 
 1. In the *Actions* pane, click *Add*.
 


### PR DESCRIPTION
The security advisory bpa was updated with a new test that verifies if the system was recently updated and a test that verifies if the referrer policy http header is set.