### PR TITLE
Version info improved for web features

### DIFF
--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Specifying_data_input_in_a_dashboard_URL.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Specifying_data_input_in_a_dashboard_URL.md
@@ -186,15 +186,15 @@ Within the dashboard or app URL, the following data objects can be specified:
 
 - *service definitions*: Requires the service definition ID.
 
-- *cpes*: Deprecated from DataMiner 10.2.0 [CU1] and 10.2.4 onwards (but still supported for the sake of backwards compatibility). To specify an EPM filter. Requires the DMA ID, the element ID, the field PID, the field value, the table index PID, and the index value.
+- *cpes*: Deprecated, but still supported for the sake of backwards compatibility. To specify an EPM filter. Requires the DMA ID, the element ID, the field PID, the field value, the table index PID, and the index value.
 
-- *epm-selections*: Available from DataMiner 10.2.0 [CU1] and 10.2.4 onwards (replaces "cpes")<!-- RN 32594 -->. To specify an EPM filter. Requires the DMA ID, element ID, field PID and primary key value, separated by forward slashes. Unlike the deprecated "cpes", "epm-selections" allows forward slashes in the primary key value.
+- *epm-selections*: To specify an EPM filter (preferred over the deprecated "cpes"). Requires the DMA ID, element ID, field PID and primary key value, separated by forward slashes. Unlike the deprecated "cpes", "epm-selections" allows forward slashes in the primary key value.<!-- RN 32594 -->
 
-- *strings*: Supported from DataMiner 10.3.5/10.4.0 onwards<!--  RN 35902 -->. A text string, which will serve as the default value for a **text input** component. Note that prior to DataMiner 10.4.1<!-- RN 37752 -->, you can only specify a default value for all text input components, while in recent DataMiner versions you can specify data per component.
+- *strings*: Supported from DataMiner web 10.3.5/10.4.0 onwards<!--  RN 35902 -->. A text string, which will serve as the default value for a **text input** component. Note that prior to DataMiner 10.4.1<!-- RN 37736 -->, you can only specify a default value for all text input components, while in recent DataMiner versions you can specify data per component.
 
-- *numbers*: Supported from DataMiner 10.3.5/10.4.0 onwards<!--  RN 35911 -->. Numbers, which will serve as the default value for a **numeric input** component. Note that prior to DataMiner 10.4.1<!-- RN 37752 -->, you can only specify a default value for all numeric input components, while in recent DataMiner versions you can specify data per component.
+- *numbers*: Supported from DataMiner web web 10.3.5/10.4.0 onwards<!--  RN 35911 -->. Numbers, which will serve as the default value for a **numeric input** component. Note that prior to DataMiner web 10.4.1<!-- RN 37736 -->, you can only specify a default value for all numeric input components, while in recent DataMiner versions you can specify data per component.
 
-- *object manager definitions*: Supported from DataMiner 10.3.6/10.4.0 onwards<!-- RN 36124 -->. Allows referencing a specific DOM definition. Use the following format: `object manager definitions=[Module]/[Definition]`.
+- *object manager definitions*: Supported from DataMiner web 10.3.6/10.4.0 onwards<!-- RN 36124 -->. Allows referencing a specific DOM definition. Use the following format: `object manager definitions=[Module]/[Definition]`.
 
   - `[Module]`: the [DOM module name](xref:DOM_ModuleId).
 
@@ -202,7 +202,7 @@ Within the dashboard or app URL, the following data objects can be specified:
 
   For example: `?object manager definitions=Jobs/7a58af57-58d6-4027-8b55-40d5ba97c368`
 
-- *object manager instances*: Supported from DataMiner 10.3.6/10.4.0 onwards<!-- RN 36124 -->. Allows referencing a specific DOM instance. Use the following format: `object manager instances=[Module]/[Instance]`.
+- *object manager instances*: Supported from DataMiner web 10.3.6/10.4.0 onwards<!-- RN 36124 -->. Allows referencing a specific DOM instance. Use the following format: `object manager instances=[Module]/[Instance]`.
 
   - `[Module]`: the [DOM module name](xref:DOM_ModuleId).
 
@@ -210,7 +210,7 @@ Within the dashboard or app URL, the following data objects can be specified:
 
   For example: `?object manager instances=Jobs/e91fe0cf-51e8-40f1-add4-f4752561890b`
 
-- *object manager modules*: Supported from DataMiner 10.3.6/10.4.0 onwards<!-- RN 36124 -->. Allows referencing a specific DOM module. Use the following format: `object manager modules=[Module]`.
+- *object manager modules*: Supported from DataMiner web 10.3.6/10.4.0 onwards<!-- RN 36124 -->. Allows referencing a specific DOM module. Use the following format: `object manager modules=[Module]`.
 
   - `[Module]`: the [DOM module name](xref:DOM_ModuleId).
 
@@ -224,7 +224,7 @@ Within the dashboard or app URL, the following data objects can be specified:
 
   For example: `?queries=Get Elements/{"ID": "Elements"}`
 
-- *query columns*: Supported from DataMiner 10.3.9/10.4.0 onwards. A GQI query filter, structured as follows: `query columns=[query ID]%1e[column ID]%1e[filter type]%1e[filter values]`. The following filter types are supported: *list*, *range*, *boolean*, *number*, and *string*.
+- *query columns*: Supported from DataMiner web 10.3.9/10.4.0 onwards.<!-- 36822 --> A GQI query filter, structured as follows: `query columns=[query ID]%1e[column ID]%1e[filter type]%1e[filter values]`. The following filter types are supported: *list*, *range*, *boolean*, *number*, and *string*.
 
   For example:
 
@@ -236,7 +236,7 @@ Within the dashboard or app URL, the following data objects can be specified:
 
     `?query columns=3af9e5a7-91fc-4333-94c0-e39a59f0d900%1e23ea428c-d52c-4041-8fd9-76ce3f436a6d_Number%1erange%1e5%1f10%1ffalse%1ftrue`
 
-- *query rows*: Supported from DataMiner 10.3.0 [CU12]/10.4.3 onwards<!-- RN 39369 -->.  An array of query rows.
+- *query rows*: Supported from DataMiner web 10.3.0 [CU12]/10.4.3 onwards<!-- RN 39369 -->.  An array of query rows.
 
   Each table must be in the following format: `VERSION\u001FCOLUMNS\u001ECELLS\u001EKEYS`.
 
@@ -252,4 +252,4 @@ Within the dashboard or app URL, the following data objects can be specified:
 
   `v:1\u001FIDColumn\u000EID\u000Estring\u001FValueColumn\u000EValue\u000Enumber\u001Evalue1\u000EValue 1\u001F5\u000EFive\u001ERowKey`
 
-- *booleans*: Supported from DataMiner 10.4.0 [CU12]/10.5.3 onwards<!--RN 41845-->. Used to specify whether a boolean value is set to "true" or "false" when the dashboard or app is loaded.
+- *booleans*: Supported from DataMiner web 10.4.0 [CU12]/10.5.3 onwards<!--RN 41845-->. Used to specify whether a boolean value is set to "true" or "false" when the dashboard or app is loaded.

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/Interactive_automation_script.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/Interactive_automation_script.md
@@ -4,13 +4,13 @@ uid: InteractiveAutomationScript
 
 # Interactive automation script
 
-Available from DataMiner 10.3.0 [CU18]/10.4.0 [CU6]/10.4.9 onwards<!-- RN 39969 -->, in the Low-Code Apps module.
+Available from DataMiner web 10.3.0 [CU18]/10.4.0 [CU6]/10.4.9 onwards<!-- RN 39969 -->, in the Low-Code Apps module.
 
 This component allows you to visualize any interactive automation script (IAS) within pages or panels of a low-code app.
 
 ## Prerequisites
 
