### PR TITLE
Removed spaces from RegexMatch examples

### DIFF
--- a/develop/devguide/Visio/reference/Placeholders_for_variables_in_shape_data_values.md
+++ b/develop/devguide/Visio/reference/Placeholders_for_variables_in_shape_data_values.md
@@ -463,17 +463,17 @@ If you want to override the above-mentioned general rule, you can add to the sha
 
 Available from DataMiner 10.3.0 [CU17]/10.4.0 [CU5]/10.4.8 onwards.<!-- RN 39763 -->
 
-This placeholder takes a regular expression and input, and it returns the parts of the input matching the regular expression. For example, `[RegexMatch: [a-z], aBc]` will return all the lowercase letters in the input, i.e., "ac".
+This placeholder takes a regular expression and input, and it returns the parts of the input matching the regular expression. For example, `[RegexMatch:[a-z],aBc]` will return all the lowercase letters in the input, i.e., "ac".
 
 When multiple matches are found within the input, by default, all matches will be concatenated and returned as one single string, without any separators. You can specify options to customize this behavior:
 
 - If you want the matches to be separated, you can specify a separator.
 
-  For example, `[RegexMatch: [a-z], aBc, separator=%]` will return "a%c".
+  For example, `[RegexMatch:[a-z],aBc,separator=%]` will return "a%c".
 
 - If you do not want all matches to be concatenated, you can use the "index=" option to indicate the specific match you want to have returned.
 
-  For example, `[RegexMatch: [a-z], aBc, index=0]` will return "a".
+  For example, `[RegexMatch:[a-z],aBc,index=0]` will return "a".
 
 If the regular expression or the input includes the default separator (","), you can use the [sep:] placeholder to replace it with another one.
 


### PR DESCRIPTION
The spaces are taken into account for the value or regex, so the examples where wrong.