### PR TITLE
Reorder keywords in ConnectionSettings_txt.md

### DIFF
--- a/dataminer/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/ConnectionSettings_txt.md
+++ b/dataminer/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/ConnectionSettings_txt.md
@@ -1,6 +1,6 @@
 ---
 uid: ConnectionSettings_txt
-keywords: enabling gRPC, gRPC configuration, disabling .Net Remoting
+keywords: gRPC, enabling gRPC, gRPC configuration, disabling .Net Remoting
 ---
 
 # ConnectionSettings.txt


### PR DESCRIPTION
Just also wanted "gRPC" only in here since the page was pretty low when looking it up. 

As a side note, would a feature on the docs where it shows the first line on where a certain keyword is found in a webpage be possible in the search bar? I think it would help for people to correlate needing to go on the "ConnectionSettings.txt" page for information on gRPC enablement as an example. 
<img width="1061" height="640" alt="image" src="https://github.com/user-attachments/assets/efe8382c-2ec9-4c29-b105-d565ff15cbdb" />
