### PR TITLE
Extend "Get parameters for elements where" capabilities

### DIFF
--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/FAQ/Dashboards_and_Low_Code_Apps_FAQ.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/FAQ/Dashboards_and_Low_Code_Apps_FAQ.md
@@ -24,6 +24,9 @@ To resolve these:
 
 If you have made protocol changes, but you do not see them reflected in your GQI query results, this is likely caused by GQI caching certain protocols for faster performance.
 
+> [!IMPORTANT]
+> This problem does not occur when using GQI DxM as the caches are being invalidated upon protocol changes. Therefore, the below approach only applies when using GQI in SLHelper.
+
 To resolve this:
 
 1. Launch your system's Task Manager utility.

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/FAQ/Dashboards_and_Low_Code_Apps_FAQ.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/FAQ/Dashboards_and_Low_Code_Apps_FAQ.md
@@ -25,7 +25,7 @@ To resolve these:
 If you have made protocol changes, but you do not see them reflected in your GQI query results, this is likely caused by GQI caching certain protocols for faster performance.
 
 > [!IMPORTANT]
-> This problem does not occur when using GQI DxM as the caches are being invalidated upon protocol changes. Therefore, the below approach only applies when using GQI in SLHelper.
+> This problem does **not** occur when the **GQI DxM** is used, as this invalidates the caches upon protocol changes. The approach below therefore only applies when using GQI in SLHelper.
 
 To resolve this:
 

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/GQI/Query_Data_Sources/Get_parameters_for_element_where.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/GQI/Query_Data_Sources/Get_parameters_for_element_where.md
@@ -4,11 +4,19 @@ uid: Get_parameters_for_element_where
 
 # Get parameters for element where
 
-The *Get parameters for element where* data source retrieves the selected parameters for the specified protocol or the parameters linked to the specified profile definition. Note that if parameters are displayed based on a specific protocol, it is not possible to combine a table parameter with other parameters, and only column parameters from the same table can be displayed in the same query.
+The *Get parameters for element where* data source retrieves parameters across elements. You can use it to compare metrics across devices and as input for further aggregation.
 
-From DataMiner 10.5.0 [CU12]/10.6.3 onwards<!--RN 44553-->, this data source can also query indexed logger tables that are stored in an Elasticsearch or OpenSearch database.
+To ensure consistent parameter mapping across devices, elements must either share the same protocol version or be linked to a profile definition.
 
-If a protocol and version have been specified, you can retrieve parameters from existing data in the dashboard. Prior to DataMiner 10.3.5/10.4.0<!--  RN 35837 -->, you can do so using the *Use feed* checkbox. In more recent DataMiner versions, you can instead click the link icon to the right of the relevant selection box.
+From DataMiner 10.5.0 [CU12]/10.6.3 onwards<!--RN 44553-->, this data source can also query indexed logger tables stored in an Elasticsearch or OpenSearch database.
 
-> [!TIP]
-> If you encounter problems with protocol changes not appearing in the query results, please refer to the following troubleshooting steps: [What should I do if I do not see my protocol changes applied in a GQI query result?](xref:Dashboards_and_Low_Code_Apps_FAQ#what-should-i-do-if-i-do-not-see-my-protocol-changes-applied-in-a-gqi-query-result)
+## By protocol version
+
+Retrieves parameters for all active elements that use the specified protocol version. After you specify a protocol version, you can select both table parameters and standalone parameters during query creation. If you select a table parameter, all columns in that table become available for further query operators.
+
+> [!NOTE]
+> It is not possible to select multiple table parameters or combine a table parameter with standalone parameters.
+
+## By profile definition
+
+Retrieves parameters for all active elements of a specific protocol version that are linked to a profile parameter. You can use converters to align parameters across different protocol versions.

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/GQI/Query_Data_Sources/Get_parameters_for_element_where.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/GQI/Query_Data_Sources/Get_parameters_for_element_where.md
@@ -6,17 +6,19 @@ uid: Get_parameters_for_element_where
 
 The *Get parameters for element where* data source retrieves parameters across elements. You can use it to compare metrics across devices and as input for further aggregation.
 
-To ensure consistent parameter mapping across devices, elements must either share the same protocol version or be linked to a profile definition.
+To ensure consistent parameter mapping across devices, elements must either share the same [protocol version](#by-protocol-version) or be linked to a [profile definition](#by-profile-definition).
 
 From DataMiner 10.5.0 [CU12]/10.6.3 onwards<!--RN 44553-->, this data source can also query indexed logger tables stored in an Elasticsearch or OpenSearch database.
 
 ## By protocol version
 
-Retrieves parameters for all active elements that use the specified protocol version. After you specify a protocol version, you can select both table parameters and standalone parameters during query creation. If you select a table parameter, all columns in that table become available for further query operators.
+Selecting a protocol and version retrieves parameters for all active elements that use the specified protocol version.
+
+You can select both table parameters and standalone parameters during query creation. If you select a table parameter, all columns in that table become available for further query operators.
 
 > [!NOTE]
 > It is not possible to select multiple table parameters or combine a table parameter with standalone parameters.
 
 ## By profile definition
 
-Retrieves parameters for all active elements of a specific protocol version that are linked to a profile parameter. You can use converters to align parameters across different protocol versions.
+Selecting a profile definition retrieves parameters for all active elements of a specific protocol version that are linked to a profile parameter. You can use converters to align parameters across different protocol versions.


### PR DESCRIPTION
Add an IMPORTANT note to the Dashboards FAQ explaining that GQI DxM invalidates caches on protocol changes and that the troubleshooting steps apply only when using GQI in SLHelper. Revise the Get parameters for element where doc to broaden the intro (retrieving parameters across elements), state that elements must share a protocol version or profile definition, add a "By protocol version" section describing how table and standalone parameters become available (selecting a table exposes its columns), and clarify that multiple table parameters or mixing table and standalone parameters is not supported.