### PR TITLE
Remove or update OPC references to reflect End of Life

### DIFF
--- a/dataminer/Administrator_guide/DataMiner_Systems/About_DataMiner_Systems/DataMiner_processes.md
+++ b/dataminer/Administrator_guide/DataMiner_Systems/About_DataMiner_Systems/DataMiner_processes.md
@@ -83,7 +83,7 @@ Controls all communication among DataMiner Agents, and between DataMiner Agents 
 
 Controls all communication from and to devices connected to either a serial port or an IP port.
 
-Types of communication controlled by this process include serial, smart-serial, GPIB and OPC.
+Types of communication controlled by this process include serial, smart-serial and GPIB.
 
 > [!NOTE]
 > Multiple SLPort processes can run simultaneously. See [Setting the number of simultaneously running SLPort processes](xref:Configuration_of_DataMiner_processes#setting-the-number-of-simultaneously-running-slport-processes).

--- a/dataminer/Administrator_guide/DataMiner_Systems/About_DataMiner_Systems/DataMiner_processes.md
+++ b/dataminer/Administrator_guide/DataMiner_Systems/About_DataMiner_Systems/DataMiner_processes.md
@@ -83,7 +83,7 @@ Controls all communication among DataMiner Agents, and between DataMiner Agents 
 
 Controls all communication from and to devices connected to either a serial port or an IP port.
 
-Types of communication controlled by this process include serial, smart-serial and GPIB.
+Types of communication controlled by this process include serial, smart-serial, and GPIB.
 
 > [!NOTE]
 > Multiple SLPort processes can run simultaneously. See [Setting the number of simultaneously running SLPort processes](xref:Configuration_of_DataMiner_processes#setting-the-number-of-simultaneously-running-slport-processes).

--- a/dataminer/Operator_guide/Elements/Working_with_elements/Importing_and_exporting_elements.md
+++ b/dataminer/Operator_guide/Elements/Working_with_elements/Importing_and_exporting_elements.md
@@ -131,7 +131,7 @@ When altering an exported CSV file in a third-party application like Microsoft E
   | 3             | Smart-serial                       |
   | 4             | Virtual                            |
   | 5             | GPIB                               |
-  | 6             | ~~OPC~~ (End of Life)              |
+  | 6             | ~~OPC~~ ([End of Life](xref:Software_support_life_cycles#end-of-life)) |
   | 7             | SLA                                |
   | 8             | SNMPv2                             |
   | 9             | SNMPv3                             |

--- a/dataminer/Operator_guide/Elements/Working_with_elements/Importing_and_exporting_elements.md
+++ b/dataminer/Operator_guide/Elements/Working_with_elements/Importing_and_exporting_elements.md
@@ -131,7 +131,7 @@ When altering an exported CSV file in a third-party application like Microsoft E
   | 3             | Smart-serial                       |
   | 4             | Virtual                            |
   | 5             | GPIB                               |
-  | 6             | OPC                                |
+  | 6             | ~~OPC~~ (End of Life)              |
   | 7             | SLA                                |
   | 8             | SNMPv2                             |
   | 9             | SNMPv3                             |

--- a/dataminer/Troubleshooting/Troubleshooting_Flowcharts/Troubleshooting_Process_Identification/Polling_processes/Troubleshooting_SLPort_exe.md
+++ b/dataminer/Troubleshooting/Troubleshooting_Flowcharts/Troubleshooting_Process_Identification/Polling_processes/Troubleshooting_SLPort_exe.md
@@ -8,7 +8,7 @@ uid: Troubleshooting_SLPort_exe
 
 SLPort controls all communication from and to devices connected to either a serial or an IP port.
 
-**Communication types**: HTTP, Web Socket, serial, smart-serial, GPIB and SSH.
+**Communication types**: HTTP, Web Socket, serial, smart-serial, GPIB, and SSH.
 
 ## SLPort troubleshooting flowchart
 

--- a/dataminer/Troubleshooting/Troubleshooting_Flowcharts/Troubleshooting_Process_Identification/Polling_processes/Troubleshooting_SLPort_exe.md
+++ b/dataminer/Troubleshooting/Troubleshooting_Flowcharts/Troubleshooting_Process_Identification/Polling_processes/Troubleshooting_SLPort_exe.md
@@ -8,7 +8,7 @@ uid: Troubleshooting_SLPort_exe
 
 SLPort controls all communication from and to devices connected to either a serial or an IP port.
 
-**Communication types**: HTTP, Web Socket, serial, smart-serial, GPIB, SSH and OPC.
+**Communication types**: HTTP, Web Socket, serial, smart-serial, GPIB and SSH.
 
 ## SLPort troubleshooting flowchart
 

--- a/develop/api/NotifyTypes/NT_CREATE_ELEMENT.md
+++ b/develop/api/NotifyTypes/NT_CREATE_ELEMENT.md
@@ -103,7 +103,7 @@ int result = (int) protocol.NotifyDataMinerQueued(160 /* NT_CREATE_ELEMENT */, e
   - 3: Smart-serial
   - 4: Virtual
   - 5: GPIB
-  - 6: OPC
+  - 6: ~~OPC~~ (End of Life)
   - 7: SLA
   - 8: SNMPv2
   - 9: SNMPv3

--- a/develop/api/NotifyTypes/NT_CREATE_ELEMENT.md
+++ b/develop/api/NotifyTypes/NT_CREATE_ELEMENT.md
@@ -103,7 +103,7 @@ int result = (int) protocol.NotifyDataMinerQueued(160 /* NT_CREATE_ELEMENT */, e
   - 3: Smart-serial
   - 4: Virtual
   - 5: GPIB
-  - 6: ~~OPC~~ (End of Life)
+  - 6: ~~OPC~~ ([End of Life](xref:Software_support_life_cycles#end-of-life))
   - 7: SLA
   - 8: SNMPv2
   - 9: SNMPv3

--- a/develop/codingguidelines/UserInterface/Default_settings.md
+++ b/develop/codingguidelines/UserInterface/Default_settings.md
@@ -22,7 +22,6 @@ Recommended port support per type:
 | HTTP                | X   |     |        |
 | GPIB                | X   |     |        |
 | Virtual             |     |     |        |
-| OPC                 | X   |     |        |
 | SLA                 |     |     |        |
 
 Make sure to disable any of the ports that are not possible for a specific type of protocol.

--- a/develop/devguide/Connector/Connections.md
+++ b/develop/devguide/Connector/Connections.md
@@ -93,7 +93,6 @@ The following table provides an overview of the port types DataMiner supports fo
 |smart-serial single|&#10004;|&#10004;||
 |http|&#10004;|||
 |gpib|&#10004;|||
-|opc|&#10004;|||
 |sla||||
 
 Port types that are not supported can be hidden from the "Type of port" box in the element editor using the *Disabled* child tag of the *PortTypeIP*, *PortTypeUDP*, and *PortTypeSerial* tag for TCP, UDP, and serial, respectively.

--- a/develop/devguide/Connector/LogicParameters.md
+++ b/develop/devguide/Connector/LogicParameters.md
@@ -118,7 +118,7 @@ The general parameters are organized into four groups: communication, DCF, repli
 
 General parameters can be loaded dynamically, and the following defaults apply:<!-- RN 12263 -->
 
-- Communication: General parameters belonging to this group are not loaded for protocols of type *http*, *websocket*, *opc*, *gpib*, *virtual*, *sla*, and *service*.
+- Communication: General parameters belonging to this group are not loaded for protocols of type *http*, *websocket*, *gpib*, *virtual*, *sla*, and *service*.
 - DCF: Only loaded if parameter groups are defined in the protocol.
 - Verification: General parameters belonging to this group are not loaded when *MaintenanceSettings.xml* has been configured to enable Command Execution Verification. (With the [ProtocolSettings.ExecutionVerification](xref:MaintenanceSettings.ProtocolSettings.ExecutionVerification) tag.)
 - Replication: By default, general parameters belonging to this group are always loaded.

--- a/develop/devguide/Connector/ReservedIDsElementControlProtocol.md
+++ b/develop/devguide/Connector/ReservedIDsElementControlProtocol.md
@@ -16,7 +16,7 @@ There are four groups of general parameters: communication, DCF, replication and
 
 General parameters can be loaded dynamically, and the following defaults apply:<!-- RN 12263 -->
 
-- Communication: General parameters belonging to this group are not loaded for protocols of type *http*, *websocket*, *opc*, *gpib*, *virtual*, *sla*, and *service*.
+- Communication: General parameters belonging to this group are not loaded for protocols of type *http*, *websocket*, *gpib*, *virtual*, *sla*, and *service*.
 - DCF: Only loaded if there is at least one parameter group defined in the protocol.
 - Verification: General parameters belonging to this group are not loaded when *MaintenanceSettings.xml* has been configured to enable Command Execution Verification. (With the [ProtocolSettings.ExecutionVerification](xref:MaintenanceSettings.ProtocolSettings.ExecutionVerification) tag.)
 - Replication: By default, general parameters belonging to this group are always loaded (because it is always possible that an element will be replicated).

--- a/develop/schemadoc/Protocol/EnumProtocolType.md
+++ b/develop/schemadoc/Protocol/EnumProtocolType.md
@@ -13,7 +13,6 @@ Specifies the protocol type.
 |***string restriction***|||
 |&nbsp;&nbsp;Enumeration|gpib|General Purpose Interface Bus (GPIB)|
 |&nbsp;&nbsp;Enumeration|http|Hypertext Transfer Protocol (HTTP)|
-|&nbsp;&nbsp;Enumeration|opc|OLE Process Control (OPC)|
 |&nbsp;&nbsp;Enumeration|serial|Serial|
 |&nbsp;&nbsp;Enumeration|serial single|Serial single|
 |&nbsp;&nbsp;Enumeration|service|Service|

--- a/develop/schemadoc/Protocol/Protocol.Pairs.Pair-ping.md
+++ b/develop/schemadoc/Protocol/Protocol.Pairs.Pair-ping.md
@@ -17,7 +17,7 @@ If set to true, the pair will be executed when the device is in timeout and slow
 ## Remarks
 
 > [!NOTE]
-> This option cannot be used in protocols of type SNMP or OPC.
+> This option cannot be used in protocols of type SNMP.
 
 ## Examples
 

--- a/develop/schemadoc/Protocol/Protocol.Type-communicationOptions.md
+++ b/develop/schemadoc/Protocol/Protocol.Type-communicationOptions.md
@@ -167,6 +167,9 @@ Example:
 <Type communicationOptions="progid=National Instruments.OPCFieldPoint">opc</Type>
 ```
 
+> [!CAUTION]
+> OPC communication should no longer be used in DataMiner connectors. Instead, QActions should be used, for example like in the [Generic OPC Data Access](https://catalog.dataminer.services/details/f2642ea9-9eaa-42f3-880e-816470b06a61) connector.
+
 ### redundantPolling
 
 If you specify this option in a two-port serial, SNMP, or HTTP protocol, the element will automatically switch to the second port when it goes in timeout.

--- a/develop/schemadoc/Protocol/Protocol.Type.md
+++ b/develop/schemadoc/Protocol/Protocol.Type.md
@@ -41,6 +41,9 @@ This type specifies that the HTTP protocol is used for communication.
 
 This type of protocol, built like a "Serial" protocol, will allow DataMiner to communicate with elements using OPC (OLE Process Control).
 
+> [!CAUTION]
+> OPC communication should no longer be used in DataMiner connectors. Instead, QActions should be used, for example like in the [Generic OPC Data Access](https://catalog.dataminer.services/details/f2642ea9-9eaa-42f3-880e-816470b06a61) connector.
+
 ### serial
 
 Used for standard serial protocols (e.g., RS232, RS485, etc.).


### PR DESCRIPTION
https://docs.dataminer.services/dataminer/Reference/Software_support_life_cycles.html?q=opc#end-of-life

Retained some OPC references to help users understand legacy connector behavior. Can be removed if we prefer not to maintain this documentation.