### PR TITLE
fUpdate ActionWmi.md with WMI query note

### DIFF
--- a/develop/devguide/Connector/Actions/ActionWmi.md
+++ b/develop/devguide/Connector/Actions/ActionWmi.md
@@ -32,6 +32,9 @@ Configures the script to be executed, made up of the following components (separ
 |where|The WHERE clause of the script. You can specify this clause hard-coded or you can specify "ID:[Parameter ID]". In the latter case, the specified parameter must contain the WHERE clause.|
 
 > [!NOTE]
+> If the `server` option references a parameter ID that is not yet initialized during element startup, the WMI query defaults to the local DMA (i.e. the DMA hosting the connector).
+
+> [!NOTE]
 > When you specify a hard-coded WHERE clause, replace quotes by "\&quot;".
 
 This is an example of a hardcoded WHERE clause:

--- a/develop/devguide/Connector/Actions/ActionWmi.md
+++ b/develop/devguide/Connector/Actions/ActionWmi.md
@@ -32,22 +32,21 @@ Configures the script to be executed, made up of the following components (separ
 |where|The WHERE clause of the script. You can specify this clause hard-coded or you can specify "ID:[Parameter ID]". In the latter case, the specified parameter must contain the WHERE clause.|
 
 > [!NOTE]
-> If the `server` option references a parameter ID that is not yet initialized during element startup, the WMI query defaults to the local DMA (i.e. the DMA hosting the connector).
-
-> [!NOTE]
-> When you specify a hard-coded WHERE clause, replace quotes by "\&quot;".
-
-This is an example of a hardcoded WHERE clause:
-
-```xml
-where:name=&quot;SLDataMiner&quot;
-```
-
-This is an example of a dynamic WHERE clause:
-
-```xml
-where:ID:25
-```
+>
+> - If the `server` option references a parameter ID that is not yet initialized during element startup, the WMI query defaults to the local DMA (i.e., the DMA hosting the connector).
+> - When you specify a hard-coded WHERE clause, replace quotes by "\&quot;".
+>
+>   This is an example of a hardcoded WHERE clause:
+>
+>   ```xml
+>   where:name=&quot;SLDataMiner&quot;
+>   ```
+>
+>   This is an example of a dynamic WHERE clause:
+>
+>   ```xml
+>   where:ID:25
+>   ```
 
 ### Type@returnValue
 


### PR DESCRIPTION
Added note about default WMI query behavior when server option is uninitialized. This is related to the Dojo question:
https://community.dataminer.services/question/protocol-action-wmi-polling-ip-when-parameter-is-not-initialized/