### PR TITLE
Update Sync Check docs to match SLC-AS-SyncCheck v1.0.1

### DIFF
--- a/dataminer/DataMiner_Tools/Sync_Check.md
+++ b/dataminer/DataMiner_Tools/Sync_Check.md
@@ -10,21 +10,32 @@ To verify the synchronization of element and service files across a DataMiner Sy
 
 This is especially intended for troubleshooting in large clusters (which can include Failover Agents) in case there are errors related to duplicate service or element IDs, errors when new services are created that reuse the name of old services, or synchronization errors related to services or elements;
 
-You can download this script from [DataMiner Dojo](https://community.dataminer.services/download/script_synccheck/).
+You can get this script from the [DataMiner Catalog](https://catalog.dataminer.services/details/151f362f-673a-4674-b678-f1f494b1713a).
 
 ## Running the Sync Check script
 
 To use this script:
 
-1. Extract the zip file you downloaded.
+1. Install the script package on a DMA in the DataMiner System you are troubleshooting, via the DataMiner Catalog. Once installed, the script will become available in the *Skyline-TechSupport* folder in the Automation module.
 
-1. Import the script *Script_SyncCheck.xml* on a DMA in the DataMiner System you are troubleshooting. The script will become available in the *Skyline-TechSupport* folder in the Automation module.
+1. Run the script in the Automation module and specify a username and password. These credentials will be used to access the different Agents in the DMS via file shares.
 
-1. Run the script in the Automation module and specify a username and password. These credentials will be used to access the different Agents in the DMS via file shares
-
-1. When the script has run, check its output in the file *SyncInfo.txt*, which you can find in the following folder on the DMA: `C:\Skyline_Data\SyncInfo`.
+1. When the script has run, check its output in the generated per-run report grouped by DMA, which you can find in the following folder on the DMA: `C:\Skyline_Data\SyncCheckResults\`. The file name uses the format `SyncCheckResult_<yyyyMMdd>_<HHmm>.txt`, based on server-local time.
 
 Note that to be able to run the script, file share access to all IP addresses in the cluster is required.
+
+### Username formats
+
+The **Username** parameter supports the following formats:
+
+- `alice` (local account)
+- `.\alice` (explicit local account)
+- `MYDOMAIN\alice` (Active Directory, NETBIOS down-level)
+- `alice@corp.example.com` (Active Directory, UPN)
+
+### Prerequisites
+
+- A Windows account with local Administrator rights on the remote DMAs. The script accesses the `C:\Skyline DataMiner` folder through the administrative UNC share `\\<DMA-IP>\c$`.
 
 ## What is included in the sync check?
 
@@ -64,9 +75,11 @@ The script checks the following things:
 
   - Inconsistent folder name (different name or capitalization)
 
-## SyncInfo output file
+  - Orphaned remote-service references (source service no longer exists)
 
-The SyncInfo file consists of an ERRORS section, a DEBUG LOGGING section (listing all the DMAs in the cluster), and the following sections for each DMA:
+## Output report
+
+The generated report file consists of an ERRORS section, a DEBUG LOGGING section (listing all the DMAs found in the cluster, including which agent acts as Main/Backup and the resolved connection identity used for each), and the following sections for each DMA:
 
 - Elements INFO
 
@@ -78,26 +91,15 @@ The SyncInfo file consists of an ERRORS section, a DEBUG LOGGING section (listin
 
 - Remote Service Folder Check
 
-> [!TIP]
-> You can download an example of the output from [DataMiner Dojo](https://community.dataminer.services/download/syncinfo3/).
-
 ### Error examples
 
 - `No ERRORS`
 
   This is the expected message when there are no errors.
 
-- `RetrieveInfoFromFolders Exception`
+- `RetrieveInfoFromFolders Exception -> <ExceptionType>: <Message>`
 
-  This error will be shown for each DataMiner Failover pair where the file share is not configured:
-
-  ```txt
-  RetrieveInfoFromFolders Exception: System.ComponentModel.Win32Exception (0x80004005): The network path was not found
-     at Skyline.Automation.Testing.NetworkShareAccesser.ConnectToShare(String remoteUnc, String username, String password, Boolean promptUser)
-     at Skyline.Automation.Testing.NetworkShareAccesser..ctor(String remoteComputerName, String userName, String password)
-     at Skyline.Automation.Testing.NetworkShareAccesser.Access(String remoteComputerName, String domainOrComuterName, String userName, String password)
-     at Skyline.Automation.Testing.DMSHelper2.DMAFolderHelper.RetrieveInfoFromFolders(ScriptData scriptdata, Dictionary`2 dictAllElements, Dictionary`2 dictAllServices)
-  ```
+  This error will be shown for each DataMiner Failover pair where folder retrieval fails, for example when the file share is not configured. The error is logged as a single compact line; the full exception stack trace is no longer included in the report.
 
 - `Inconsistent FolderName`
 
@@ -114,18 +116,22 @@ The SyncInfo file consists of an ERRORS section, a DEBUG LOGGING section (listin
   This error is shown when there are two services with the same ID, for example the services *Service_name_A* and *Service_name_B* here:
 
   ```txt
-  Duplicate Entries in Main Service folder for ID <DMA_ID>/<service_ID>:Service_name_A, Service_name_B
+  Duplicate Entries in Backup Service folder for ID <DMA_ID>/<service_ID>:Service_name_A, Service_name_B
   ```
+
+- `Orphaned remote-service references (source service no longer exists):`
+
+  This is shown when a local remote-service reference folder exists, but the source service it points to no longer exists on the origin DMA. This differs from `Missing services`, which indicates a remote-service reference is expected but not found locally.
 
 ### Other examples
 
-In the *Elements INFO*, *Service INFO*, *ELEMENT FOLDER INFO*, *Service FOLDER INFO*, and *Remote Service Folder Check* sections, if everything is OK, the message `<IP_DMA1_Online> And <IP_DMA1_Offline> Are In Sync!` will be displayed.
+In the *Elements INFO*, *Service INFO*, *ELEMENT FOLDER INFO*, *Service FOLDER INFO*, and *Remote Service Folder Check* sections, if everything is OK, a message such as `<IP_DMA1> And <IP_DMA2> Are In Sync!` or `The remote services for DMA <DMA_ID> are in Sync!` will be displayed.
 
 For example:
 
 ```txt
 #################################
-####Elements INFO FOR DMA 123
+####Elements INFO FOR DMA 123 'DMA_A'
 #################################
 
 INFO: Compared based on DMAID, ID, protocol, version and Name
@@ -133,7 +139,7 @@ SLNet And Folder Structure Are In Sync!
 ---------------------------------
 
 #################################
-####Service INFO FOR DMA 123
+####Service INFO FOR DMA 123 'DMA_A'
 #################################
 
 INFO: Compared based on DMAID, ID, protocol, version and Name
@@ -141,7 +147,7 @@ SLNet And Folder Structure Are In Sync!
 ---------------------------------
 
 #################################
-####ELEMENT FOLDER INFO FOR DMA 123
+####ELEMENT FOLDER INFO FOR DMA 123 (FO Pair: 'DMA_A' <-> 'DMA_B')
 #################################
 
 INFO: Compared based on DMAID, ELID, Name, Protocol, Version and Properties
@@ -149,7 +155,7 @@ INFO: Compared based on DMAID, ELID, Name, Protocol, Version and Properties
 ---------------------------------
 
 #################################
-####Service FOLDER INFO FOR DMA 123
+####Service FOLDER INFO FOR DMA 123 (FO Pair: 'DMA_A' <-> 'DMA_B')
 #################################
 
 INFO: Compared based on DMAID, ID, Name and Properties
@@ -157,25 +163,24 @@ INFO: Compared based on DMAID, ID, Name and Properties
 ---------------------------------
 
 #################################
-####Remote Service Folder Check for DMA 123
+####Remote Service Folder Check for DMA 123 (FO Pair: 'DMA_A' <-> 'DMA_B')
 #################################
 
-INFO: MAKE SURE THE MAIN BACKUP IS IN SYNC FIRST!
+INFO: MAKE SURE MAIN AND BACKUP ARE IN SYNC FIRST!
 The remote services for DMA 123 are in Sync!
 ---------------------------------
 ```
 
-If something is missing on one of the DMAs, a message starting with `Missing` will be displayed. For example, if a service *Service_name_A* is missing on the online DMA with ID 123 compared to the offline DMA:
+If something is missing on one of the DMAs, a message starting with `Missing` will be displayed, scoped to the relevant agent's role. For example, if a service *Service_name_A* is missing on the Backup DMA compared to the Main DMA:
 
 ```txt
 #################################
-####Service FOLDER INFO FOR DMA 123
+####Service FOLDER INFO FOR DMA 123 (FO Pair: 'DMA_A' <-> 'DMA_B')
 #################################
 
 INFO: Compared based on DMAID, ID, Name and Properties
 
-------<IP_DMA1_Offline>------
+------ Missing on 'DMA_B' => <IP_DMA1_Backup> (Backup) ------
 
-Missing: 
 Service_name_A
 ```

--- a/dataminer/DataMiner_Tools/Sync_Check.md
+++ b/dataminer/DataMiner_Tools/Sync_Check.md
@@ -8,34 +8,50 @@ uid: Sync_Check
 
 To verify the synchronization of element and service files across a DataMiner System, you can use the "Sync Check" automation script.
 
-This is especially intended for troubleshooting in large clusters (which can include Failover Agents) in case there are errors related to duplicate service or element IDs, errors when new services are created that reuse the name of old services, or synchronization errors related to services or elements;
+This is especially intended for troubleshooting in large clusters (which can include Failover Agents) in case there are errors related to duplicate service or element IDs, errors when new services are created that reuse the name of old services, or synchronization errors related to services or elements.
 
-You can get this script from the [DataMiner Catalog](https://catalog.dataminer.services/details/151f362f-673a-4674-b678-f1f494b1713a).
+You can download this script from the [DataMiner Catalog](https://catalog.dataminer.services/details/151f362f-673a-4674-b678-f1f494b1713a).
 
-## Running the Sync Check script
+## Prerequisites
 
-To use this script:
+To run the script, you need:
 
-1. Install the script package on a DMA in the DataMiner System you are troubleshooting, via the DataMiner Catalog. Once installed, the script will become available in the *Skyline-TechSupport* folder in the Automation module.
+- A Windows account with local Administrator rights on the remote DMAs.
 
-1. Run the script in the Automation module and specify a username and password. These credentials will be used to access the different Agents in the DMS via file shares.
+  The script accesses the `C:\Skyline DataMiner` folder through the administrative UNC share `\\<DMA-IP>\c$`.
 
-1. When the script has run, check its output in the generated per-run report grouped by DMA, which you can find in the following folder on the DMA: `C:\Skyline_Data\SyncCheckResults\`. The file name uses the format `SyncCheckResult_<yyyyMMdd>_<HHmm>.txt`, based on server-local time.
+## Deploying the SLC-AS-SyncCheck package from the Catalog
+
+1. Look up the [*SLC-AS-SyncCheck* package](https://catalog.dataminer.services/details/151f362f-673a-4674-b678-f1f494b1713a) in the Catalog.
+
+1. Click the *Deploy* button.
+
+1. Select the DMA you want to troubleshoot and confirm the deployment.
+
+   Once the package has been installed, the script is available in the *Skyline-TechSupport* folder in the Automation module.
+
+## Running the SLC-AS-SyncCheck automation script
+
+1. In the Automation module, select the *SLC-AS-SyncCheck* script and click *Execute*.
+
+1. Specify a username and password. These credentials will be used to access the different Agents in the DMS via file shares.
+
+   Supported username formats:
+
+   - `alice` (local account)
+   - `.\alice` (explicit local account)
+   - `MYDOMAIN\alice` (Active Directory, NETBIOS down-level)
+   - `alice@corp.example.com` (Active Directory, UPN)
+
+1. Click *Execute now*.
+
+1. When the script has run, check its output in the generated per-run report grouped by DMA.
+
+   The report is generated on the DMA in: `C:\Skyline_Data\SyncCheckResults\`.
+
+   Report files use the following naming format: `SyncCheckResult_<yyyyMMdd>_<HHmm>.txt`. This timestamp is based on the local time of the server on which the report is generated.
 
 Note that to be able to run the script, file share access to all IP addresses in the cluster is required.
-
-### Username formats
-
-The **Username** parameter supports the following formats:
-
-- `alice` (local account)
-- `.\alice` (explicit local account)
-- `MYDOMAIN\alice` (Active Directory, NETBIOS down-level)
-- `alice@corp.example.com` (Active Directory, UPN)
-
-### Prerequisites
-
-- A Windows account with local Administrator rights on the remote DMAs. The script accesses the `C:\Skyline DataMiner` folder through the administrative UNC share `\\<DMA-IP>\c$`.
 
 ## What is included in the sync check?
 
@@ -75,11 +91,11 @@ The script checks the following things:
 
   - Inconsistent folder name (different name or capitalization)
 
-  - Orphaned remote-service references (source service no longer exists)
+  - Orphaned remote-service references (where the source service no longer exists)
 
 ## Output report
 
-The generated report file consists of an ERRORS section, a DEBUG LOGGING section (listing all the DMAs found in the cluster, including which agent acts as Main/Backup and the resolved connection identity used for each), and the following sections for each DMA:
+The generated report file consists of an ERRORS section, a DEBUG LOGGING section (listing all DMAs found in the cluster, including which Agent acts as Main or Backup and the resolved connection identity used for each Agent), and the following sections for each DMA:
 
 - Elements INFO
 
@@ -99,7 +115,9 @@ The generated report file consists of an ERRORS section, a DEBUG LOGGING section
 
 - `RetrieveInfoFromFolders Exception -> <ExceptionType>: <Message>`
 
-  This error will be shown for each DataMiner Failover pair where folder retrieval fails, for example when the file share is not configured. The error is logged as a single compact line; the full exception stack trace is no longer included in the report.
+  This error is shown when folder retrieval fails for a DataMiner Failover pair, for example when the file share is not configured.
+
+  The report only includes a compact error message. The full exception stack trace is no longer included.
 
 - `Inconsistent FolderName`
 
@@ -121,7 +139,9 @@ The generated report file consists of an ERRORS section, a DEBUG LOGGING section
 
 - `Orphaned remote-service references (source service no longer exists):`
 
-  This is shown when a local remote-service reference folder exists, but the source service it points to no longer exists on the origin DMA. This differs from `Missing services`, which indicates a remote-service reference is expected but not found locally.
+  This error is shown when a local remote-service reference folder exists, but the source service it references no longer exists on the source DMA.
+
+  This differs from `Missing services`, which indicates that a remote-service reference is expected but not found locally.
 
 ### Other examples
 
@@ -171,7 +191,7 @@ The remote services for DMA 123 are in Sync!
 ---------------------------------
 ```
 
-If something is missing on one of the DMAs, a message starting with `Missing` will be displayed, scoped to the relevant agent's role. For example, if a service *Service_name_A* is missing on the Backup DMA compared to the Main DMA:
+If something is missing on one of the DMAs, a message starting with `Missing` will be displayed, scoped to the relevant Agent's role. For example, if a service *Service_name_A* is missing on the backup DMA compared to the main DMA:
 
 ```txt
 #################################


### PR DESCRIPTION
Ref: https://github.com/SkylineCommunications/SLC-AS-SyncCheck

- Replace Dojo download link with DataMiner Catalog install instructions
- Update output path/filename to SyncCheckResult_<yyyyMMdd>_<HHmm>.txt under C:\Skyline_Data\SyncCheckResults\
- Document supported Username formats (local, NETBIOS, UPN)
- Add Prerequisites section (local admin + admin share access)
- Add Orphaned remote-service references check and example
- Correct RetrieveInfoFromFolders exception example to the current compact one-line format (no stack trace)
- Fix Duplicate Entries example (Backup, not Main, service folder)
- Remove unused Sync Info Folder Check section (not active by default in the script)
- Refresh sample output blocks to match current headers (ComputerName, FO pair, Main/Backup wording)
- Align wording with SLC-AS-SyncCheck/CatalogInformation/README.md