### PR TITLE
Update Installing_Cassandra_Reaper.md

### DIFF
--- a/dataminer/Administrator_guide/Databases/Configuring_dedicated_clustered_storage/Cassandra-compatible_database_service/Deploying_Cassandra/Installing_Cassandra_Reaper.md
+++ b/dataminer/Administrator_guide/Databases/Configuring_dedicated_clustered_storage/Cassandra-compatible_database_service/Deploying_Cassandra/Installing_Cassandra_Reaper.md
@@ -74,7 +74,7 @@ Cassandra Reaper is an application that can manage Cassandra cluster repairs on 
       - `archivedLogFilenamePattern: /var/log/cassandra-reaper/reaper-%d{yyyy-MM-dd}_%i.log.gz`
       - `archivedFileCount: 10`
 
-   - Configure logging format: `logFormat: "%date{ISO8601} %-6level [%t] %logger{5} - %msg %n"`. Compared to the default format, this setting adds a timestamp to a log line.
+   - Configure the following logging format: `logFormat: "%date{ISO8601} %-6level [%t] %logger{5} - %msg %n"`. Compared to the default format, this setting adds a timestamp to the log line.
 
    - For a sidecar-based configuration, to configure the connection with the Cassandra cluster, use the following configuration:
 


### PR DESCRIPTION
Updated section on logging: 
- added requirement to change default log level to WARN (based on DCP280074 and DCP291303).
- Changed the number of log files to keep from 99 to 10.
- Made adding timestamp in the log format a required step rather than a note.