### PR TITLE
Clarify STaaS networking on cloud connectivity page

### DIFF
--- a/dataminer/Administrator_guide/Security/About_DMS_Security/Cloud_connectivity_and_security.md
+++ b/dataminer/Administrator_guide/Security/About_DMS_Security/Cloud_connectivity_and_security.md
@@ -50,6 +50,9 @@ All communication between the DataMiner System and dataminer.services happens us
 Only outgoing traffic needs to be allowed through for the domain *.dataminer.services.
 
 > [!NOTE]
+> If your DataMiner System uses [Storage as a Service (STaaS)](xref:Setting_up_StaaS), additional Skyline-managed storage endpoints must be reachable on top of the dataminer.services endpoints listed above. These depend on the region your system is registered for. For the STaaS network requirements, see the [STaaS prerequisites](xref:Setting_up_StaaS#prerequisites).
+
+> [!NOTE]
 >
 > - Technical details of this implementation may be subject to change, as we regularly review our security implementations.
 > - Users can disconnect their system from dataminer.services at any given time. For more information, please refer to [Connecting your DataMiner System to dataminer.services](xref:Connecting_your_DataMiner_System_to_the_cloud).

--- a/dataminer/Administrator_guide/Security/About_DMS_Security/Cloud_connectivity_and_security.md
+++ b/dataminer/Administrator_guide/Security/About_DMS_Security/Cloud_connectivity_and_security.md
@@ -50,10 +50,8 @@ All communication between the DataMiner System and dataminer.services happens us
 Only outgoing traffic needs to be allowed through for the domain *.dataminer.services.
 
 > [!NOTE]
-> If your DataMiner System uses [Storage as a Service (STaaS)](xref:Setting_up_StaaS), additional Skyline-managed storage endpoints must be reachable on top of the dataminer.services endpoints listed above. These depend on the region your system is registered for. For the STaaS network requirements, see the [STaaS prerequisites](xref:Setting_up_StaaS#prerequisites).
-
-> [!NOTE]
 >
+> - If your DataMiner System uses [Storage as a Service (STaaS)](xref:Setting_up_StaaS), **additional Skyline-managed storage endpoints** must be reachable on top of the dataminer.services endpoints listed above. These depend on the region your system is registered for. For the STaaS network requirements, refer to the [STaaS prerequisites](xref:Setting_up_StaaS#prerequisites).
 > - Technical details of this implementation may be subject to change, as we regularly review our security implementations.
 > - Users can disconnect their system from dataminer.services at any given time. For more information, please refer to [Connecting your DataMiner System to dataminer.services](xref:Connecting_your_DataMiner_System_to_the_cloud).
 


### PR DESCRIPTION
## Why

When setting up Storage as a Service (STaaS), users need to know that the networking requirements go beyond the standard dataminer.services connection: STaaS also relies on region-specific endpoints. The Cloud connectivity and security page listed the dataminer.services endpoints but said nothing about this STaaS-specific requirement, so a reader configuring firewall rules could easily miss it.

## What changed

Added a note to the "Connecting to dataminer.services" section of `Cloud_connectivity_and_security.md`, right after the endpoint list. It explains that STaaS systems need additional storage endpoints (which depend on the registered region) on top of the dataminer.services endpoints, and links to the STaaS prerequisites for the full network requirements.

This makes the relationship between the two pages explicit and gives users a clear path to the STaaS-specific networking details.