### PR TITLE
[ai] DIS Release Notes 3.1.24 Docs Updates

### DIFF
--- a/release-notes/DIS/DIS_3.1.md
+++ b/release-notes/DIS/DIS_3.1.md
@@ -8,15 +8,21 @@ uid: DIS_3.1
 
 ### New features
 
-#### GetColumn/GetColumns/SetColumns snippets will now use ProtocolExtension methods [ID 45875]
+#### C# snippets updated to use ProtocolExtension methods [ID 45875]
 
-The following C# snippets have been updated. They will now use the extension methods of the [Skyline.DataMiner.Utils.Protocol.Extension](https://www.nuget.org/packages/Skyline.DataMiner.Utils.Protocol.Extension) NuGet package:
+The following C# snippets have been updated to use the extension methods of the [Skyline.DataMiner.Utils.Protocol.Extension](https://www.nuget.org/packages/Skyline.DataMiner.Utils.Protocol.Extension) NuGet package:
 
 - GetColumn
 - GetColumns
 - SetColumns
 
-#### Updated DIS dependencies
+#### DIS no longer freezes during startup when initializing the NuGet helper [ID 45999]
+
+When opening a Visual Studio solution, DIS could in some cases freeze while instantiating the NuGetHelper.
+
+DIS has been updated so that part of the initialization now happens asynchronously, preventing the freeze.
+
+#### Updated NuGet package dependencies
 
 - [Skyline.DataMiner.CICD.DMProtocol](https://www.nuget.org/packages/Skyline.DataMiner.CICD.DMProtocol) version 6.1.0
 - [Skyline.DataMiner.CICD.Parsers.Common](https://www.nuget.org/packages/Skyline.DataMiner.CICD.Parsers.Common) version 6.1.0
@@ -27,17 +33,11 @@ The following C# snippets have been updated. They will now use the extension met
 
 ### Fixes
 
-#### Menu items have been updated in order to avoid possible deadlocks [ID 45898]
+#### Menu items updated to avoid possible deadlocks [ID 45898]
 
-The implementation of the *Copy protocol to clipboard* context menu item and the *Save compiled protocol* menu item has been updated. It will now work similar to the "publish" flow in order to avoid deadlocks.
+The implementation of the *Copy protocol to clipboard* context menu item and the *Save compiled protocol* menu item has been updated to work similarly to the publish flow, in order to avoid deadlocks.
 
-Also, the implementation of the logic that retrieves the C# projects in the solution has been updated in order to avoid deadlocks.
-
-#### DIS could freeze while instantiating the NuGetHelper [ID 45999]
-
-When opening a Visual Studio solution, in some cases, DIS could freeze while instantiating the NuGetHelper.
-
-From now on, the initialization of the NuGetHelper will partially happen asynchronously.
+Additionally, the implementation of the logic that retrieves the C# projects in the solution has been updated to avoid deadlocks.
 
 ## DIS 3.1.23
 


### PR DESCRIPTION
## DIS Release Notes 3.1.24

This PR updates the DIS 3.1 release notes file with the corrected content for version **3.1.24**.

### Changes made

The existing DIS 3.1.24 section in `release-notes/DIS/DIS_3.1.md` has been updated with the following corrections and improvements:

- **ID 45999** was incorrectly classified as a *Fix* in the previous version of the file. It is a `New Feature/Enhancement` and has been moved to the *New features* section.
- NuGet package dependencies have been placed under the **Updated NuGet package dependencies** subsection in the *New features* section (previously listed under "Updated DIS dependencies").
- Titles and descriptions have been improved for clarity, conciseness, and consistency with the DataMiner Docs house style.

### Updated files

- `release-notes/DIS/DIS_3.1.md` — Updated the DIS 3.1.24 release notes section.

### New TOOLS/DIS pages

No new TOOLS/DIS pages were added. The changes in this release (snippet method updates and async NuGetHelper initialization) are implementation-level improvements that do not require new or updated TOOLS/DIS documentation pages.




> Generated by [📝 DIS Release Notes Markdown Generator](https://github.com/SkylineCommunications/DIS/actions/runs/30239821952) · sonnet46 33.2 AIC · ⌖ 7.53 AIC · ⊞ 5.9K · [◷](https://github.com/search?q=repo%3ASkylineCommunications%2Fdataminer-docs+%22gh-aw-workflow-id%3A+dis-release-notes-markdown%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: DIS Release Notes Markdown Generator, engine: copilot, version: 1.0.73, model: claude-sonnet-4.6, id: 30239821952, workflow_id: dis-release-notes-markdown, run: https://github.com/SkylineCommunications/DIS/actions/runs/30239821952 -->

<!-- gh-aw-workflow-id: dis-release-notes-markdown -->
<!-- gh-aw-workflow-call-id: SkylineCommunications/DIS/dis-release-notes-markdown -->