### PR TITLE
Add scheduling configuration documentation for MediaOps Plan

### DIFF
--- a/solutions/standard_solutions/MediaOps/MediaOps.Plan/Apps/MO_Resource_Studio.md
+++ b/solutions/standard_solutions/MediaOps/MediaOps.Plan/Apps/MO_Resource_Studio.md
@@ -24,7 +24,7 @@ The following pages are available in the app:
 
 - ![Capacity Management](~/solutions/images/Resource_Studio_Capacity_Management.png) **Capacity Management**: Here you can **create** and **manage** [capacities](#capacities).
 
-- ![Configuration Management](~/solutions/images/Resource_Studio_Configuration_Management.png) **Configuration Management**: If a resource pool has **parameters** that can be defined per job in the Scheduling app, you can add those types of parameters here. You can give the configurations default values or make it mandatory to configure them upon job creation.
+- ![Configuration Management](~/solutions/images/Resource_Studio_Configuration_Management.png) **Configuration Management**: If a resource pool has **parameters** that can be defined per job in the Scheduling app, you can add those types of parameters here. You can give the configurations default values or make it mandatory to configure them upon job creation. For more information on how to configure these parameters, see [Scheduling configuration](xref:MO_Scheduling_Configuration).
 
 - ![Properties](~/solutions/images/Resource_Studio_Properties.png) **Properties**: Allows you to manage [properties](#properties) that can be used by resources and resource pools.
 

--- a/solutions/standard_solutions/MediaOps/MediaOps.Plan/Apps/MO_Scheduling_Configuration.md
+++ b/solutions/standard_solutions/MediaOps/MediaOps.Plan/Apps/MO_Scheduling_Configuration.md
@@ -1,0 +1,164 @@
+---
+uid: MO_Scheduling_Configuration
+description: Learn how to configure capabilities, capacities, configurations, and automated actions for resource pools, workflows, and jobs using the Scheduling Configuration dialog.
+---
+
+# Scheduling configuration
+
+The scheduling configuration dialog allows you to define what capabilities, capacities, and configurations a resource should have when it is selected from a resource pool. It also allows you to configure automated actions (orchestration scripts) that run when a job starts or ends.
+
+This dialog is available in the [Resource Studio](xref:MO_Resource_Studio), [Workflow Designer](xref:MO_Workflow_Designer), and [Scheduling](xref:MO_Scheduling) apps.
+
+## Opening the scheduling configuration dialog
+
+Depending on the app you are using, you can open the dialog in different ways:
+
+- **Resource Studio**: Go to the *Resource Pools* page, click the three-dot button in the row of a resource pool, and select *Scheduling Config*. This opens the *Edit Resource Pool Parameters* dialog.
+
+- **Workflow Designer**: Click the pencil icon in the row of a workflow to open the *Edit* panel. Select a node in the workflow, then click the *Configure* button. To edit the global scheduling configuration of the workflow, click the *Configure* button at the top of the panel. This opens the *Select Configuration* dialog.
+
+- **Scheduling**: Click the pencil icon to open the *Edit* panel of a job. In the *Nodes* table, click the icon in the *Config Status* column. To edit the global configuration of the job, click the *Edit job config* button above the *Nodes* table. This opens the *Select Configuration* dialog.
+
+## Dialog layout
+
+The dialog consists of two main areas:
+
+- **Left side**: The scheduling configuration, which consists of three sections: [Capabilities](#capabilities), [Capacities](#capacities), and [Configurations](#configurations).
+
+- **Right side**: The [automated actions](#automated-actions) (orchestration scripts), which allow you to configure scripts that run at specific moments during the lifecycle of a job.
+
+## Capabilities
+
+[Capabilities](xref:MO_Resource_Studio#capabilities) give a qualitative description of a resource, making it clear what it can be used for. When capabilities are configured in the scheduling configuration, only resources that match all defined capabilities can be selected from the resource pool.
+
+To add a capability:
+
+1. In the *Capabilities* section, use the dropdown at the bottom to select the capability you want to assign.
+
+1. Select the checkbox next to the capability to enable value selection.
+
+1. Select the required value from the dropdown.
+
+To remove a capability, click the **X** button next to it.
+
+> [!NOTE]
+> If a capability is marked as mandatory (indicated by a ✋ icon), it must be configured before the job can be confirmed.
+
+## Capacities
+
+[Capacities](xref:MO_Resource_Studio#capacities) define how a resource can be used, measured numerically. When capacities are configured, only resources that have sufficient remaining capacity can be selected from the resource pool.
+
+To add a capacity:
+
+1. In the *Capacities* section, use the dropdown at the bottom to select the capacity you want to assign.
+
+1. Select the checkbox next to the capacity to enable value input.
+
+1. Enter the required numeric value.
+
+To remove a capacity, click the **X** button next to it.
+
+## Configurations
+
+Configurations are additional settings that are applied to the resource when a job runs, but they do not have an impact on the resource selection. Use configurations for any parameters that need to be passed to the resource but should not limit which resources are available.
+
+To add a configuration:
+
+1. In the *Configurations* section, use the dropdown at the bottom to select the configuration you want to assign.
+
+1. Select the checkbox next to the configuration to enable value input.
+
+1. Enter the required value (text, numeric, or a discrete value from a dropdown, depending on the configuration type).
+
+To remove a configuration, click the **X** button next to it.
+
+> [!NOTE]
+> If a configuration is marked as mandatory (indicated by a ✋ icon), it must be configured before the job can be confirmed.
+
+## Automated actions
+
+On the right side of the dialog, you can configure **automated actions** (orchestration scripts). These are automation scripts that execute at specific moments during the lifecycle of a job. Four orchestration events are available:
+
+- **Pre-roll Start**: Executes when the pre-roll phase starts, before the actual job start time.
+- **Pre-roll Stop**: Executes when the pre-roll phase ends (i.e. at the job start time).
+- **Post-roll Start**: Executes when the post-roll phase starts (i.e. at the job end time).
+- **Post-roll Stop**: Executes when the post-roll phase ends, after the actual job end time.
+
+To configure an automated action:
+
+1. Expand the section for the orchestration event you want to configure.
+
+1. Select the *Execute Script* checkbox to enable script execution for this event.
+
+1. In the dropdown, select the automation script you want to execute.
+
+1. Configure the input parameters for the script, if any. These may include:
+
+   - **Script input elements**: DataMiner element selections required by the script.
+   - **Script input parameters**: Free-form parameters expected by the script.
+
+## Dynamic parameter linking
+
+When configuring a resource pool in Resource Studio, or configuring a workflow in the Workflow Designer or Scheduling app, you can dynamically link parameter values to other data sources. Instead of manually entering fixed values for capabilities, capacities, configurations, or orchestration script inputs, you can configure a link to dynamically resolve the value from another source, such as a resource property, capability, capacity, configuration, or job property.
+
+The value is automatically determined on job update based on the linked source. The UI shows a placeholder indicating where the value comes from.
+
+This feature has several benefits:
+
+- Less manual configuration.
+- More consistency across setups.
+- Dynamic linking based on resource selection.
+
+### Configuring a parameter link
+
+1. While you are editing a workflow or configuring a resource pool, click the 🔗 (link) button next to the parameter you want to link.
+
+   The parameter can be a capability, capacity, configuration, or orchestration script input.
+
+   If the parameter is not yet linked, the button has a neutral style. If it is already linked, the button appears highlighted (call-to-action style) and its tooltip shows the current link target.
+
+1. In the *Configure Link* dialog, select the [link type](#available-link-types) from the dropdown at the top.
+
+1. If the selected [link type is node-scoped](#node-scoped-link-types), in the node dropdown, select the node whose data you want to reference.
+
+   Depending on the link type, a second dropdown will appear where you can select the specific target (e.g. which property, which capability, which capacity, etc.).
+
+1. Click the *Link* button to confirm.
+
+   The parameter field in the configuration dialog will now show a placeholder indicating the linked source.
+
+### Removing a parameter link
+
+1. While you are editing a workflow or configuring a resource pool, locate the linked parameter (recognizable by the highlighted 🔗 button and placeholder text).
+
+1. Click the 🔗 (link) button next to the parameter.
+
+1. In the *Configure Link* dialog, click *Unlink*.
+
+   This button is only shown for parameters that are currently linked. It will return the parameter to manual-entry mode and remove the link.
+
+### Available link types
+
+The available link types depend on the parameter category being configured. Each link type resolves to a specific value or object within the workflow, job, or node context.
+
+| Link type | Description | Available for |
+|--|--|--|
+| Resource Name | Resolves to the name of the resource assigned to a node. | Configuration parameters and orchestration script inputs |
+| Resource Property | Resolves to a specific property value of the assigned resource. | Configuration parameters, orchestration script inputs, and orchestration script elements |
+| Resource Linked Object ID | Resolves to the linked object ID of the assigned resource. | Configuration parameters, orchestration script inputs, and orchestration script elements |
+| Capability Parameter | Resolves to the value of a capability configured on a node. | Capability parameters, configuration parameters, and orchestration script inputs |
+| Capacity Parameter | Resolves to the value of a capacity configured on a node. | Capacity parameters, configuration parameters, and orchestration script inputs |
+| Configuration Parameter | Resolves to the value of a configuration parameter on a node. | Capability parameters, capacity parameters, configuration parameters, and orchestration script inputs |
+| Job Name | Resolves to the name of the job. | Configuration parameters and orchestration script inputs |
+| Job Property | Resolves to a custom property defined on the job. | Capability parameters, configuration parameters, orchestration script inputs, and orchestration script elements |
+
+### Node-scoped link types
+
+The following link types are node-scoped, meaning that a specific workflow node (or the workflow itself) must be selected to determine where the value should be resolved from:
+
+- Resource Name
+- Resource Property
+- Resource Linked Object ID
+- Capability Parameter
+- Capacity Parameter
+- Configuration Parameter

--- a/solutions/standard_solutions/MediaOps/MediaOps.Plan/Apps/MO_Scheduling_Configuration.md
+++ b/solutions/standard_solutions/MediaOps/MediaOps.Plan/Apps/MO_Scheduling_Configuration.md
@@ -5,7 +5,7 @@ description: Learn how to configure capabilities, capacities, configurations, an
 
 # Scheduling configuration
 
-The scheduling configuration dialog allows you to define what capabilities, capacities, and configurations a resource should have when it is selected from a resource pool. It also allows you to configure automated actions (orchestration scripts) that run when a job starts or ends.
+The scheduling configuration dialog allows you to define which capabilities, capacities, and configurations a resource should have when it is selected from a resource pool. It also allows you to configure automated actions (orchestration scripts) that run when a job starts or ends.
 
 This dialog is available in the [Resource Studio](xref:MO_Resource_Studio), [Workflow Designer](xref:MO_Workflow_Designer), and [Scheduling](xref:MO_Scheduling) apps.
 
@@ -13,13 +13,13 @@ This dialog is available in the [Resource Studio](xref:MO_Resource_Studio), [Wor
 
 Depending on the app you are using, you can open the dialog in different ways:
 
-- **Resource Studio**: Go to the *Resource Pools* page, click the three-dot button in the row of a resource pool, and select *Scheduling Config*. This opens the *Edit Resource Pool Parameters* dialog.
+- **Resource Studio**: Go to the *Resource Pools* page, click the `...` button in the row of a resource pool, and select *Scheduling Config*. This opens the *Edit Resource Pool Parameters* dialog.
 
 - **Workflow Designer**: Click the pencil icon in the row of a workflow to open the *Edit* panel. Select a node in the workflow, then click the *Configure* button. To edit the global scheduling configuration of the workflow, click the *Configure* button at the top of the panel. This opens the *Select Configuration* dialog.
 
 - **Scheduling**: Click the pencil icon to open the *Edit* panel of a job. In the *Nodes* table, click the icon in the *Config Status* column. To edit the global configuration of the job, click the *Edit job config* button above the *Nodes* table. This opens the *Select Configuration* dialog.
 
-## Dialog layout
+## Scheduling configuration dialog layout
 
 The dialog consists of two main areas:
 
@@ -27,7 +27,7 @@ The dialog consists of two main areas:
 
 - **Right side**: The [automated actions](#automated-actions) (orchestration scripts), which allow you to configure scripts that run at specific moments during the lifecycle of a job.
 
-## Capabilities
+### Capabilities
 
 [Capabilities](xref:MO_Resource_Studio#capabilities) give a qualitative description of a resource, making it clear what it can be used for. When capabilities are configured in the scheduling configuration, only resources that match all defined capabilities can be selected from the resource pool.
 
@@ -41,7 +41,7 @@ To add a capability:
 
 To remove a capability, click the **X** button next to it.
 
-## Capacities
+### Capacities
 
 [Capacities](xref:MO_Resource_Studio#capacities) define how a resource can be used, measured numerically. When capacities are configured, only resources that have sufficient remaining capacity can be selected from the resource pool.
 
@@ -55,7 +55,7 @@ To add a capacity:
 
 To remove a capacity, click the **X** button next to it.
 
-## Configurations
+### Configurations
 
 Configurations are additional settings that are applied to the resource when a job runs, but they do not have an impact on the resource selection. Use configurations for any parameters that need to be passed to the resource but should not limit which resources are available.
 
@@ -69,17 +69,9 @@ To add a configuration:
 
 To remove a configuration, click the **X** button next to it.
 
-## Mandatory parameters and full configuration
+### Automated actions
 
-Capabilities, capacities, and configurations can be marked as mandatory (indicated by a ✋ icon). All mandatory parameters must have a value configured. Additionally, all input arguments of the automated actions (if any) must be provided.
-
-Only when all mandatory parameters and all automated action inputs are fully defined, a node is considered as fully configured. This is reflected in the UI by the hand icon disappearing from the node.
-
-All nodes and the job-level configuration must be fully configured before you can confirm the job. Once the job is confirmed, you can only update the job in a way that keeps everything fully configured. If an update would leave mandatory parameters incomplete, you can return the job to the tentative state first.
-
-## Automated actions
-
-On the right side of the dialog, you can configure **automated actions** (orchestration scripts). These are automation scripts that execute at specific moments during the lifecycle of a job. Four orchestration events are available:
+If [MediaOps Live](https://catalog.dataminer.services/details/213031b9-af0b-488c-be20-934912b967c0) is deployed alongside MediaOps Plan, on the right side of the dialog, you can configure automated actions (i.e., orchestration scripts). These are automation scripts that execute at specific moments during the lifecycle of a job. Four orchestration events are available:
 
 - **Pre-roll Start**: Executes when the pre-roll phase starts, before the actual job start time.
 - **Pre-roll Stop**: Executes when the pre-roll phase ends (i.e. at the job start time).
@@ -94,22 +86,26 @@ To configure an automated action:
 
 1. In the dropdown, select the automation script you want to execute.
 
-1. Configure the input parameters for the script, if any. These may include:
+1. Configure the input parameters for the script, if any.
+
+   These may include:
 
    - **Script input elements**: DataMiner element selections required by the script.
    - **Script input parameters**: Free-form parameters expected by the script.
 
+## Mandatory parameters and full configuration
+
+Capabilities, capacities, and configurations can be configured as mandatory in Resource Studio. This is indicated by a ✋ icon in the scheduling configuration dialog. All mandatory parameters must have a value configured. Additionally, all input arguments of the automated actions (if any) must be provided.
+
+Only when all mandatory parameters and all automated action inputs are fully defined, is a node considered fully configured. This is reflected in the UI by the hand icon disappearing from the node.
+
+All nodes and job-level configuration must be fully configured before you can confirm a job. Once a job is confirmed, you can only update the job in a way that keeps everything fully configured. If an update were to leave mandatory parameters incomplete, you can return the job to the tentative state first.
+
 ## Dynamic parameter linking
 
-When configuring a resource pool in Resource Studio, or configuring a workflow in the Workflow Designer or Scheduling app, you can dynamically link parameter values to other data sources. Instead of manually entering fixed values for capabilities, capacities, configurations, or orchestration script inputs, you can configure a link to dynamically resolve the value from another source, such as a resource property, capability, capacity, configuration, or job property.
+As from MediaOps Plan version 1.6.0, when configuring a resource pool in Resource Studio, or configuring a workflow in the Workflow Designer or Scheduling app, you can dynamically link parameter values to other data sources. Instead of manually entering fixed values for capabilities, capacities, configurations, or orchestration script inputs, you can configure a link to dynamically resolve the value from another source, such as a resource property, capability, capacity, configuration, or job property.
 
 The value is automatically determined on job update based on the linked source. The UI shows a placeholder indicating where the value comes from.
-
-This feature has several benefits:
-
-- Less manual configuration.
-- More consistency across setups.
-- Dynamic linking based on resource selection.
 
 ### Configuring a parameter link
 
@@ -123,7 +119,7 @@ This feature has several benefits:
 
 1. If the selected [link type is node-scoped](#node-scoped-link-types), in the node dropdown, select the node whose data you want to reference.
 
-   Depending on the link type, a second dropdown will appear where you can select the specific target (e.g. which property, which capability, which capacity, etc.).
+   Depending on the link type, a second dropdown will appear where you can select the specific target (e.g., which property, which capability, which capacity, etc.).
 
 1. Click the *Link* button to confirm.
 

--- a/solutions/standard_solutions/MediaOps/MediaOps.Plan/Apps/MO_Scheduling_Configuration.md
+++ b/solutions/standard_solutions/MediaOps/MediaOps.Plan/Apps/MO_Scheduling_Configuration.md
@@ -41,9 +41,6 @@ To add a capability:
 
 To remove a capability, click the **X** button next to it.
 
-> [!NOTE]
-> If a capability is marked as mandatory (indicated by a ✋ icon), it must be configured before the job can be confirmed.
-
 ## Capacities
 
 [Capacities](xref:MO_Resource_Studio#capacities) define how a resource can be used, measured numerically. When capacities are configured, only resources that have sufficient remaining capacity can be selected from the resource pool.
@@ -72,8 +69,13 @@ To add a configuration:
 
 To remove a configuration, click the **X** button next to it.
 
-> [!NOTE]
-> If a configuration is marked as mandatory (indicated by a ✋ icon), it must be configured before the job can be confirmed.
+## Mandatory parameters and full configuration
+
+Capabilities, capacities, and configurations can be marked as mandatory (indicated by a ✋ icon). All mandatory parameters must have a value configured. Additionally, all input arguments of the automated actions (if any) must be provided.
+
+Only when all mandatory parameters and all automated action inputs are fully defined, a node is considered as fully configured. This is reflected in the UI by the hand icon disappearing from the node.
+
+All nodes and the job-level configuration must be fully configured before you can confirm the job. Once the job is confirmed, you can only update the job in a way that keeps everything fully configured. If an update would leave mandatory parameters incomplete, you can return the job to the tentative state first.
 
 ## Automated actions
 

--- a/solutions/standard_solutions/MediaOps/MediaOps.Plan/Apps/Scheduling/SCH_Edit_Job.md
+++ b/solutions/standard_solutions/MediaOps/MediaOps.Plan/Apps/Scheduling/SCH_Edit_Job.md
@@ -39,7 +39,7 @@ Below this general information, different buttons are shown depending on the [st
 These buttons can be used for the following actions:
 
 - **Save as Tentative**: Moves the job to the tentative state, which will reserve all resources.
-- **Edit job config**: Allows you to configure the capabilities and/or capacities linked to the job.
+- **Edit job config**: Allows you to configure the capabilities and/or capacities linked to the job. See [Scheduling configuration](xref:MO_Scheduling_Configuration).
 - **Confirm**: Moves the job from the tentative to the confirmed state, which will execute the orchestration script linked to the job.
 - **Cancel job**: Cancels the job and frees up the resources again.
 - **Return to Tentative**: Moves the job back to the tentative state, which frees up the resources again.<!-- RN 43042 -->

--- a/solutions/standard_solutions/MediaOps/MediaOps.Plan/Apps/Workflow_Designer/WFD_Edit_Workflow.md
+++ b/solutions/standard_solutions/MediaOps/MediaOps.Plan/Apps/Workflow_Designer/WFD_Edit_Workflow.md
@@ -46,9 +46,7 @@ You will then be able to adjust the name and description of the workflow, config
 
 ### Configuring the workflow orchestration settings
 
-To edit the workflow orchestration settings, click the cogwheel next to the title of the workflow section.
-
-<!-- TODO: Add info on orchestration settings -->
+To edit the workflow orchestration settings, click the cogwheel next to the title of the workflow section. This opens the [Scheduling configuration](xref:MO_Scheduling_Configuration) dialog at the workflow (global) level, which allows you to define the required capabilities, capacities, configurations, and automated actions that apply to the workflow as a whole.
 
 ![The cogwheel icon to edit the workflow orchestration settings](~/solutions/images/Workflow_Designer_Configure_Workflow.png)
 
@@ -86,9 +84,7 @@ To do so, select the node and click *Swap To Pool* or *Swap to Resource*, depend
 
 ### Configuring the node orchestration settings
 
-To edit the node orchestration settings, select the node and click the *Configure* button.
-
-<!-- TODO: Add info on orchestration settings -->
+To edit the node orchestration settings, select the node and click the *Configure* button. This opens the [Scheduling configuration](xref:MO_Scheduling_Configuration) dialog, which allows you to define the required capabilities, capacities, and configurations for the node, as well as automated actions.
 
 ![Button to configure the orchestration settings of the selected node](~/solutions/images/Workflow_Designer_Configure_Node.png)
 

--- a/solutions/toc.yml
+++ b/solutions/toc.yml
@@ -56,6 +56,8 @@ items:
               topicUid: Overview_MediaOps_Validation
             - name: Filtering resource pools by category
               topicUid: SCH_Filter_Pools
+        - name: Scheduling configuration
+          topicUid: MO_Scheduling_Configuration
         - name: Tutorials
           items: 
           - name: Configuring resources and resource pools


### PR DESCRIPTION
The MediaOps Plan "Scheduling Configuration" feature is used across Resource Studio, Workflow Designer, and Scheduling apps, but had no dedicated documentation page. This PR adds a comprehensive reference page and cross-links from existing app pages.

## What's included

- **New page** (`MO_Scheduling_Configuration.md`): Documents the scheduling configuration dialog, covering:
  - How to open the dialog from each app (Resource Studio, Workflow Designer, Scheduling)
  - Capabilities, capacities, and configurations sections
  - Automated actions (orchestration scripts) with the four event types
  - Dynamic parameter linking -- configuring links, removing them, available link types, and node-scoped link types
- **Cross-references** added to existing pages (`MO_Resource_Studio.md`, `WFD_Edit_Workflow.md`, `SCH_Edit_Job.md`) pointing to the new page
- **TOC entry** added under the MediaOps Plan section
- Removed two TODO comments in `WFD_Edit_Workflow.md` that are now addressed by the new page

