### PR TITLE
DCP294211: Add warning to advise against using %20 in script names

### DIFF
--- a/dataminer/Functions/Automation_module/Managing_Automation_scripts.md
+++ b/dataminer/Functions/Automation_module/Managing_Automation_scripts.md
@@ -58,6 +58,9 @@ You can also add a new script by duplicating an existing script and then changin
 > [!NOTE]
 > You cannot create two automation scripts with the same name.
 
+> [!WARNING]
+> Do not use `%20` in an automation script name. `%20` is interpreted as an encoded space, which will cause the script to fail to load.
+
 To create a functional new script, you will then need to configure it further. For more information, see [Designing automation scripts](xref:Designing_Automation_scripts).
 
 ## Adding a new automation script folder

--- a/dataminer/Functions/Automation_module/Managing_Automation_scripts.md
+++ b/dataminer/Functions/Automation_module/Managing_Automation_scripts.md
@@ -58,7 +58,7 @@ You can also add a new script by duplicating an existing script and then changin
 > [!NOTE]
 > You cannot create two automation scripts with the same name.
 
-> [!WARNING]
+> [!CAUTION]
 > Do not use `%20` in an automation script name. `%20` is interpreted as an encoded space, which will cause the script to fail to load.
 
 To create a functional new script, you will then need to configure it further. For more information, see [Designing automation scripts](xref:Designing_Automation_scripts).


### PR DESCRIPTION
Add a warning to the Automation documentation to advise users not to use `%20` in automation script names.
When %20 is present in the script file name, it is interpreted as an encoded space by the XML loading path, causing the script load to fail.