### PR TITLE
Add System namespace to C# code snippet

### DIFF
--- a/dataminer/Functions/SRM/The_Bookings_module/Function_resource_settings.md
+++ b/dataminer/Functions/SRM/The_Bookings_module/Function_resource_settings.md
@@ -42,6 +42,7 @@ For example:
 To update this file without the need to restart DataMiner, use the protocolFunctionHelper as illustrated in the code snippet below. The configuration change will then be automatically synced in the cluster.
 
 ```csharp
+using System;
 using Skyline.DataMiner.Automation;
 using Skyline.DataMiner.Net.Messages;
 namespace Script


### PR DESCRIPTION
Added using directive for System namespace in C# code snippet, this is needed for the Timespan.Fromxxx methods.