### PR TITLE
Update PATCH API version from 10.6.7 to 10.6.8

### DIFF
--- a/dataminer/Functions/User-Defined_APIs/UD_APIs_Triggering_an_API.md
+++ b/dataminer/Functions/User-Defined_APIs/UD_APIs_Triggering_an_API.md
@@ -43,7 +43,7 @@ The following HTTP methods are supported:
 | PUT | 10.3.6/10.4.0 |
 | POST | 10.3.6/10.4.0 |
 | DELETE | 10.3.6/10.4.0 |
-| PATCH | 10.6.7/10.7.0 | <!-- RN45542 -->
+| PATCH | 10.6.8/10.7.0 | <!-- RN45542 -->
 
 > [!NOTE]
 > You are free to choose which of these methods your API will support.


### PR DESCRIPTION
According to RN, supported version for PATCH support is 10.6.8. @Skyline-ThomasGH to confirm