### PR TITLE
RN 45843

### DIFF
--- a/dataminer/Functions/Spectrum_Analysis/Working_with_Spectrum_Analyzer_elements/Using_Spectrum_Analysis_presets.md
+++ b/dataminer/Functions/Spectrum_Analysis/Working_with_Spectrum_Analyzer_elements/Using_Spectrum_Analysis_presets.md
@@ -12,7 +12,7 @@ Spectrum Analysis presets can be used to reload settings, to reload a set of mar
 
 - Display settings, including the trace visibility
 
-- A reference trace (including reference trace markers, from DataMiner 10.5.0 [CU18]/10.6.0 [CU6]/10.6.9 onwards<!--RN 45843-->)
+- A reference trace
 
 - Marker positions
 

--- a/dataminer/Functions/Spectrum_Analysis/Working_with_Spectrum_Analyzer_elements/Using_Spectrum_Analysis_presets.md
+++ b/dataminer/Functions/Spectrum_Analysis/Working_with_Spectrum_Analyzer_elements/Using_Spectrum_Analysis_presets.md
@@ -12,7 +12,7 @@ Spectrum Analysis presets can be used to reload settings, to reload a set of mar
 
 - Display settings, including the trace visibility
 
-- A reference trace
+- A reference trace (including reference trace markers, from DataMiner 10.5.0 [CU18]/10.6.0 [CU6]/10.6.9 onwards<!--RN 45843-->)
 
 - Marker positions
 
@@ -66,6 +66,7 @@ To load a preset in DataMiner Cube:
 >
 > - You can change the reference trace color in the *trace* tab of the ribbon, by clicking *Color* > *Reference trace*, and selecting the new color.
 > - To hide the reference trace, in the *trace* tab of the ribbon, clear the selection from *Show reference*.
+> - From DataMiner 10.5.0 [CU18]/10.6.0 [CU6]/10.6.9 onwards<!--RN 45843-->, reference trace markers are also restored when a preset containing a reference trace is loaded.
 
 ## Creating new presets
 

--- a/dataminer/Functions/Spectrum_Analysis/Working_with_Spectrum_Analyzer_elements/Viewing_spectrum_analyzer_traces.md
+++ b/dataminer/Functions/Spectrum_Analysis/Working_with_Spectrum_Analyzer_elements/Viewing_spectrum_analyzer_traces.md
@@ -161,6 +161,27 @@ It is possible to display the minimum and/or maximum hold of the trace you are c
 > [!NOTE]
 > When you are viewing multiple measurement points at the same time, these options are not available.
 
+## Displaying the reference trace
+
+From DataMiner 10.5.0 [CU18]/10.6.0 [CU6]/10.6.9 onwards<!--RN 45843-->, you can save the current trace as a reference trace and compare subsequent measurements against it.
+
+To do so:
+
+1. On the spectrum analyzer card, go to the *trace* tab of the ribbon.
+
+1. Click *Set reference* to save the current trace as the reference trace.
+
+The reference trace is displayed under *Traces* in the info pane. It remains available until it is reset or replaced by setting a new reference trace.
+
+- To remove the saved reference trace, in the *trace* tab, click *Reset reference*.
+
+- To hide the reference trace, in the *trace* tab, clear the selection from *Show reference*.
+
+- To change the color of the reference trace, in the *Colors* section of the *trace* tab, select a different color in the *Reference trace* dropdown list.
+
+> [!NOTE]
+> Prior to DataMiner 10.5.0 [CU18]/10.6.0 [CU6]/10.6.9, a reference trace can only be loaded from a preset. See [Using Spectrum Analysis presets](xref:Using_Spectrum_Analysis_presets).
+
 ## Displaying the average trace
 
 It is possible to display the average trace, next to or instead of the actual real-time trace.

--- a/dataminer/Functions/Spectrum_Analysis/Working_with_Spectrum_Analyzer_elements/Working_with_markers.md
+++ b/dataminer/Functions/Spectrum_Analysis/Working_with_Spectrum_Analyzer_elements/Working_with_markers.md
@@ -37,7 +37,9 @@ Different modes are available:
    - **Lock to trace**: Locks the marker to the trace.
 
    > [!NOTE]
-   > You can also quickly change an existing marker into a reference marker or noise marker by right-clicking the marker and selecting *Reference marker* or *Noise marker* respectively.
+   >
+   > - You can also quickly change an existing marker into a reference marker or noise marker by right-clicking the marker and selecting *Reference marker* or *Noise marker* respectively.
+   > - From DataMiner 10.5.0 [CU18]/10.6.0 [CU6]/10.6.9 onwards<!--RN 45843-->, markers can also be placed on the reference trace. When you add a marker and move it to the reference trace, the marker takes the color of the reference trace.
 
 1. Click *OK* to save your changes and close the pop-up window.
 


### PR DESCRIPTION
@RobbeBultynck, I'm not entirely sure how to document release note 45843. According to the release note, reference traces and their makers can now be used and saved in presets, but this was already listed on the [*Using Spectrum Analysis presets* page](https://docs.dataminer.services/dataminer/Functions/Spectrum_Analysis/Working_with_Spectrum_Analyzer_elements/Using_Spectrum_Analysis_presets.html#:~:text=the%20trace%20visibility-,A%20reference%20trace,-Marker%20positions). Reference trace markers aren't specifically mentioned there, so for now I've added those, but maybe this falls under "Marker positions", which is mentioned in the list. Let me know if I should remove this again.

Could you tell me what has concretely changed for the user? What will they notice in the Spectrum Analysis UI that wasn't possible before?

Are there any other pages in the [Spectrum Analysis documentation](https://docs.dataminer.services/dataminer/Functions/Spectrum_Analysis/Working_with_Spectrum_Analyzer_elements/Spectrum_analyzer_cards.html) that need updating because of RN 45843?