### PR TITLE
Update Changing the IP of a DMA documentation

### DIFF
--- a/dataminer/Administrator_guide/DataMiner_Agents/Configuring_a_DMA/Changing_the_IP_of_a_DMA.md
+++ b/dataminer/Administrator_guide/DataMiner_Agents/Configuring_a_DMA/Changing_the_IP_of_a_DMA.md
@@ -7,6 +7,9 @@ keywords: hardware migration
 
 The way you can change the IP of a DMA depends on how your DataMiner System is set up. It is different for a standalone DMA, a DMA in a DMS, a Failover DMA in a DMS, and a DMA in a DMS using a Cassandra cluster.
 
+> [!TIP]
+> When reconnecting from Cube Client after performing the applicable change if you are attempting to connect using a hostname you will need to delete that entry from your Cube Launcher screen and re-add the hostname.  Otherwise you will get a TrustFailure error and Cube Client will not reconnect.   Connecting with the new IP will not have this issue.
+
 ## Standalone DMA
 
 For a standalone DMA, i.e., a DMA that is not combined with other DMAs in a cluster:


### PR DESCRIPTION
Added a tip about reconnecting from Cube Client after changing DMA IP

Trying to connect to a hostname previously used on the old IP will fail and make you think you didn't do the server Ip address change correctly.

<img width="596" height="305" alt="image" src="https://github.com/user-attachments/assets/be9f5e04-a68d-414e-8695-240b4c4b4e24" />
