### PR TITLE
Clarify PLM tool behavior and alarm masking

### DIFF
--- a/solutions/custom_solutions/PLM_Tool/DataMiner_PLM_Tool_Overview.md
+++ b/solutions/custom_solutions/PLM_Tool/DataMiner_PLM_Tool_Overview.md
@@ -15,6 +15,7 @@ This solution empowers users to create, edit, and delete maintenance events dire
 ![Planned Maintenance tool home page](~/dataminer/images/PLM_main_page_new.png)
 
 > [!IMPORTANT]
-> The Planned Maintenance tool is designed as a **scheduling and tracking system** for maintenance activities. It does not execute proactive actions or automated workflows based on the scheduler. The tool's purpose is to provide visibility into planned maintenance windows, allowing operators and integrated systems to coordinate activities accordingly.
->
-> **Alarm masking:** This solution includes the *SLC-AS-PLM_MaskAlarms* Automation script, which can mask/unmask correlation-based alarms during active PLM activities. To use this feature, you must configure a Correlation rule manually. For setup instructions, refer to the [PLM Mask Alarms documentation](https://github.com/SkylineCommunications/SLC-AS-Example_PLM_MaskAlarms).
+> The Planned Maintenance tool is designed as a **scheduling and tracking system** for maintenance activities. It does not execute proactive actions or automated workflows based on the scheduler. This tool's purpose is to provide visibility into planned maintenance windows, allowing operators and integrated systems to coordinate activities accordingly.
+
+> [!NOTE]
+> This solution includes the *SLC-AS-PLM_MaskAlarms* Automation script, which can **mask/unmask correlation-based alarms** during active PLM activities. To use this feature, you must **configure a Correlation rule** manually. For setup instructions, refer to the [PLM Mask Alarms documentation](https://github.com/SkylineCommunications/SLC-AS-Example_PLM_MaskAlarms).


### PR DESCRIPTION
Add an IMPORTANT note to the PLM overview clarifying that the Planned Maintenance tool is a scheduling/tracking system and does not execute proactive actions or automated workflows. Also document the included SLC-AS-PLM_MaskAlarms automation script (for masking/unmasking correlation-based alarms) and note that a Correlation rule must be configured manually, with a link to the PLM Mask Alarms documentation.