### PR TITLE
Update MediaOps Plan 1.6.2 release notes

### DIFF
--- a/release-notes/MediaOps/MediaOps_Live/MediaOps_Live_1.1.0.md
+++ b/release-notes/MediaOps/MediaOps_Live/MediaOps_Live_1.1.0.md
@@ -4,9 +4,6 @@ uid: MediaOps_Live_1.1.0
 
 # MediaOps Live 1.1.0
 
-> [!IMPORTANT]
-> We are still working on this release. Release notes may still be modified, added, or moved to a later release. Check back soon for updates!
-
 ## New features
 
 #### Control Surface: Direct access to job details [ID 45745]

--- a/release-notes/MediaOps/MediaOps_Plan/MediaOps_Plan_1.6.2.md
+++ b/release-notes/MediaOps/MediaOps_Plan/MediaOps_Plan_1.6.2.md
@@ -2,10 +2,7 @@
 uid: MediaOps_Plan_1.6.2
 ---
 
-# MediaOps Plan 1.6.2 - Preview
-
-> [!IMPORTANT]
-> We are still working on this release. Release notes may still be modified, added, or moved to a later release. Check back soon for updates!
+# MediaOps Plan 1.6.2
 
 > [!NOTE]
 > This version requires:

--- a/release-notes/MediaOps/toc.yml
+++ b/release-notes/MediaOps/toc.yml
@@ -11,7 +11,7 @@ items:
     items:
     - name: MediaOps Plan 2.0.0 - Preview
       topicUid: MediaOps_Plan_2.0.0
-    - name: MediaOps Plan 1.6.2 - Preview
+    - name: MediaOps Plan 1.6.2
       topicUid: MediaOps_Plan_1.6.2
     - name: MediaOps Plan 1.6.1
       topicUid: MediaOps_Plan_1.6.1


### PR DESCRIPTION
Removed preview notice and updated version header.