### PR TITLE
Clarify namespace usage of DomHelper.DomInstances.Read select method

### DIFF
--- a/dataminer/Functions/DOM/DOM_helper_crud_methods.md
+++ b/dataminer/Functions/DOM/DOM_helper_crud_methods.md
@@ -274,7 +274,7 @@ foreach (var doc in results)
 ```
 
 > [!NOTE]
-> To use the `DomHelper.DomInstances.Read(FilterElement<DomInstance>, SelectedFields<DomInstance>);` method, a using statement with `using Skyline.DataMiner.Net.Messages;` is required.
+> Prior to DataMiner version 10.6.9/10.7.0, to use the `DomHelper.DomInstances.Read(FilterElement<DomInstance>, SelectedFields<DomInstance>);` method, a using statement with `using Skyline.DataMiner.Net.Messages;` is required.
 
 #### Example: Reading selected fields page by page
 

--- a/dataminer/Functions/DOM/DOM_helper_crud_methods.md
+++ b/dataminer/Functions/DOM/DOM_helper_crud_methods.md
@@ -274,7 +274,7 @@ foreach (var doc in results)
 ```
 
 > [!NOTE]
-> Prior to DataMiner version 10.6.9/10.7.0, to use the `DomHelper.DomInstances.Read(FilterElement<DomInstance>, SelectedFields<DomInstance>);` method, a using statement with `using Skyline.DataMiner.Net.Messages;` is required.
+> Prior to DataMiner version 10.6.9/10.7.0<!-- RN 45902 -->, to use the `DomHelper.DomInstances.Read(FilterElement<DomInstance>, SelectedFields<DomInstance>);` method, a using statement with `using Skyline.DataMiner.Net.Messages;` is required.
 
 #### Example: Reading selected fields page by page
 


### PR DESCRIPTION
Updated note regarding the usage of the DomHelper.DomInstances.Read method to include version-specific information. Since 10.6.9, the extension method with the FilterElement input argument was moved to the same namespace as the 'SelectedFields' type. That using statement is automatically added in VisualStudio, so no note needs to be added for that.

(Part of RN45902)