### PR TITLE
Rename BPA test to 'Local Single Cassandra DB Size'

### DIFF
--- a/dataminer/Administrator_guide/DataMiner_Systems/BPA_tests/BPA_Cassandra_DB_Size.md
+++ b/dataminer/Administrator_guide/DataMiner_Systems/BPA_tests/BPA_Cassandra_DB_Size.md
@@ -8,7 +8,7 @@ Cassandra has some operational limits regarding the size of its files, for examp
 
 The *Cassandra DB Size* BPA test checks the size of the local Cassandra file system against a predefined set of rules. You can find information about this BPA test below.
 
-This BPA test is available on demand. From DataMiner 10.1.4 up to DataMiner 10.4.11/10.4.0 [CU9], it is available in System Center.<!--RN 40751-->
+This BPA test is available on demand and now it is known as *Local Single Cassandra DB Size*. From DataMiner 10.1.4 up to DataMiner 10.4.11/10.4.0 [CU9], it is available in System Center.<!--RN 40751-->
 
 > [!NOTE]
 >

--- a/dataminer/Administrator_guide/DataMiner_Systems/BPA_tests/BPA_Cassandra_DB_Size.md
+++ b/dataminer/Administrator_guide/DataMiner_Systems/BPA_tests/BPA_Cassandra_DB_Size.md
@@ -2,18 +2,18 @@
 uid: BPA_Cassandra_DB_Size
 ---
 
-# Cassandra DB Size
+# Local Single Cassandra DB Size
 
 Cassandra has some operational limits regarding the size of its files, for example to keep enough disk space free for compaction. In addition, Skyline might impose some other limits based on previous issues observed in the field.
 
-The *Cassandra DB Size* BPA test checks the size of the local Cassandra file system against a predefined set of rules. You can find information about this BPA test below.
+The *Local Single Cassandra DB Size* BPA test checks the size of the local Cassandra file system against a predefined set of rules. You can find information about this BPA test below.
 
-This BPA test is available on demand and now it is known as *Local Single Cassandra DB Size*. From DataMiner 10.1.4 up to DataMiner 10.4.11/10.4.0 [CU9], it is available in System Center.<!--RN 40751-->
+This BPA test is available on demand. From DataMiner 10.1.4 up to DataMiner 10.4.11/10.4.0 [CU9], it is known as *Cassandra DB Size* and it is available in System Center by default.<!--RN 40751-->
 
 > [!NOTE]
 >
 > - This BPA test does not work for remote Cassandra nodes or for systems with a Cassandra Cluster setup.
-> - Prior to DataMiner 10.4.12/10.5.0<!--RN 40751-->, this BPA test does not work if your IP address is "localhost".
+> - Prior to DataMiner 10.4.12/10.5.0 [CU10]<!--RN 40751-->, this BPA test does not work if your IP address is "localhost".
 
 ## Metadata
 

--- a/dataminer/Administrator_guide/toc.yml
+++ b/dataminer/Administrator_guide/toc.yml
@@ -162,8 +162,6 @@ items:
             topicUid: BPA_Report_Active_RTE
           - name: Antivirus on the DataMiner Agents
             topicUid: BPA_Check_Antivirus_DLLs
-          - name: Cassandra DB Size
-            topicUid: BPA_Cassandra_DB_Size
           - name: Check Deprecated DLL Usage
             topicUid: BPA_Check_Deprecated_DLL_Usage
           - name: Check System Health
@@ -186,6 +184,8 @@ items:
             topicUid: BPA_Https_Configuration
           - name: Large Alarm Trees
             topicUid: BPA_LargeAlarmTrees
+          - name: Local Single Cassandra DB Size
+            topicUid: BPA_Cassandra_DB_Size
           - name: NATS cluster verification
             topicUid: BPA_Check_Agent_Presence
           - name: Password Strength

--- a/release-notes/General/General_Feature_Release_10.4/General_Feature_Release_10.4.12.md
+++ b/release-notes/General/General_Feature_Release_10.4/General_Feature_Release_10.4.12.md
@@ -164,6 +164,7 @@ A number of minor enhancements have been made to the following BPAs:
 
 ##### Cassandra DB Size
 
+- Renamed to *Local Single Cassandra DB Size*.
 - Will no longer be considered a standard BPA test.
 - Will no longer fail when the IP address is "localhost".
 - Error `! execution failed | This BPA does not apply for this DataMiner Agent` will no longer appear on DMAs using STaaS.

--- a/release-notes/General/General_Main_Release_10.5/General_Main_Release_10.5.0_enhancements.md
+++ b/release-notes/General/General_Main_Release_10.5/General_Main_Release_10.5.0_enhancements.md
@@ -753,6 +753,7 @@ A number of minor enhancements have been made to the following BPAs:
 
 ##### Cassandra DB Size
 
+- Renamed to *Local Single Cassandra DB Size*.
 - Will no longer be considered a standard BPA test.
 - Will no longer fail when the IP address is "localhost".
 - Error `! execution failed | This BPA does not apply for this DataMiner Agent` will no longer appear on DMAs using STaaS.


### PR DESCRIPTION
Updated the description of the BPA test to reflect its new name and clarify its availability. 
RN40751
https://gerrit.skyline.be/review/c/BpaTests/+/6474/3/Cassandra+DB+Size/Cassandra+DB+Size/BpaTestEntry.cs