### PR TITLE
Remove IMPORTANT notice from Plan 1.6.0

### DIFF
--- a/release-notes/MediaOps/MediaOps_Plan/MediaOps_Plan_1.6.0.md
+++ b/release-notes/MediaOps/MediaOps_Plan/MediaOps_Plan_1.6.0.md
@@ -4,9 +4,6 @@ uid: MediaOps_Plan_1.6.0
 
 # MediaOps Plan 1.6.0
 
-> [!IMPORTANT]
-> We are still working on this release. Release notes may still be modified, added, or moved to a later release. Check back soon for updates!
-
 > [!NOTE]
 > This version requires:
 >


### PR DESCRIPTION
Deleted the temporary [!IMPORTANT] warning  from the MediaOps Plan 1.6.0 release notes, as this is no longer needed.