### PR TITLE
Add APP item type to GitHub guidelines

### DIFF
--- a/develop/CICD/Skyline Communications/Github/Use_Github_Guidelines.md
+++ b/develop/CICD/Skyline Communications/Github/Use_Github_Guidelines.md
@@ -72,6 +72,7 @@ If the repository is private, the name should look like this (using "-" as separ
   | UDAPI | User-Defined APIs |
   | V | Visio files |
   | EXT | External tools - software  |
+  | APP | Application code (web/mobile/desktop/Vibe Coded Apps)  |
 
   > [!NOTE]
   > If you think an item type should be added, please contact us so we can add it before you create the repository.


### PR DESCRIPTION
Propose adding APP to the Skyline repository naming conventions for application repositories (e.g. UI/Vibe Coded Web Apps), enabling clear names like SLC-APP-DocumentHub-UI instead of overloading EXT (SLC-EXT-DocumentHub-UI)