### PR TITLE
Change 'DOM security app' to 'DOM security UI'

### DIFF
--- a/release-notes/Web_apps/Web_apps_Feature_Release_10.6/Web_apps_Feature_Release_10.6.3.md
+++ b/release-notes/Web_apps/Web_apps_Feature_Release_10.6/Web_apps_Feature_Release_10.6.3.md
@@ -20,18 +20,18 @@ This Feature Release of the DataMiner web applications contains the same new fea
 
 ## New features
 
-#### DOM security app now supports instance-level security [ID 44385]
+#### DOM security UI now supports instance-level security [ID 44385]
 
 <!-- MR 10.5.0 [CU12] - FR 10.6.3 -->
 
-Up to now, the DOM security app allowed you to configure security settings on DOM definition level. From now on, it also allows you to configure security settings on DOM instance level. This means, that you can now allow user groups access to an individual DOM instance based on whether that DOM instance contains at least one of a specified set of values for a specified FieldDescriptor.
+Up to now, the DOM security UI allowed you to configure security settings on DOM definition level. From now on, it also allows you to configure security settings on DOM instance level. This means, that you can now allow user groups access to an individual DOM instance based on whether that DOM instance contains at least one of a specified set of values for a specified FieldDescriptor.
 
 For example, the user group *London employees* will only be able to read the "Job" instances where the *Assigned office* field (i.e. a `DomInstanceFieldDescriptor`) contains the ID of the DOM instance for the London office.
 
 For more information, see [DataMiner Object Models: Instance-level security [ID 44233]](xref:General_Feature_Release_10.6.3#dataminer-object-models-instance-level-security-id-44233).
 
 > [!NOTE]
-> To access the DOM security app, go to `https://<DMA IP or hostname>/dom`. In DataMiner Cube, this app can be accessed via *System Center > DOM*.
+> To access the DOM security UI, go to `https://<DMA IP or hostname>/dom`. In DataMiner Cube, this UI can be accessed via *System Center > DOM*.
 
 #### Dashboards app: New Add button in navigation pane [ID 44432]
 


### PR DESCRIPTION
Updated the terminology from 'app' to 'UI' for DOM security and adjusted the corresponding descriptions.