### PR TITLE
Fix outdated automation script template name and add templates overview table

### DIFF
--- a/develop/TOOLS/NuGet/VisualStudioTemplates.md
+++ b/develop/TOOLS/NuGet/VisualStudioTemplates.md
@@ -33,11 +33,25 @@ You can also use the *dotnet new* command to manage the templates. To install th
 dotnet new install Skyline.DataMiner.VisualStudioTemplates
 ```
 
-This will install the NuGet package. When that is done, you can create a connector or automation script solution via the dotnet CLI. For example, to create a new automation script solution, you can use the following command:
+This will install the NuGet package. When that is done, you can create a connector or automation script project via the dotnet CLI. For example, to create a new automation script project, you can use the following command:
 
 ```dotnetcli
-dotnet new dataminer-automation-solution -name "ExampleScript" -auth "Joe"
+dotnet new dataminer-automation-project --name "ExampleScript" -auth "Joe"
 ```
+
+Other available templates include `dataminer-automation-library-project`, `dataminer-gqi-ad-hoc-data-source-project`, `dataminer-user-defined-api-project`, and `dataminer-package-project`.
+
+The following table lists all available DataMiner templates:
+
+| Template | Short name |
+|----------|------------|
+| Connector solution | `dataminer-connector-solution` |
+| Automation script project | `dataminer-automation-project` |
+| Automation script library project | `dataminer-automation-library-project` |
+| User-defined API project | `dataminer-user-defined-api-project` |
+| GQI ad hoc data source project | `dataminer-gqi-ad-hoc-data-source-project` |
+| Package project | `dataminer-package-project` |
+| Test package project | `dataminer-test-package-project` |
 
 To see all the available options for a template, use the command `dotnet new <template-name> --help`. For example:
 


### PR DESCRIPTION
## Changes

The `VisualStudioTemplates.md` page was referencing `dataminer-automation-solution`, which was the v1 template name that was **removed in v2** of the [Skyline.DataMiner.VisualStudioTemplates](https://github.com/SkylineCommunications/Skyline.DataMiner.VisualStudioTemplates) package. The current template is `dataminer-automation-project`.

### Fix
- Updated template name from `dataminer-automation-solution` to `dataminer-automation-project`
- Updated `-name`/`-auth` flags to `--name` (standard dotnet new convention)
- Updated prose from "solution" to "project" to match the new template type
- Added a table listing all available DataMiner templates — this page is the natural home for this overview and it was not documented anywhere else in the docs

## Related
The `Developing_Automation_scripts_as_Visual_Studio_solutions.md` page already has an obsolete notice for v2, so no changes needed there.