-- From DataMiner 10.5.0 [CU11]/10.6.2 onwards<!--RN 44232-->, to visualize the interactive automation script, you need the user permission [*Modules > Automation > Execute*](xref:DataMiner_user_permissions#modules--automation--execute). Prior to DataMiner 10.5.0 [CU11]/10.6.2, to visualize the interactive automation script, you need both the [*Modules > Automation > Execute*](xref:DataMiner_user_permissions#modules--automation--execute) and [Modules > Automation > UI Available](xref:DataMiner_user_permissions#modules--automation--ui-available) user permissions.
+- From DataMiner web 10.5.0 [CU11]/10.6.2 onwards<!--RN 44232-->, to visualize the interactive automation script, you need the user permission [*Modules > Automation > Execute*](xref:DataMiner_user_permissions#modules--automation--execute). In earlier DataMiner versions, you need both the [*Modules > Automation > Execute*](xref:DataMiner_user_permissions#modules--automation--execute) and [Modules > Automation > UI Available](xref:DataMiner_user_permissions#modules--automation--ui-available) user permissions.
 
 - From DataMiner 10.5.9/10.6.0 onwards, the script's [InteractivityOptions](xref:Automation-InteractivityOptions) should be set to *Always* for it to be compatible with this component.
 

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/List.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/List.md
@@ -25,7 +25,7 @@ The way items are listed in the component depends on the type and number of data
   - When you apply a single query data source or *Tables* data source, the list shows the individual rows from that query or table. Each row becomes a selectable item.
 
     > [!NOTE]
-    > Prior to DataMiner 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4<!--RN 38811-->, when you apply a single query data source, the query itself is listed as data.
+    > Prior to DataMiner web 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4<!--RN 38811-->, when you apply a single query data source, the query itself is listed as data.
 
   - When you apply multiple query data sources or *Tables* data sources, the list instead shows the queries or tables themselves.
 
@@ -39,7 +39,7 @@ Additionally, the following layout options are also available:
 
 | Section | Option | Description |
 |--|--|--|
-| Advanced | Display column | Available from DataMiner 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38811-->. Select the column whose values are shown in the list. Only available when a single query data source or *Tables* component data source was applied. |
+| Advanced | Display column | Available from DataMiner web 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38811-->. Select the column whose values are shown in the list. Only available when a single query data source or *Tables* component data source was applied. |
 
 ### List settings
 
@@ -48,6 +48,6 @@ In the *Settings* pane for this component, you can customize its behavior to sui
 | Section | Option | Description |
 |--|--|--|
 | WebSocket settings | Inherit WebSocket settings from page/panel | Clear the checkbox to use a custom polling interval for this component. When cleared, you can specify a different polling interval (in seconds). |
-| Initial selection | Select first item by default | Available from DataMiner 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38775-->. When enabled, the first item is automatically selected when the data in the list is refreshed, unless a custom URL is used specifying a different value. This setting is enabled by default. |
-| Initial Selection | Select item by default | Specify a fixed default value, which is automatically selected when the data in the list is refreshed, unless a custom URL is used specifying a different value. From DataMiner 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38775-->, this setting is only available when the *Select first item by default* setting is disabled.<br><br>Formerly known as:<br>- *Initial Selection* (Prior to DataMiner 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4<!--RN 38775-->)<br>- *Feed Defaults* (Prior to DataMiner 10.3.6/10.4.0<!--RN 35984-->)|
-| Data retrieval | Update data | Available from DataMiner 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38811-->. Toggle the switch to determine whether the values displayed in the component should be updated automatically (provided this is supported by the data source). See [Query updates](xref:Query_updates)<!--RN 37269-->. This setting is only available when a single query data source or an indices dataset was applied. This setting is disabled by default. |
+| Initial selection | Select first item by default | Available from DataMiner web 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38775-->. When enabled, the first item is automatically selected when the data in the list is refreshed, unless a custom URL is used specifying a different value. This setting is enabled by default. |
+| Initial Selection | Select item by default | Specify a fixed default value, which is automatically selected when the data in the list is refreshed, unless a custom URL is used specifying a different value. From DataMiner web 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38775-->, this setting is only available when the *Select first item by default* setting is disabled.<br><br>Formerly known as:<br>- *Initial Selection* (Prior to DataMiner web 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4<!--RN 38775-->)<br>- *Feed Defaults* (Prior to DataMiner web 10.3.6/10.4.0<!--RN 35984-->)|
+| Data retrieval | Update data | Available from DataMiner web 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38811-->. Toggle the switch to determine whether the values displayed in the component should be updated automatically (provided this is supported by the data source). See [Query updates](xref:Query_updates)<!--RN 37269-->. This setting is only available when a single query data source or an indices dataset was applied. This setting is disabled by default. |

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/Node_edge_graph.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/Node_edge_graph.md
@@ -203,8 +203,8 @@ Depending on this selection, different *Identifiers* settings become available, 
 | Base node | Size | From DataMiner 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6 onwards<!--RN 39417-->, use the slider to adjust the size of the node, with a minimum of 1 px and a maximum of 100 px (default: 48 px). Prior to DataMiner 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6, select whether the node should be small, medium-sized, or large. |
 | Base node | Weight | A number indicating the relative importance of the node. The higher the number, the more important the node, which determines where it is displayed in the graph (depending on the layout settings). |
 | Base node | Enable tooltip | Available from DataMiner 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6 onwards<!--RN 39417-->. This setting is only available when the parameter *showAdvancedSettings=true* is added to the URL. When this option is enabled, a tooltip is shown when the mouse pointer hovers over a node. This setting is enabled by default. From DataMiner 10.5.0 [CU13]/10.6.0 [CU1]/10.6.4 onwards<!--RN 44809-->, nodes using templates do not support this setting, as tooltip content is defined in the template. |
-| Base node | Metric | Available from DataMiner 10.5.0 [CU11]/10.6.2 onwards<!--RN 44218-->. Configure how the node label is displayed. You can hide the label, derive it from conditional coloring, or select a custom column to display as the label. See [Configuring node and edge labels](#configuring-node-and-edge-labels). |
-| Base node | Show metric | Available from DataMiner 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6<!--RN 39417--> up to DataMiner 10.5.0 [CU10]/10.6.1<!--RN 44218-->, when the parameter *showAdvancedSettings=true* is added to the URL. When this option is enabled, the metric that determines the conditional color of the node will not be displayed underneath the node. |
+| Base node | Metric | Available from DataMiner web 10.5.0 [CU11]/10.6.2 onwards<!--RN 44218-->. Configure how the node label is displayed. You can hide the label, derive it from conditional coloring, or select a custom column to display as the label. See [Configuring node and edge labels](#configuring-node-and-edge-labels). |
+| Base node | Show metric | Available from DataMiner web 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6<!--RN 39417--> up to DataMiner web 10.5.0 [CU10]/10.6.1<!--RN 44218-->, when the parameter *showAdvancedSettings=true* is added to the URL. When this option is enabled, the metric that determines the conditional color of the node will not be displayed underneath the node. |
 | Base node | Actions | Select *Add action* to configure an action that is executed when a node is clicked or double-clicked, or when an icon is clicked in the tooltip. See [Adding actions to a node edge graph](#adding-actions-to-a-node-edge-graph). |
 | Override nodes | Add override | If you want to visualize some nodes differently for the same query, click *Add override*, specify a filter, and configure the nodes as detailed above. |
 
@@ -219,8 +219,8 @@ Depending on this selection, different *Identifiers* settings become available, 
 | Style | Optionally, select a different style for the connection lines. |
 | Weight | Optionally, specify a number to indicate the relative importance of the edge. This will determine the thickness of the connection line. |
 | Enable tooltip | Available from DataMiner 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6 onwards<!--RN 39417-->. This setting is only available when the parameter *showAdvancedSettings=true* is added to the URL. When this option is enabled, a tooltip is shown when the mouse pointer hovers over an edge. This setting is enabled by default. |
-| Metric | Available from DataMiner 10.5.0 [CU11]/10.6.2 onwards<!--RN 44218-->. Configure how the node label is displayed. You can hide the label, derive it from conditional coloring, or select a custom column to display as the label. See [Configuring node and edge labels](#configuring-node-and-edge-labels). |
-| Show metric | Available from DataMiner 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6<!--RN 39417--> up to DataMiner 10.5.0 [CU10]/10.6.1<!--RN 44218-->, when the parameter *showAdvancedSettings=true* is added to the URL. When this option is enabled, the metric that determines the conditional color of the edge will not be displayed underneath the edge. |
+| Metric | Available from DataMiner web 10.5.0 [CU11]/10.6.2 onwards<!--RN 44218-->. Configure how the node label is displayed. You can hide the label, derive it from conditional coloring, or select a custom column to display as the label. See [Configuring node and edge labels](#configuring-node-and-edge-labels). |
+| Show metric | Available from DataMiner web 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6<!--RN 39417--> up to DataMiner web 10.5.0 [CU10]/10.6.1<!--RN 44218-->, when the parameter *showAdvancedSettings=true* is added to the URL. When this option is enabled, the metric that determines the conditional color of the edge will not be displayed underneath the edge. |
 | Minimize metric | Available from DataMiner 10.5.0 [CU16]/10.6.0 [CU4]/10.6.7 onwards<!--RN 45538-->. Configure when edge metrics are minimized. Possible values are *Auto* (default), where metrics are minimized automatically when edges are too close to each other; *Always*, where metrics are always minimized; and *Never*, where metrics are never minimized. |
 | Visualize directions | Available from DataMiner 10.2.4/10.3.0 onwards. Toggle the switch to specify whether the edges should display a direction. |
 | How | Only available when *Visualize directions* is enabled. Choose how the direction should be displayed. Select *Flow* to visualize the direction using animated edges (default), or *Arrows* to show arrows drawn on the edges. You can also specify the exact arrow position. |
@@ -228,7 +228,7 @@ Depending on this selection, different *Identifiers* settings become available, 
 
 #### Configuring node and edge labels
 
-From DataMiner 10.5.0 [CU11]/10.6.2 onwards<!--RN 44218-->, you can configure how labels are displayed for nodes and edges independently of [conditional coloring](#conditional-coloring). This configuration makes it possible to control label visibility and content separately from analytical coloring.
+From DataMiner web 10.5.0 [CU11]/10.6.2 onwards<!--RN 44218-->, you can configure how labels are displayed for nodes and edges independently of [conditional coloring](#conditional-coloring). This configuration makes it possible to control label visibility and content separately from analytical coloring.
 
 For each node query and edge query, and for any configured node or edge override, you can choose one of the following label options:
 
@@ -236,7 +236,7 @@ For each node query and edge query, and for any configured node or edge override
 
 - **Coloring**: The label visibility is determined by the conditional coloring configuration.
 
-- **Custom**: Allows you to either select a specific column to use as the label or, from DataMiner 10.5.0 [CU14]/10.6.0 [CU2]/10.6.5 onwards<!--RN 44907-->, link the label to data from another component by clicking the ![Link to](~/dataminer/images/Link_to_Data.png) icon. If you link the label to another component, the label can change dynamically based on that component, for example based on the column selected in a [dropdown component](xref:DashboardDropdown).
+- **Custom**: Allows you to either select a specific column to use as the label or, from DataMiner web 10.5.0 [CU14]/10.6.0 [CU2]/10.6.5 onwards<!--RN 44907-->, link the label to data from another component by clicking the ![Link to](~/dataminer/images/Link_to_Data.png) icon. If you link the label to another component, the label can change dynamically based on that component, for example based on the column selected in a [dropdown component](xref:DashboardDropdown).
 
   The label is shown even if the node or edge itself does not have conditional coloring.
 
@@ -262,7 +262,7 @@ You can **customize the appearance of nodes** in the graph to better represent y
 
    - *Icon*: Select an icon from the dropdown list to display inside the node shape (Default: `CircleRing`). Click the circle to the right of the box to select a custom color.
 
-   - *Template*: Use a prebuilt or custom design for more control over the node's appearance. Available from DataMiner 10.5.0 [CU13]/10.6.0 [CU1]/10.6.4 onwards<!--RN 44809-->.
+   - *Template*: Use a prebuilt or custom design for more control over the node's appearance. Available from DataMiner web 10.5.0 [CU13]/10.6.0 [CU1]/10.6.4 onwards<!--RN 44809-->.
 
      ![Node edge graph template example showing a network diagram with multiple nodes displaying status indicators, roles, and labels organized in a hierarchical structure](~/dataminer/images/NodeEdgeGraphTemplate.gif)<br>*Node edge graph component in DataMiner 10.6.4*
 

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/Service_definition.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/Service_definition.md
@@ -14,7 +14,7 @@ To configure the component:
 
    - Add booking data, or
 
-   - Add service data (supported from DataMiner 10.2.0/10.1.3 onwards), or
+   - Add service data, or
 
    - Add component data, which can use bookings data filtered by service definition data.
 
@@ -65,9 +65,9 @@ To configure the component:
    - *Edge style*: Determines whether curly or straight edges are used in the graph.
 
 > [!NOTE]
-> From DataMiner 10.2.5/10.3.0 onwards, service definitions of type "Skyline Process Automation" are displayed differently from other service definitions. From DataMiner 10.2.8/10.3.0 onwards, service definition of type "Custom Process Automation" are also displayed this way.
+> Service definitions of type "Skyline Process Automation" and "Custom Process Automation" are displayed differently from other service definitions.
 >
 > - Arrows will automatically be drawn to represent the detected connections between the nodes.
 > - Different function shapes will reflect the different function types, if these have been configured in the Process Automation framework.
 > - Function nodes will display the number of tokens currently in queue or in progress.
-> - From DataMiner 10.2.9/10.3.0 onwards, instead of the function definition names, nodes will display the value of their *Label* property if this is present.
+> - Instead of the function definition names, nodes will display the value of their *Label* property if this is present.

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/Timeline_component.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/Timeline_component.md
@@ -4,7 +4,7 @@ uid: DashboardTimeline
 
 # Timeline
 
-Available from DataMiner 10.4.1/10.5.0 onwards<!--RN 37812-->.
+Available from DataMiner web 10.4.1/10.5.0 onwards<!--RN 37812-->.
 
 The timeline component is a powerful way to **visualize and interact with time-bound data**, such as bookings, events, or schedules. It not only provides a clear overview of what’s happening when, but also lets you manage and update items directly on the timeline, with extensive customization options.
 
@@ -56,11 +56,11 @@ You can interact with the timeline in several ways:
 
   ![Resizing timeline item](~/dataminer/images/Resize_Timeline_Item.gif)<br>*Timeline component in DataMiner 10.5.9*
 
-- **Moving an item**: Select and drag an item to a new position. You can also drag it to another group. From DataMiner 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->, you can hold SHIFT to move items with greater precision, or CTRL to move them precisely both horizontally and vertically.
+- **Moving an item**: Select and drag an item to a new position. You can also drag it to another group. From DataMiner web 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->, you can hold SHIFT to move items with greater precision, or CTRL to move them precisely both horizontally and vertically.
 
   ![Moving timeline item](~/dataminer/images/Moving_Timeline_Item.gif)<br>*Timeline component in DataMiner 10.5.9*
 
-At any time during an interaction, you can press ESC to cancel the action and restore the item ot its original state (available from DataMiner 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->).
+At any time during an interaction, you can press ESC to cancel the action and restore the item ot its original state (available from DataMiner web 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->).
 
 > [!IMPORTANT]
 >
@@ -137,7 +137,7 @@ Panning changes **the position of the displayed time range** without affecting i
 
 ### Adjusting item height
 
-From DataMiner 10.5.0 [CU12]/10.6.3 onwards<!--RN 44524-->, you can adjust the height of all items on a timeline at once.
+From DataMiner web 10.5.0 [CU12]/10.6.3 onwards<!--RN 44524-->, you can adjust the height of all items on a timeline at once.
 
 To increase or decrease the height of all timeline items, rotate the mouse wheel while keeping the ALT key pressed.
 
@@ -154,7 +154,7 @@ Instead of adjusting the time range directly in the timeline, you can link it to
 
 To link a timeline component to a time range component:
 
-1. In the *Settings* pane, click the ![Link to](~/dataminer/images/Link_to_Data.png) icon next to *Link time range* (called *Link time range to feed* in versions prior to DataMiner 10.3.0 [CU21]/10.4.0 [CU9]/10.4.12).
+1. In the *Settings* pane, click the ![Link to](~/dataminer/images/Link_to_Data.png) icon next to *Link time range* (called *Link time range to feed* in versions prior to DataMiner web 10.3.0 [CU21]/10.4.0 [CU9]/10.4.12).
 
 1. From the dropdown list, select the time range component you want to link.
 
@@ -193,7 +193,7 @@ To group items on the timeline based on one of the columns in your data<!--35638
 
 ### Group height behavior
 
-When grouping is applied, you can control how the height of each group is handled. This *Height* setting is available under *Groups* in the *Layout* pane, from DataMiner 10.5.0 [CU12]/10.6.3 onwards<!--RN 44577-->.
+When grouping is applied, you can control how the height of each group is handled. This *Height* setting is available under *Groups* in the *Layout* pane, from DataMiner web 10.5.0 [CU12]/10.6.3 onwards<!--RN 44577-->.
 
 You can choose between two kinds of behavior:
 
@@ -279,21 +279,21 @@ Additionally, the following layout options are also available:
 
 | Section | Option | Description |
 |--|--|--|
-| Filtering & Highlighting | Highlight | Available from DataMiner 10.1.11/10.2.0 onwards<!--RN 33276-->. Toggle the switch to determine whether the items that match the criteria specified in a query filter will be highlighted. Enabled by default. For more information, see [Highlighting specific items](#highlighting-specific-items). |
-| Filtering & Highlighting | Opacity | Available from DataMiner 10.1.11/10.2.0 onwards<!--RN 33276-->. Set the level of transparency of the items that do not match the criteria specified in a query filter. This option is only available when *Highlight* is enabled. For more information, see [Highlighting specific items](#highlighting-specific-items). |
-| Advanced | Empty result message | Available from 10.3.11/10.4.0 onwards<!-- RN 37173 -->. Specify a custom message that is displayed when a query returns no results. From DataMiner 10.5.0 [CU12]/10.6.3 onwards<!-- RN 44472 -->, this setting can be left empty, in which case no message is displayed and the component remains empty. See also: [Displaying a custom empty component message](xref:Tutorial_Dashboards_Displaying_a_custom_empty_component_message). |
+| Filtering & Highlighting | Highlight | Toggle the switch to determine whether the items that match the criteria specified in a query filter will be highlighted. Enabled by default. For more information, see [Highlighting specific items](#highlighting-specific-items).<!--RN 33276--> |
+| Filtering & Highlighting | Opacity | Set the level of transparency of the items that do not match the criteria specified in a query filter. This option is only available when *Highlight* is enabled. For more information, see [Highlighting specific items](#highlighting-specific-items).<!--RN 33276--> |
+| Advanced | Empty result message | Available from DataMiner web 10.3.11/10.4.0 onwards<!-- RN 37173 -->. Specify a custom message that is displayed when a query returns no results. From DataMiner web 10.5.0 [CU12]/10.6.3 onwards<!-- RN 44472 -->, this setting can be left empty, in which case no message is displayed and the component remains empty. See also: [Displaying a custom empty component message](xref:Tutorial_Dashboards_Displaying_a_custom_empty_component_message). |
 | Style | Grouping by | Toggle the switch to determine whether the name of the column the data was grouped by (optionally) is shown. Disabled by default. |
 | Style | Segment lines | Toggle the switch to determine whether segment lines are displayed in the timeline component. Enabled by default. |
 | Style | Lock timeline to now | Select the checkbox to set a "now" indicator at a fixed position on the timeline. When this option is enabled, users can zoom in and out on the timeline, but are restricted from panning past the indicator. Disabled by default. |
 | Item templates | Browse templates *or*<br>Reuse template (depending on your DataMiner version) | Reuse a saved template from another component in the same dashboard or low-code app. This option is only available if a template is already in use<!--RN 42226-->. |
 | Item templates | Edit | Open the Template Editor<!--RN 34761--> to customize the appearance of timeline items and configure actions triggered when a layer is selected. For more information, refer to [Customizing timeline items](#customizing-timeline-items). |
-| Groups | Height | Available from DataMiner 10.5.0 [CU12]/10.6.3 onwards<!--RN 44577-->, when [grouping](#grouping-items-in-a-timeline) is applied. Set the height of the timeline groups to *Fixed* (default) or *Grow*. For more information, see [Group height behavior](#group-height-behavior). |
-| Groups | Template | Open the Template Editor to customize the appearance of timeline groups and configure actions triggered when a layer is selected. For more information, refer to [Customizing timeline groups](#customizing-timeline-groups). Available from DataMiner 10.5.0 [CU12]/10.6.3 onwards<!--RN 44557-->, when [grouping](#grouping-items-in-a-timeline) is applied. |
+| Groups | Height | Available from DataMiner web 10.5.0 [CU12]/10.6.3 onwards<!--RN 44577-->, when [grouping](#grouping-items-in-a-timeline) is applied. Set the height of the timeline groups to *Fixed* (default) or *Grow*. For more information, see [Group height behavior](#group-height-behavior). |
+| Groups | Template | Open the Template Editor to customize the appearance of timeline groups and configure actions triggered when a layer is selected. For more information, refer to [Customizing timeline groups](#customizing-timeline-groups). Available from DataMiner web 10.5.0 [CU12]/10.6.3 onwards<!--RN 44557-->, when [grouping](#grouping-items-in-a-timeline) is applied. |
 
 > [!NOTE]
 >
 > - When you disable the *Highlight* option, items that do not match the filter will no longer be displayed, and the remaining items will be reorganized.
-> - Prior to DataMiner 10.4.0 [CU13]/10.5.0 [CU1]/10.5.4, the option to reuse a template is only available when another timeline component in the dashboard or low-code app is configured with a custom template.
+> - Prior to DataMiner web 10.4.0 [CU13]/10.5.0 [CU1]/10.5.4, the option to reuse a template is only available when another timeline component in the dashboard or low-code app is configured with a custom template.
 
 #### Customizing timeline appearance
 
@@ -333,7 +333,7 @@ Some **real-life examples**:
 
 When grouping is applied to the timeline, you can also customize the appearance of timeline groups, for example to style group headers, add icons, or visually distinguish different groups.
 
-This option is available from DataMiner 10.5.0 [CU12]/10.6.3 onwards<!--RN 44557-->.
+This option is available from DataMiner web 10.5.0 [CU12]/10.6.3 onwards<!--RN 44557-->.
 
 To access the Template Editor for timeline groups:
 
@@ -351,7 +351,7 @@ Using [conditional cases](xref:Template_Editor#adding-conditional-cases-to-a-lay
 
 By default, the template of a timeline component includes the following **pre-configured layers**:
 
-- **Timeline items** (template available from DataMiner 10.4.0 [CU13]/10.5.0 [CU1]/10.5.4 onwards<!--RN 42322-->):
+- **Timeline items** (template available from DataMiner web 10.4.0 [CU13]/10.5.0 [CU1]/10.5.4 onwards<!--RN 42322-->):
 
   | Layer | Type | Description |
   |--|--|--|
@@ -359,7 +359,7 @@ By default, the template of a timeline component includes the following **pre-co
   | ![Rectangle layer 1](~/dataminer/images/Timeline_Rectangle_Layer1.png) | Rectangle | Acts as the background of each timeline item, with conditional formatting for hover and selection. |
   | ![Rectangle layer 2](~/dataminer/images/Timeline_Rectangle_Layer2.png) | Rectangle | Acts as a visual border by being slightly larger than the background layer, with conditional formatting for selection. |
 
-- **Timeline groups** (template available from DataMiner 10.5.0 [CU12]/10.6.3 onwards<!--RN 44557-->):
+- **Timeline groups** (template available from DataMiner web 10.5.0 [CU12]/10.6.3 onwards<!--RN 44557-->):
 
   | Layer | Type | Description |
   |--|--|--|
@@ -386,21 +386,21 @@ In the *Settings* pane for this component, you can customize its behavior to sui
 | General | Default time range | Select a time range to zoom the timeline to, for example, *Today*, *Last 7 days*, or *Next hour*. Options are grouped into the following categories: *Still busy*, *In the past*, *Near future*, *Recently*, *Long run*, *Starting from now*, and *Distant future*. If you select *Custom*, you can set a custom start and end time. Default: *Still busy, This week*<!--RN 33287-->. |
 | General | Link time range | Synchronize the timeline's time range with another dashboard or app component, e.g., a time range component. Any changes in the linked component's time range are automatically applied to the timeline. See [Linking to a time range component](#linking-to-a-time-range-component). |
 | Data retrieval | Update data | Toggle the switch to determine whether the data in the timeline should be refreshed automatically (provided this is supported by the data source). See [Query updates](xref:Query_updates)<!--RN 37269-->. Disabled by default. |
-| Events | On range select | Available from DataMiner 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->. Configure an action that is triggered when a section of the timeline is selected using the right mouse button. See [Adding actions to a timeline](#adding-actions-to-a-timeline). |
-| Events | On item resize | Available from DataMiner 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->. Configure an action that is triggered when an item on the timeline is resized. A timeline item can only resized if at minimum one action has been configured that is triggered on item resize. See [Adding actions to a timeline](#adding-actions-to-a-timeline). |
-| Events | On item move | Available from DataMiner 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->. Configure an action that is triggered when an item on the timeline is moved. See [Adding actions to a timeline](#adding-actions-to-a-timeline). |
-| Events | On group change | Available from DataMiner 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->. Configure an action that is triggered when an item on the timeline is moved to another group. See [Adding actions to a timeline](#adding-actions-to-a-timeline). |
+| Events | On range select | Available from DataMiner web 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->. Configure an action that is triggered when a section of the timeline is selected using the right mouse button. See [Adding actions to a timeline](#adding-actions-to-a-timeline). |
+| Events | On item resize | Available from DataMiner web 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->. Configure an action that is triggered when an item on the timeline is resized. A timeline item can only resized if at minimum one action has been configured that is triggered on item resize. See [Adding actions to a timeline](#adding-actions-to-a-timeline). |
+| Events | On item move | Available from DataMiner web 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->. Configure an action that is triggered when an item on the timeline is moved. See [Adding actions to a timeline](#adding-actions-to-a-timeline). |
+| Events | On group change | Available from DataMiner web 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->. Configure an action that is triggered when an item on the timeline is moved to another group. See [Adding actions to a timeline](#adding-actions-to-a-timeline). |
 | Highlight range | Use highlighting | Toggle the switch to determine whether a configured time range in the timeline component is highlighted. See [Highlighting a time range](#highlighting-a-time-range). |
 | Highlight range | Time range | Specify which time range of the timeline component should be highlighted. This option is only available when *Use highlighting* is enabled. |
 
 > [!NOTE]
 >
 > - The timeline component has a minimum time range of 5 milliseconds and a maximum of 10 years<!--RN 35620-->.
-> - When you enable the *Update data* setting, real-time updates will only be applied for the data sources and operators listed on the [Query updates](xref:Query_updates) page. Prior to DataMiner 10.4.0/10.4.3<!-- RN 37372 -->, data will only be updated every 30 seconds, and this will only be applied for GQI queries using the [Get parameter table by ID](xref:Get_parameter_table_by_ID) data source.
+> - When you enable the *Update data* setting, real-time updates will only be applied for the data sources and operators listed on the [Query updates](xref:Query_updates) page. Prior to DataMiner web 10.4.0/10.4.3<!-- RN 37372 -->, data will only be updated every 30 seconds, and this will only be applied for GQI queries using the [Get parameter table by ID](xref:Get_parameter_table_by_ID) data source.
 
 ## Adding actions to a timeline
 
-From DataMiner 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->, you can configure actions for any timeline component you add to a low-code app. This feature is not available in the Dashboards app.
+From DataMiner web 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards<!-- RN 39254 -->, you can configure actions for any timeline component you add to a low-code app. This feature is not available in the Dashboards app.
 
 To configure actions:
 
@@ -433,20 +433,20 @@ For the timeline component, the following component actions are available:
 
 - *Clear highlights*: Clears all highlights set by *Highlight time range* actions.
 
-- *Clear selection*: This action clears the selection of data in the component. Available from DataMiner 10.4.0 [CU20]/10.5.0 [CU8]/10.5.11 onwards<!--RN 43635-->.
+- *Clear selection*: This action clears the selection of data in the component. Available from DataMiner web 10.4.0 [CU20]/10.5.0 [CU8]/10.5.11 onwards<!--RN 43635-->.
 
-- *Fetch the data*: Available from DataMiner 10.2.10/10.3.0 onwards. Fetches the data for the component.
+- *Fetch the data*: Fetches the data for the component.
 
 - *Highlight time range*: Highlights a range on the timeline component. The highlighted section will expose data in the form of a *Timespan* object. If multiple sections are highlighted, the data will contain an array of *Timespan* objects.
 
 - *Set viewport*: Sets the viewport of the timeline to a certain time range<!-- RN 39254 -->.
 
 > [!NOTE]
-> Prior to DataMiner 10.3.0 CU14/10.4.0 CU2/10.4.5, highlights can be configured using the *Highlight range* setting. This setting is still available in later DataMiner versions and can be used in combination with highlights set by actions. Its behavior remains the same: a highlight set by the *Highlight range* setting will not expose data and it will not be cleared by the *Clear highlights* action.
+> Prior to DataMiner web 10.3.0 CU14/10.4.0 CU2/10.4.5, highlights can be configured using the *Highlight range* setting. This setting is still available in later DataMiner versions and can be used in combination with highlights set by actions. Its behavior remains the same: a highlight set by the *Highlight range* setting will not expose data and it will not be cleared by the *Clear highlights* action.
 
 ### Using event data in actions
 
-When [a user interacts with the timeline](#interacting-with-the-timeline-component) (e.g., moving an item), the event can provide details about what changed. From DataMiner 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards, you can use this event data in your actions.
+When [a user interacts with the timeline](#interacting-with-the-timeline-component) (e.g., moving an item), the event can provide details about what changed. From DataMiner web 10.3.0 CU14/10.4.0 CU2/10.4.5 onwards, you can use this event data in your actions.
 
 This is useful because it allows you to:
 
@@ -470,11 +470,5 @@ Each event provides the following data:
 
 > [!NOTE]
 >
-> - Prior to DataMiner 10.3.0 [CU21]/10.4.0 [CU9]/10.4.12<!--RN 41075-->, the data type "Table" is called "Query row" instead.
+> - Prior to DataMiner web 10.3.0 [CU21]/10.4.0 [CU9]/10.4.12<!--RN 41075-->, the data type "Table" is called "Query row" instead.
 > - If your data source does not support real-time updates, the *Launch a script* action (to update your data) will need to be followed by an *Execute component action* (to refetch the data).
-
-## Enabling the component in soft launch
-
-From DataMiner 10.1.10 onwards, the timeline component is available in soft launch, if the soft-launch option *ReportsAndDashboardsScheduler* is enabled. For more information, see [Soft-launch options](xref:SoftLaunchOptions).
-
-If you use the preview version of the timeline component, its functionality may be different from what is described on this page.

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/Tree.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Other/Tree.md
@@ -21,7 +21,7 @@ The way items are listed in the component depends on the type and number of data
   - When you apply a single query data source or *Tables* data source, the tree shows the individual rows from that query or table. Each row becomes a selectable item.
 
     > [!NOTE]
-    > Prior to DataMiner 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4<!--RN 38811-->, when you apply a single query data source, the query itself is listed as data.
+    > Prior to DataMiner web 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4<!--RN 38811-->, when you apply a single query data source, the query itself is listed as data.
 
   - When you apply multiple query data sources or *Tables* data sources, the tree instead shows the queries or tables themselves.
 
@@ -31,7 +31,7 @@ You can filter the contents of a tree component using one of two available metho
 
 - Use the **filter box** at the top of the component.
 
-- Pass a **text string** to the tree component, for example by using a text input component (supported from DataMiner Web 10.5.0 [CU16]/10.6.0 [CU4]/10.6.7 onwards<!--RN 45485-->).
+- Pass a **text string** to the tree component, for example by using a text input component (supported from DataMiner web 10.5.0 [CU16]/10.6.0 [CU4]/10.6.7 onwards<!--RN 45485-->).
 
   You can filter based on a text string in several different ways, for example:
 
@@ -65,7 +65,7 @@ Additionally, the following layout options are also available:
 
 | Section | Option | Description |
 |--|--|--|
-| Advanced | Display column | Available from DataMiner 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38811-->. Select the column whose values are shown in the tree. Only available when a single query data source or *Tables* component data source was applied. |
+| Advanced | Display column | Available from DataMiner web 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38811-->. Select the column whose values are shown in the tree. Only available when a single query data source or *Tables* component data source was applied. |
 
 ### Tree settings
 
@@ -74,6 +74,6 @@ In the *Settings* pane for this component, you can customize its behavior to sui
 | Section | Option | Description |
 |--|--|--|
 | WebSocket settings | Inherit WebSocket settings from page/panel | Clear the checkbox to use a custom polling interval for this component. When cleared, you can specify a different polling interval (in seconds). |
-| Initial selection | Select first item by default | Available from DataMiner 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38775-->. When enabled, the first item is automatically selected when the data in the tree is refreshed, unless a custom URL is used specifying a different value. This setting is enabled by default. |
-| Initial Selection | Select item by default | Specify a fixed default value, which is automatically selected when the data in the tree is refreshed, unless a custom URL is used specifying a different value. From DataMiner 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38775-->, this setting is only available when the *Select first item by default* setting is disabled.<br><br>Formerly known as:<br>- *Initial Selection* (Prior to DataMiner 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4<!--RN 38775-->)<br>- *Feed Defaults* (Prior to DataMiner 10.3.6/10.4.0<!--RN 35984-->)|
-| Data retrieval | Update data | Available from DataMiner 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38811-->. Toggle the switch to determine whether the values displayed in the component should be updated automatically (provided this is supported by the data source). See [Query updates](xref:Query_updates)<!--RN 37269-->. This setting is only available when a single query data source or an indices dataset was applied. This setting is disabled by default. |
+| Initial selection | Select first item by default | Available from DataMiner web 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38775-->. When enabled, the first item is automatically selected when the data in the tree is refreshed, unless a custom URL is used specifying a different value. This setting is enabled by default. |
+| Initial Selection | Select item by default | Specify a fixed default value, which is automatically selected when the data in the tree is refreshed, unless a custom URL is used specifying a different value. From DataMiner web 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38775-->, this setting is only available when the *Select first item by default* setting is disabled.<br><br>Formerly known as:<br>- *Initial Selection* (Prior to DataMiner web 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4<!--RN 38775-->)<br>- *Feed Defaults* (Prior to DataMiner 10.3.6/10.4.0<!--RN 35984-->)|
+| Data retrieval | Update data | Available from DataMiner web 10.3.0 [CU13]/10.4.0 [CU1]/10.4.4 onwards<!--RN 38811-->. Toggle the switch to determine whether the values displayed in the component should be updated automatically (provided this is supported by the data source). See [Query updates](xref:Query_updates)<!--RN 37269-->. This setting is only available when a single query data source or an indices dataset was applied. This setting is disabled by default. |

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/States_and_values/Gauge_component.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/States_and_values/Gauge_component.md
@@ -28,7 +28,7 @@ To configure the component:
 
    - In case the component displays more than one item, in the *Settings* pane, select how the items should be grouped: by parameter, by element, by table index (if relevant) or by all the above together.
 
-   - To customize the value range of the component, in the *Settings* pane, select *Fixed minimum* and/or *Fixed maximum* and specify the custom minimum and/or maximum. This option is available from DataMiner 10.2.0/10.1.6 onwards.
+   - To customize the value range of the component, in the *Settings* pane, select *Fixed minimum* and/or *Fixed maximum* and specify the custom minimum and/or maximum.
 
 1. Fine-tune the component layout. In the *Component* > *Layout* pane, the following options are available:
 
@@ -51,18 +51,16 @@ To configure the component:
 
      - *Align font sizes*: Only available if *Design* is set to *Auto Size*. This option causes the font size to be aligned with the font size of other components using this option. If the option is not selected, the text is simply displayed as large as possible within the component.
 
-     - *Show progress*: Available from DataMiner 10.2.0/10.1.6 onwards. Only available if the component displays an analog parameter. In that case, a darker color within the gauge will indicate the current parameter value.
+     - *Show progress*: Only available if the component displays an analog parameter. In that case, a darker color within the gauge will indicate the current parameter value.
 
-     - *Show minimum*: Available from DataMiner 10.2.0/10.1.6 onwards. Select this option to show the minimum value of the value range below the gauge. Note that this value can be customized in the component settings.
+     - *Show minimum*: Select this option to show the minimum value of the value range below the gauge. Note that this value can be customized in the component settings.
 
-     - *Show maximum*: Available from DataMiner 10.2.0/10.1.6 onwards. Select this option to show the maximum value of the value range below the gauge. Note that this value can be customized in the component settings.
+     - *Show maximum*: Select this option to show the maximum value of the value range below the gauge. Note that this value can be customized in the component settings.
 
      - *Show icon*: Determines whether an icon is displayed for the parameter. You can select which icon is displayed in a dropdown list.
 
        For trended parameters, by default a trend icon is displayed. Clicking this icon will open the corresponding trend graph in the Monitoring app.
 
-     - *Design*: Available from DataMiner 10.2.0/10.1.6 onwards. Determines how the text in the component is displayed. The options *Small* and *Large* show the text in a small and large font size, respectively. If you select *Auto size*, the font size will automatically be adjusted to fit in the available space.
+     - *Design*: Determines how the text in the component is displayed. The options *Small* and *Large* show the text in a small and large font size, respectively. If you select *Auto size*, the font size will automatically be adjusted to fit in the available space.
 
-     - *Gauge/Vertical alignment*: Only available up to DataMiner 10.1.5. Determines whether the gauge should be aligned at the top or the center of the component.
-
-     - Alignment: Available from DataMiner 10.2.0/10.1.6 onwards. Only displayed if *Design* is set to *Small* or *Large*. Allows you to align the contents of the components to the left, in the center or to the right.
+     - *Alignment*: Only displayed if *Design* is set to *Small* or *Large*. Allows you to align the contents of the components to the left, in the center or to the right.

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/States_and_values/Progress_bar_component.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/States_and_values/Progress_bar_component.md
@@ -4,7 +4,7 @@ uid: DashboardProgressBar
 
 # Progress bar
 
-This component shows the value of one or more analog parameters with a progress bar. It is available from DataMiner 10.2.0/10.1.7 onwards.
+This component shows the value of one or more analog parameters with a progress bar.
 
 ![Progress bar](~/dataminer/images/Progress_Bar.png)<br>*Progress bar component in DataMiner 10.4.5*
 

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/States_and_values/Ring_component.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/States_and_values/Ring_component.md
@@ -19,7 +19,7 @@ To configure the component:
 
    - In case parameter data included a parameter based on a protocol, a filter can be used to filter on a specific element.
 
-   - From DataMiner 10.2.0/10.1.4 onwards, you can select view parameters as a data source to view information on aggregation rules on specific views. To select these, in the dropdown box for the parameter data source, select *View*.
+   - You can select view parameters as a data source to view information on aggregation rules on specific views. To do so, in the dropdown box for the parameter data source, select *View*.
 
    > [!NOTE]
    > Once this component has been configured with data input, the exposed data will appear as [component data](xref:Component_Data) in the *Data* pane and can be used by other components. This way, if the input for this component changes, the exposed data will update automatically for all components that use it as their data input.
@@ -30,7 +30,7 @@ To configure the component:
 
    - In case the component displays more than one item, in the *Settings* pane, select how the items should be grouped: by parameter, by element, by table index (if relevant) or by all the above together. Note that view parameters can only be grouped together with other parameters with the option *All together*, otherwise they are placed in a separate group.
 
-   - To customize the value range of the component, in the *Settings* pane, select *Fixed minimum* and/or *Fixed maximum* and specify the custom minimum and/or maximum. This option is available from DataMiner 10.2.0/10.1.6 onwards.
+   - To customize the value range of the component, in the *Settings* pane, select *Fixed minimum* and/or *Fixed maximum* and specify the custom minimum and/or maximum.
 
 1. Fine-tune the component layout. In the *Component* > *Layout* pane, the following options are available:
 
@@ -55,14 +55,14 @@ To configure the component:
 
      - *Show progress*: Only available if the component displays an analog parameter. In that case, a darker color within the ring will indicate the current parameter value.
 
-     - *Show minimum*: Available from DataMiner 10.2.0/10.1.6 onwards. Select this option to show the minimum value of the value range below the ring. Note that this value can be customized in the component settings.
+     - *Show minimum*: Select this option to show the minimum value of the value range below the ring. Note that this value can be customized in the component settings.
 
-     - *Show maximum*: Available from DataMiner 10.2.0/10.1.6 onwards. Select this option to show the maximum value of the value range below the ring. Note that this value can be customized in the component settings.
+     - *Show maximum*: Select this option to show the maximum value of the value range below the ring. Note that this value can be customized in the component settings.
 
      - *Show icon*: Determines whether an icon is displayed for the parameter. You can select which icon is displayed in a dropdown list.
 
        For trended parameters, by default a trend icon is displayed. Clicking this icon will open the corresponding trend graph in the Monitoring app.
 
-     - *Design*: Available from DataMiner 10.2.0/10.1.6 onwards. Determines how the text in the component is displayed. The options *Small* and *Large* show the text in a small and large font size, respectively. If you select *Auto size*, the font size will automatically be adjusted to fit in the available space.
+     - *Design*: Determines how the text in the component is displayed. The options *Small* and *Large* show the text in a small and large font size, respectively. If you select *Auto size*, the font size will automatically be adjusted to fit in the available space.
 
-     - Alignment: Available from DataMiner 10.2.0/10.1.6 onwards. Only displayed if *Design* is set to *Small* or *Large*. Allows you to align the contents of the components to the left, in the center or to the right.
+     - *Alignment*: Only displayed if *Design* is set to *Small* or *Large*. Allows you to align the contents of the components to the left, in the center or to the right.

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/States_and_values/State_component.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/States_and_values/State_component.md
@@ -9,7 +9,7 @@ This component displays the state, name and, if applicable, the value of a DataM
 ![State](~/dataminer/images/State.png)<br>*State component in DataMiner 10.4.6*
 
 > [!NOTE]
-> From DataMiner 10.3.6/10.4.0 onwards, if an item in this component is selected, you can clear the selection by clicking it while keeping the Ctrl key pressed. If you are using the State component as data input for other components, this will also clear the data shown in those components. <!-- RN 36056 -->
+> From DataMiner web 10.3.6/10.4.0 onwards, if an item in this component is selected, you can clear the selection by clicking it while keeping the Ctrl key pressed. If you are using the State component as data input for other components, this will also clear the data shown in those components. <!-- RN 36056 -->
 
 To configure the component:
 
@@ -24,7 +24,7 @@ To configure the component:
 
    - This component also supports queries as data input. See [Creating a GQI query](xref:Creating_GQI_query).
 
-   - From DataMiner 10.2.0/10.1.4 onwards, you can select view parameters as a data source to view the alarm state for aggregation rules on specific views. To select these, in the dropdown box for the parameter data source, select *View*.
+   - You can select view parameters as a data source to view the alarm state for aggregation rules on specific views. To do so, in the dropdown box for the parameter data source, select *View*.
 
    > [!NOTE]
    > Once this component has been configured with data input, the exposed data will appear as [component data](xref:Component_Data) in the *Data* pane and can be used by other components. This way, if the input for this component changes, the exposed data will update automatically for all components that use it as their data input.
@@ -33,13 +33,13 @@ To configure the component:
 
    - To customize the polling interval for this component, expand the *Settings* \> *WebSocket settings* section, clear the checkbox in this section, and specify the custom polling interval.
 
-   - If the component shows a parameter with a unit, but you do not want the unit to be displayed, in the *Settings* pane, clear the *Show units* option (available from DataMiner 10.1.9/10.2.0 onwards).
+   - If the component shows a parameter with a unit, but you do not want the unit to be displayed, in the *Settings* pane, clear the *Show units* option.
 
    - In case the component displays more than one item, in the *Settings* pane, select how the items should be grouped: by parameter, by element, by table index (if relevant) or by all the above together. Note that view parameters can only be grouped together with other parameters with the option *All together*, otherwise they are placed in a separate group.
 
-   - In case the component displays a query source and you want the data to be refreshed automatically, Set *Update data* to *On* (available from DataMiner 10.2.0/10.2.1 onwards<!-- RN 31450 -->).
+   - In case the component displays a query source and you want the data to be refreshed automatically, Set *Update data* to *On*.
 
-   - If you want the first item in the component to be selected by default, in the *Settings* pane, under *Initial Selection*, set the toggle button to *On* (available from DataMiner 10.3.6/10.4.0 onwards<!-- RN 35984 -->). This way, the first item will be automatically selected whenever the component is loaded or when the data is refreshed.
+   - If you want the first item in the component to be selected by default, in the *Settings* pane, under *Initial Selection*, set the toggle button to *On* (available from DataMiner web 10.3.6/10.4.0 onwards<!-- RN 35984 -->). This way, the first item will be automatically selected whenever the component is loaded or when the data is refreshed.
 
 1. Fine-tune the component layout. In the *Component* > *Layout* pane, the following options are available:
 
@@ -73,4 +73,4 @@ To configure the component:
 
      - *Layout flow*: Allows you to select whether the different states should be displayed in rows or columns. If they are displayed in rows, they will be displayed next to each other until there is no more space and a new row is started. If they are displayed as columns, they will be displayed below each other until there is no more space and a new column is started.
 
-     - Alignment: Available from DataMiner 10.1.0/10.1.3 onwards. Only displayed if *Design* is set to *Large* or *Auto Size*. Allows you to align the contents of the components to the left, in the center or to the right.
+     - Alignment: Only displayed if *Design* is set to *Large* or *Auto Size*. Allows you to align the contents of the components to the left, in the center or to the right.

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Tables/Alarm_table_component.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Tables/Alarm_table_component.md
@@ -4,11 +4,6 @@ uid: DashboardAlarmTable
 
 # Alarm table
 
-> [!NOTE]
-> This feature is in preview until DataMiner 10.1.5. If you use the preview version of the feature, its functionality may be different from what is described below. For more information, see [Soft-launch options](xref:SoftLaunchOptions).
-
-Available from DataMiner 10.2.0/10.1.5 onwards. Prior to this, the component is available in soft launch from DataMiner 9.6.8 onwards.
-
 The component displays a list of alarms or information events, which can be filtered in multiple ways. By default, the following columns are included in the alarm table: element name, parameter description, value, time, and root time. However, columns can be removed and added in the component settings (see information below).
 
 ![Alarm table](~/dataminer/images/Alarm_Table.png)<br>*Alarm table component in DataMiner 10.4.6*
@@ -24,7 +19,7 @@ To configure the component:
      In case you select history alarms, the start time and end time will also need to be specified. In case you select alarms in a sliding window, the sliding window size and refresh time will need to be configured.
 
      > [!NOTE]
-     > From DataMiner 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6 onwards<!--RN 39484-->, the sliding window size and refresh time are limited to a minimum of 1 minute and a maximum of 1 day. You can specify these parameters in minutes, hours, or days. Prior to DataMiner 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6, you have the option to specify the sliding window size and refresh time in milliseconds, seconds, minutes, hours, or days.
+     > From DataMiner web 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6 onwards<!--RN 39484-->, the sliding window size and refresh time are limited to a minimum of 1 minute and a maximum of 1 day. You can specify these parameters in minutes, hours, or days. Prior to DataMiner web 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6, you have the option to specify the sliding window size and refresh time in milliseconds, seconds, minutes, hours, or days.
 
    - Optionally, specify a filter for the list with the *Filters* boxes. You can either configure a filter of your own, or select *Saved filter* to use an existing shared alarm filter from the DMS. If you select to use a *Parameter index* filter, you can use “?” and “\*” as wildcards (see [Searching with wildcard characters](xref:Searching_in_DataMiner_Cube#searching-with-wildcard-characters)).
 
@@ -33,14 +28,14 @@ To configure the component:
      > [!NOTE]
      >
      > - If an initial number of alarms to load is specified, no grouping is applied.
-     > - From DataMiner 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6 onwards<!--RN 39484-->, the initial number of alarms to load is limited to a minimum of 1 alarm and a maximum of 100,000 alarms.
+     > - From DataMiner web 10.3.0 [CU15]/10.4.0 [CU3]/10.4.6 onwards<!--RN 39484-->, the initial number of alarms to load is limited to a minimum of 1 alarm and a maximum of 100,000 alarms.
 
    - Below *Columns*, you can select one or more columns in order to have only those columns displayed in the alarm list, and you can add columns that were initially not included in the alarm table, e.g., "Alarm ID", "Root alarm ID", "Severity", and "Alarm type". For each column, arrow buttons will be displayed that allow you to customize the column order.
 
      > [!NOTE]
      > The content of the *Alarm ID* and *Root Alarm ID* columns may differ depending on your DataMiner version:
      >
-     > | Column | From DataMiner 10.3.0 [CU21]/10.4.0 [CU9]/10.4.12 onwards<!--RN 41113--> | Prior to DataMiner 10.3.0 [CU21]/10.4.0 [CU9]/10.4.12 |
+     > | Column | From DataMiner web 10.3.0 [CU21]/10.4.0 [CU9]/10.4.12 onwards<!--RN 41113--> | Prior to DataMiner web 10.3.0 [CU21]/10.4.0 [CU9]/10.4.12 |
      > |--|--|--|
      > | Alarm ID | DMAID/EID/RootAlarmID/AlarmID | HostingDMAID/AlarmID |
      > | Root Alarm ID | DMAID/EID/RootAlarmID | HostingDMAID/RootAlarmID |

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Tables/Table_component.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Tables/Table_component.md
@@ -41,7 +41,7 @@ Each row in a query corresponds to a row in a table.
 
 ## Filtering table content
 
-From DataMiner 10.2.7/10.3.0 onwards, you can filter the contents of a table component using one of four available methods:
+You can filter the contents of a table component using one of four available methods:
 
 - Use the [search box](xref:Filtering_Table_Content#general-filter) to filter the entire table based on the entered value.
 
@@ -60,14 +60,14 @@ From DataMiner 10.2.7/10.3.0 onwards, you can filter the contents of a table com
   ![Filter operator](~/dataminer/images/Filter_Operator.gif)<br>*Table component and grid component in DataMiner 10.5.6*
 
 > [!TIP]
-> If you have made changes to the way a table is displayed, and you want to quickly reset your changes and return to the initial table view, click the eye icon in the upper-right corner of the component (available from DataMiner 10.2.11/10.3.0 onwards).
+> If you have made changes to the way a table is displayed, and you want to quickly reset your changes and return to the initial table view, click the eye icon in the upper-right corner of the component.
 
 ## Resizing the table columns
 
-You can **resize the columns** of a table by dragging the edges of the column headers. From DataMiner 10.1.8/10.2.0 onwards, you can also change the order of the columns by dragging the column headers to a different position.
+You can **resize the columns** of a table by dragging the edges of the column headers, and **change the order** of the columns by dragging the column headers to a different position.
 
 > [!TIP]
-> From DataMiner 10.4.1/10.5.0 onwards<!--RN 37522-->, you can adjust the default column width by accessing the [Template Editor](xref:Template_Editor) through *Layout > Column appearance*.
+> From DataMiner web 10.4.1/10.5.0 onwards<!--RN 37522-->, you can adjust the default column width by accessing the [Template Editor](xref:Template_Editor) through *Layout > Column appearance*.
 
 ![Resizing and moving columns](~/dataminer/images/Resizing.gif)<br>*Table component in DataMiner 10.5.6*
 
@@ -85,7 +85,7 @@ To **group** by a specific table column, right-click the column header and click
 
 ## Copying table data
 
-From DataMiner 10.2.7/10.3.0 onwards, you can copy a cell, a column, a row, or the entire table via the right-click menu of the component.
+You can copy a cell, a column, a row, or the entire table via the right-click menu of the component.
 
 ![Copy table data](~/dataminer/images/Copy_Table_Data.png)<br>*Table component in DataMiner 10.5.6*
 
@@ -93,15 +93,15 @@ Unless a single cell is copied, the copy is in CSV format. If an entire column o
 
 ## Exporting the table
 
-From DataMiner 10.1.3/10.2.0 onwards, you can export the content of the table by clicking the ... button in the upper-right corner of the component and selecting *Export to CSV*.
+To export the content of the table, click the ... button in the upper-right corner of the component and select *Export to CSV*.
 
 ![Export to CSV](~/dataminer/images/Export_to_CSV.png)<br>*Table component in DataMiner 10.5.6*
 
 What happens next depends on your DataMiner version:
 
-- Prior to DataMiner 10.3.8/10.4.0, if nothing is selected in the table, the entire table will be exported; otherwise only the selected rows will be exported. The data will contain the display values, not the raw values. This means that units will be included for the parameter values and that discrete values will be replaced by their corresponding display values.
+- Prior to DataMiner web 10.3.8/10.4.0, if nothing is selected in the table, the entire table will be exported; otherwise only the selected rows will be exported. The data will contain the display values, not the raw values. This means that units will be included for the parameter values and that discrete values will be replaced by their corresponding display values.
 
-- From DataMiner 10.3.8/10.4.0 onwards, a pop-up window will open where you can select whether the raw values or the display values from the table should be exported. Exporting the display values will result in a CSV file that contains all the values as they are seen in the table, formatted and with units. If you export the raw values, no formatting will be applied to them. The only exception are discrete values, for which the corresponding display values will always be exported. If no rows are selected in the table, the entire table will be exported; otherwise only the selected rows will be exported.
+- From DataMiner web 10.3.8/10.4.0 onwards, a pop-up window will open where you can select whether the raw values or the display values from the table should be exported. Exporting the display values will result in a CSV file that contains all the values as they are seen in the table, formatted and with units. If you export the raw values, no formatting will be applied to them. The only exception are discrete values, for which the corresponding display values will always be exported. If no rows are selected in the table, the entire table will be exported; otherwise only the selected rows will be exported.
 
 The export file will be named “Query XXX” (XXX being the name of the query, as configured in the *Data* pane). The first line of the CSV file will contain the names of the columns. The subsequent lines will contain the data, each line being a row of the query result.
 
@@ -119,9 +119,9 @@ Additionally, the following layout options are also available:
 | Section | Option | Description |
 |--|--|--|
 | Filtering & Highlighting | Conditional coloring | Highlight cells based on a condition. For more information, refer to [Conditional coloring](#conditional-coloring). |
-| Filtering & Highlighting | Show quick filter | Available from DataMiner 10.3.0 [CU20]/10.4.0 [CU8]/10.4.11 onwards<!--RN 40818-->. Toggle the switch to determine whether the search box, which lets you [apply a general filter](xref:Filtering_Table_Content#general-filter) across the table, is available in the upper-right corner of the table. Enabled by default. |
-| Column appearance | Column appearance | Available from DataMiner 10.4.1/10.5.0 onwards<!--RN 37522-->. Customize the appearance of a column. For more information, refer to [Column appearance](#column-appearance). |
-| Advanced | Empty result message | Available from DataMiner 10.3.11/10.4.0 onwards<!--RN 37173-->. Configure the message shown when a query returns no results. From DataMiner 10.5.0 [CU12]/10.6.3 onwards<!-- RN 44472 -->, this setting can be left empty, in which case no message is displayed and the component remains empty. See also: [Displaying a custom empty component message](xref:Tutorial_Dashboards_Displaying_a_custom_empty_component_message). |
+| Filtering & Highlighting | Show quick filter | Available from DataMiner web 10.3.0 [CU20]/10.4.0 [CU8]/10.4.11 onwards<!--RN 40818-->. Toggle the switch to determine whether the search box, which lets you [apply a general filter](xref:Filtering_Table_Content#general-filter) across the table, is available in the upper-right corner of the table. Enabled by default. |
+| Column appearance | Column appearance | Available from DataMiner web 10.4.1/10.5.0 onwards<!--RN 37522-->. Customize the appearance of a column. For more information, refer to [Column appearance](#column-appearance). |
+| Advanced | Empty result message | Available from DataMiner web 10.3.11/10.4.0 onwards<!--RN 37173-->. Configure the message shown when a query returns no results. From DataMiner web 10.5.0 [CU12]/10.6.3 onwards<!-- RN 44472 -->, this setting can be left empty, in which case no message is displayed and the component remains empty. See also: [Displaying a custom empty component message](xref:Tutorial_Dashboards_Displaying_a_custom_empty_component_message). |
 
 #### Conditional coloring
 
@@ -129,7 +129,7 @@ In the *Layout* pane for this component, the *Conditional coloring* option is av
 
 - If the column you want to use for highlighting contains **values for which a specific range can be specified**, select the column, indicate the range to be highlighted, select the range and then click the color icon on the right to specify a highlight color. Multiple ranges can be indicated for one column, each with a color of its own.
 
-- Alternatively, from DataMiner 10.2.0/10.1.8 onwards, you can **filter on specific text** instead. To do so, select the column you want to use for highlighting, specify the text, and select the highlight color. You can change the filtering behavior by clicking *equal* above the text box and selecting one of the available options:
+- Alternatively, you can **filter on specific text** instead. To do so, select the column you want to use for highlighting, specify the text, and select the highlight color. You can change the filtering behavior by clicking *equal* above the text box and selecting one of the available options:
 
   - **Equal** (default): Highlights cells that are exactly equal to the specified text.
 
@@ -147,7 +147,7 @@ In the *Layout* pane for this component, the *Conditional coloring* option is av
 
 #### Column appearance
 
-From DataMiner 10.4.1/10.5.0 onwards<!-- RN 37522 -->, in the *Layout* pane, the *Column appearance* option is available, which allows you to customize the appearance of a column.
+From DataMiner web 10.4.1/10.5.0 onwards<!-- RN 37522 -->, in the *Layout* pane, the *Column appearance* option is available, which allows you to customize the appearance of a column.
 
 ##### Column appearance presets
 
@@ -178,7 +178,7 @@ To freely **customize the appearance** of a column:
 >
 > For example, if you selected the *Hyperlink* preset, a rectangle layer with opacity 0%, including a *Navigate to a URL* action, will be configured. Additionally, the text color of the text layer will be set to blue (#1F68BF), and the text inside the text box will be enclosed by HTML `<u>` elements to define underlined text.
 
-From DataMiner 10.4.0 [CU13]/10.5.0 [CU1]/10.5.4 onwards<!--RN 42226-->, you can also **reuse saved templates** from the same dashboard or low-code app:
+From DataMiner web 10.4.0 [CU13]/10.5.0 [CU1]/10.5.4 onwards<!--RN 42226-->, you can also **reuse saved templates** from the same dashboard or low-code app:
 
 1. Click the ellipsis button ("...") next to the column name.
 
@@ -210,15 +210,15 @@ In the *Settings* pane for this component, you can customize its behavior to sui
 |--|--|--|
 | WebSocket settings | Inherit WebSocket settings from page/panel | Clear the checkbox to use a custom polling interval for this component. When cleared, you can specify a different polling interval (in seconds). |
 | General | Override dynamic units | Clear the checkbox to prevent parameter units from changing dynamically based on their value and protocol definition. Disabled by default. |
-| Data retrieval | Update data | Available from DataMiner 10.2.0/10.2.1 onwards. Toggle the switch to determine whether the data in the table should be refreshed automatically (provided this is supported by the data source). |
+| Data retrieval | Update data | Toggle the switch to determine whether the data in the table should be refreshed automatically (provided this is supported by the data source). |
 | Actions | On double click | Configure one or more actions to be executed when a row is double-clicked. Only available in Low-Code Apps. |
-| Initial selection | Select first row by default | Available from DataMiner 10.3.6/10.4.0 onwards<!-- RN 35984 -->. Toggle the switch to determine whether the first row is selected by default. When enabled, the first row will automatically be selected whenever the component is loaded or when the data in the table is refreshed. |
+| Initial selection | Select first row by default | Available from DataMiner web 10.3.6/10.4.0 onwards<!-- RN 35984 -->. Toggle the switch to determine whether the first row is selected by default. When enabled, the first row will automatically be selected whenever the component is loaded or when the data in the table is refreshed. |
 
 > [!NOTE]
 >
-> - While the *Update data* setting is available from DataMiner 10.2.0/10.2.1 onwards<!-- RN 31450 -->, in older DataMiner versions it can only be used with the *Get parameter table by ID* query data source. From DataMiner 10.3.10/10.4.0 onwards<!-- RN 36789 -->, other data sources are also supported.
+> - In older DataMiner versions, the *Update data* setting can only be used with the *Get parameter table by ID* query data source. From DataMiner web 10.3.10/10.4.0 onwards<!-- RN 36789 -->, other data sources are also supported.
 > - Instead of enabling the *Update data* setting to refresh data automatically, you can also refresh it manually using a [trigger component](xref:DashboardTrigger) or a [component action](xref:LowCodeApps_event_config).
-> - In versions prior to DataMiner 10.3.7/10.4.0, refreshing the table using a trigger component or component action causes the any selected data to be lost. From DataMiner 10.3.7/10.4.0 onwards, the component will try to reapply the selection. This means that the table will keep fetching more data until all previously selected rows are found. When a previously selected row is missing, the table will fetch all data looking for it. Reapplying the previous selection will take precedence over selecting the first row when the *Initial Selection* setting is enabled. The table will also update its data to reflect the new selection. <!-- RN 36372 -->
+> - In versions prior to DataMiner web 10.3.7/10.4.0, refreshing the table using a trigger component or component action causes the any selected data to be lost. From DataMiner web 10.3.7/10.4.0 onwards, the component will try to reapply the selection. This means that the table will keep fetching more data until all previously selected rows are found. When a previously selected row is missing, the table will fetch all data looking for it. Reapplying the previous selection will take precedence over selecting the first row when the *Initial Selection* setting is enabled. The table will also update its data to reflect the new selection. <!-- RN 36372 -->
 
 ## Adding actions to a table
 
@@ -226,7 +226,7 @@ If you add a table component to a custom app using the [DataMiner Low-Code Apps]
 
 To configure actions:
 
-- From DataMiner 10.4.1/10.5.0 onwards<!--RN 37522-->:
+- From DataMiner web 10.4.1/10.5.0 onwards<!--RN 37522-->:
 
   - In the Template Editor, you can **configure actions for table columns**. Actions can be linked to the *On click* event of a shape in a column template, allowing you to define your own links or buttons inside a table.
 
@@ -241,7 +241,7 @@ To configure actions:
 
     1. In the pop-up window, select the action that should be executed. See [Configuring app events](xref:LowCodeApps_event_config).
 
-- Prior to DataMiner 10.4.1/10.5.0:
+- Prior to DataMiner web 10.4.1/10.5.0:
 
   1. In the *Component* \> *Settings* pane, expand the *Actions* section.
 

--- a/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Tables/Table_component/Filtering_Table_Content.md
+++ b/dataminer/Functions/Dashboards_and_Low_Code_Apps/Visualizations/Available_visualizations/Tables/Table_component/Filtering_Table_Content.md
@@ -10,7 +10,7 @@ From DataMiner 10.2.7/10.3.0 onwards, you can filter the contents of a table com
 
 To apply a general filter across the table, a **search box** is available:
 
-1. In edit mode, make sure the [*Show quick filter* setting](xref:DashboardTable#table-layout) is enabled (from DataMiner 10.3.0 [CU20]/10.4.0 [CU8]/10.4.11 onwards<!-- RN 40818-->).
+1. In edit mode, make sure the [*Show quick filter* setting](xref:DashboardTable#table-layout) is enabled (from DataMiner web 10.3.0 [CU20]/10.4.0 [CU8]/10.4.11 onwards<!-- RN 40818-->).
 
 1. In read mode, click the search icon in the upper-right corner of the component.
 

--- a/dataminer/Functions/Maps/Configuring_DataMiner_Maps/Layer_types.md
+++ b/dataminer/Functions/Maps/Configuring_DataMiner_Maps/Layer_types.md
@@ -364,7 +364,7 @@ Example:
 
 #### Customizing the appearance of GeoJSON overlays
 
-From DataMiner 10.5.0 [CU16]/10.6.0 [CU4]/10.6.7 onwards<!--RN 45518-->, you can customize the appearance of GeoJSON overlays by defining style properties of the geometry objects in the GeoJSON file.
+From DataMiner web 10.5.0 [CU16]/10.6.0 [CU4]/10.6.7 onwards<!--RN 45518-->, you can customize the appearance of GeoJSON overlays by defining style properties of the geometry objects in the GeoJSON file.
 
 The following properties are supported:
 

--- a/dataminer/Reference/Feature_overview.md
+++ b/dataminer/Reference/Feature_overview.md
@@ -128,13 +128,13 @@ Below you can find an overview of the main features that have been added to Data
 | Low-Code Apps: [Customizing the app styling using custom CSS code](xref:Changing_low-code_app_settings#customizing-the-app-styling-using-custom-css-code) | DataMiner web 10.5.0 [CU12]/10.6.3 <!-- [ID 44570] --> |
 | Low-Code Apps: [Duplicating an app](xref:Creating_custom_apps#duplicating-an-existing-low-code-app) | DataMiner web 10.3.0 [CU10]/10.4.1 <!-- [ID 37698] -->|
 | Low-Code Apps: [*Interactive automation script* component](xref:InteractiveAutomationScript) | DataMiner web 10.3.0 [CU18]/10.4.0 [CU6]/10.4.9 <!-- [ID 39969] -->|
-| Low-Code Apps: [Node movement events](xref:DashboardNodeEdgeGraph#configuring-node-movement-events) for the node edge graph component | DataMiner 10.5.0 [CU10]/10.6.1 <!-- [ID 44144] --> |
+| Low-Code Apps: [Node movement events](xref:DashboardNodeEdgeGraph#configuring-node-movement-events) for the node edge graph component | DataMiner web 10.5.0 [CU10]/10.6.1 <!-- [ID 44144] --> |
 | Low-Code Apps: [*Open monitoring card* action](xref:LowCodeApps_event_config#opening-a-monitoring-card) | DataMiner web 10.3.4/10.4.0 <!-- [ID 35661] -->|
-| Low-Code Apps: [*Show a notification* action](xref:LowCodeApps_event_config#showing-a-notification) | DataMiner 10.3.0 [CU12]/10.4.3 <!-- [ID 38548] -->|
+| Low-Code Apps: [*Show a notification* action](xref:LowCodeApps_event_config#showing-a-notification) | DataMiner web 10.3.0 [CU12]/10.4.3 <!-- [ID 38548] -->|
 | Low-Code Apps: [Timeline component events and actions](xref:DashboardTimeline#adding-actions-to-a-timeline) | DataMiner web 10.3.0 CU14/10.4.0 CU2/10.4.5<!-- [ID 39254] --> |
 | Low-Code Apps: [Trigger component actions that let users control the trigger timer](xref:DashboardTrigger#letting-users-control-the-trigger-timer) | DataMiner web 10.4.0 [CU17]/10.5.0 [CU5]/10.5.8 <!-- [ID 43184]  --> |
-| Low-Code Apps: [On app open event](xref:Changing_low-code_app_settings#having-an-event-triggered-when-the-app-is-opened) | DataMiner 10.4.0 [CU19]/10.5.0 [CU7]/10.5.10<!-- [ID 43350] --> |
-| Maps: [Customizing the appearance of GeoJSON layers](xref:Layer_types#customizing-the-appearance-of-geojson-overlays) | DataMiner 10.5.0 [CU16]/10.6.0 [CU4]/10.6.7 <!-- [ID 45518] --> |
+| Low-Code Apps: [On app open event](xref:Changing_low-code_app_settings#having-an-event-triggered-when-the-app-is-opened) | DataMiner web 10.4.0 [CU19]/10.5.0 [CU7]/10.5.10<!-- [ID 43350] --> |
+| Maps: [Customizing the appearance of GeoJSON layers](xref:Layer_types#customizing-the-appearance-of-geojson-overlays) | DataMiner web 10.5.0 [CU16]/10.6.0 [CU4]/10.6.7 <!-- [ID 45518] --> |
 | [Node Recovery](xref:NodeRecovery_About) | DataMiner 10.6.0/10.6.2, with the NodeRecovery DxM |
 | Protocols: [Buttons in table cells to open DataMiner objects](xref:UIComponentsTableRowButtons) | DataMiner 10.1.9/10.2.0 <!-- [ID 30413] --> |
 | Protocols: [Buttons to open EPM objects](xref:AdvancedEPMLaunchEPMObjectsTableCellButtons)| DataMiner 10.2.3/10.3.0 <!-- [ID 32368] --> |


### PR DESCRIPTION
- To ensure that it's clear that a web only upgrade is sufficient for certain features, the "web" clarification has been added to the DataMiner version number (note that this is a work in progress).
-  Some obsolete version info has also been removed.