### PR TITLE
[ai] DIS Release Notes 3.1.23 Docs Updates

### DIFF
--- a/develop/TOOLS/DIS/Editors/XML_editor.md
+++ b/develop/TOOLS/DIS/Editors/XML_editor.md
@@ -98,10 +98,10 @@ To publish a protocol or an automation script to another, non-default DMA, click
 
 When you publish a protocol or an automation script, DIS will create either a *.dmprotocol* package (in case of a protocol) or a *.dmapp* package (in case of an automation script) in the background, install that package on the DataMiner Agent, and then automatically remove it again. This way, there is no need to manually copy all required DLL files on the DataMiner Agent in question (e.g., DLL files of NuGet packages that are used in the protocol or automation script).
 
-If you click *Publish* for an Automation script that is part of a solution package (i.e., a script of which the `.csproj` file contains a `DataMinerSolutionId`), DIS will publish the entire solution package rather than only the individual script:
+If you click *Publish* for an automation script that is part of a solution package (i.e., a script of which the `.csproj` file contains a `DataMinerSolutionId`), DIS will publish the entire solution package rather than only the individual script:
 
-- If the script belongs to a single solution package, a confirmation popup will appear informing you that the entire package will be published.
-- If the script is referenced in multiple solution packages, a selection popup will appear allowing you to choose which package to publish. The popup also informs you that the entire package will be published.
+- If the script belongs to a single solution package, a confirmation popup will appear, informing you that the entire package will be published.
+- If the script is referenced in multiple solution packages, a selection popup will appear, allowing you to choose which package to publish. The popup will also inform you that the entire package will be published.
 
 > [!TIP]
 > See also: [DMA](xref:DIS_settings#dma)

--- a/develop/TOOLS/DIS/Editors/XML_editor.md
+++ b/develop/TOOLS/DIS/Editors/XML_editor.md
@@ -98,6 +98,11 @@ To publish a protocol or an automation script to another, non-default DMA, click
 
 When you publish a protocol or an automation script, DIS will create either a *.dmprotocol* package (in case of a protocol) or a *.dmapp* package (in case of an automation script) in the background, install that package on the DataMiner Agent, and then automatically remove it again. This way, there is no need to manually copy all required DLL files on the DataMiner Agent in question (e.g., DLL files of NuGet packages that are used in the protocol or automation script).
 
+If you click *Publish* for an Automation script that is part of a solution package (i.e., a script of which the `.csproj` file contains a `DataMinerSolutionId`), DIS will publish the entire solution package rather than only the individual script:
+
+- If the script belongs to a single solution package, a confirmation popup will appear informing you that the entire package will be published.
+- If the script is referenced in multiple solution packages, a selection popup will appear allowing you to choose which package to publish. The popup also informs you that the entire package will be published.
+
 > [!TIP]
 > See also: [DMA](xref:DIS_settings#dma)
 

--- a/develop/TOOLS/DIS/Reference/DIS_settings.md
+++ b/develop/TOOLS/DIS/Reference/DIS_settings.md
@@ -250,6 +250,16 @@ Click *Fix default XML encoding* if you want DataMiner Integration Studio to cha
 >   - Unicode (UTF-8 with signature) - Codepage 65001
 > - XML files with an UTF-8 signature header can only be uploaded to DataMiner using DataMiner Cube.
 
+## XML Schemas
+
+In the *XML Schemas* tab, you can configure how DIS manages XML schema updates at startup.
+
+The tab contains a *Download XML Schemas on Visual Studio startup* checkbox, which is enabled by default.
+
+- When this checkbox is enabled, DIS checks for a newer version of the [Skyline.DataMiner.XmlSchemas](https://www.nuget.org/packages/Skyline.DataMiner.XmlSchemas) NuGet package each time Visual Studio starts. If a newer version is available, DIS automatically downloads the updated schemas and installs them into Visual Studio (e.g. `C:\Program Files\Microsoft Visual Studio\18\Professional\Xml\Schemas`). The outcome — whether a new version was installed or the current version is already up to date — is reported in the DIS output window.
+
+- When this checkbox is disabled, DIS installs the schemas that are bundled with DIS, as long as it detects that the currently installed schemas differ from the bundled ones.
+
 ## Info
 
 In the *Info* tab, you can find the version of the currently installed DataMiner Integration Studio.

--- a/develop/TOOLS/DIS/Reference/DIS_settings.md
+++ b/develop/TOOLS/DIS/Reference/DIS_settings.md
@@ -256,9 +256,9 @@ In the *XML Schemas* tab, you can configure how DIS manages XML schema updates a
 
 The tab contains a *Download XML Schemas on Visual Studio startup* checkbox, which is enabled by default.
 
-- When this checkbox is enabled, DIS checks for a newer version of the [Skyline.DataMiner.XmlSchemas](https://www.nuget.org/packages/Skyline.DataMiner.XmlSchemas) NuGet package each time Visual Studio starts. If a newer version is available, DIS automatically downloads the updated schemas and installs them into Visual Studio (e.g. `C:\Program Files\Microsoft Visual Studio\18\Professional\Xml\Schemas`). The outcome — whether a new version was installed or the current version is already up to date — is reported in the DIS output window.
+- When this checkbox is enabled, DIS will check for a newer version of the [Skyline.DataMiner.XmlSchemas](https://www.nuget.org/packages/Skyline.DataMiner.XmlSchemas) NuGet package each time Visual Studio starts. If a newer version is available, DIS will automatically download the updated schemas and install them into Visual Studio (e.g. `C:\Program Files\Microsoft Visual Studio\18\Professional\Xml\Schemas`). The outcome — whether a new version was installed or the current version is already up to date — will be reported in the DIS output window.
 
-- When this checkbox is disabled, DIS installs the schemas that are bundled with DIS, as long as it detects that the currently installed schemas differ from the bundled ones.
+- When this checkbox is disabled, DIS will install the schemas that are bundled with DIS, as long as it detects that the currently installed schemas differ from the bundled ones.
 
 ## Info
 

--- a/release-notes/DIS/DIS_3.1.md
+++ b/release-notes/DIS/DIS_3.1.md
@@ -62,7 +62,7 @@ When you click the *Publish* button for an automation script that is part of a s
 
 This behavior is aligned with how DataMiner handles solution-package scripts. Scripts sharing the same `DataMinerSolutionId` have their NuGet dependencies unified (the highest referenced version is used across all scripts), and run in their own dedicated process in DataMiner.
 
-#### Updated DIS dependencies
+#### Updated NuGet package dependencies
 
 - [Skyline.DataMiner.CICD.Validators.Common](https://www.nuget.org/packages/Skyline.DataMiner.CICD.Validators.Common) version 3.4.0
 - [Skyline.DataMiner.CICD.Validators.Protocol](https://www.nuget.org/packages/Skyline.DataMiner.CICD.Validators.Protocol) version 3.4.0

--- a/release-notes/DIS/DIS_3.1.md
+++ b/release-notes/DIS/DIS_3.1.md
@@ -62,7 +62,7 @@ When you click the *Publish* button for an automation script that is part of a s
 
 This behavior is aligned with how DataMiner handles solution-package scripts. Scripts sharing the same `DataMinerSolutionId` have their NuGet dependencies unified (the highest referenced version is used across all scripts), and run in their own dedicated process in DataMiner.
 
-#### Updated NuGet package dependencies
+#### Updated DIS dependencies
 
 - [Skyline.DataMiner.CICD.Validators.Common](https://www.nuget.org/packages/Skyline.DataMiner.CICD.Validators.Common) version 3.4.0
 - [Skyline.DataMiner.CICD.Validators.Protocol](https://www.nuget.org/packages/Skyline.DataMiner.CICD.Validators.Protocol) version 3.4.0


### PR DESCRIPTION
## DIS 3.1.23 release notes documentation update

This PR adds and updates documentation for the DIS 3.1.23 release.

### Inserted release note version

**DIS 3.1.23**

### Updated files

- **`develop/TOOLS/DIS/Reference/DIS_settings.md`** — Added a new **XML Schemas** section documenting the new *XML Schemas* tab in DIS settings (introduced in DIS 3.1.23, ID 45476). This tab controls whether DIS automatically downloads and installs updated XML schemas from the `Skyline.DataMiner.XmlSchemas` NuGet package at Visual Studio startup.

- **`develop/TOOLS/DIS/Editors/XML_editor.md`** — Updated the **Publish** section to document the new solution-package publish behavior (introduced in DIS 3.1.23, ID 45695): when publishing an Automation script that belongs to a solution package (i.e., its `.csproj` contains a `DataMinerSolutionId`), DIS now publishes the entire solution package and shows a confirmation or selection popup accordingly.

### New TOOLS/DIS pages added

No new pages were added. Existing pages were updated to reflect newly introduced functionality.




> Generated by [📝 DIS Release Notes Markdown Generator](https://github.com/SkylineCommunications/DIS/actions/runs/30163135270) · sonnet46 50.6 AIC · ⌖ 7.75 AIC · ⊞ 5.9K · [◷](https://github.com/search?q=repo%3ASkylineCommunications%2Fdataminer-docs+%22gh-aw-workflow-id%3A+dis-release-notes-markdown%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: DIS Release Notes Markdown Generator, engine: copilot, version: 1.0.73, model: claude-sonnet-4.6, id: 30163135270, workflow_id: dis-release-notes-markdown, run: https://github.com/SkylineCommunications/DIS/actions/runs/30163135270 -->

<!-- gh-aw-workflow-id: dis-release-notes-markdown -->
<!-- gh-aw-workflow-call-id: SkylineCommunications/DIS/dis-release-notes-markdown -->