### PR TITLE
Add 10.6.10/10.6.0 CU7/10.5.0 CU19 RNs pages

### DIFF
--- a/release-notes/Cube/Cube_Feature_Release_10.6/Cube_10.6.10.md
+++ b/release-notes/Cube/Cube_Feature_Release_10.6/Cube_10.6.10.md
@@ -1,0 +1,31 @@
+---
+uid: Cube_Feature_Release_10.6.10
+---
+
+# DataMiner Cube Feature Release 10.6.10 – Preview
+
+> [!IMPORTANT]
+> We are still working on this release. Some release notes may still be modified or moved to a later release. Check back soon for updates!
+
+This Feature Release of the DataMiner Cube client application contains the same new features, enhancements, and fixes as DataMiner Cube Main Release 10.6.0 [CU7].
+
+> [!TIP]
+>
+> - For release notes related to the general DataMiner release, see [General Feature Release 10.6.10](xref:General_Feature_Release_10.6.10).
+> - For release notes related to the DataMiner web applications, see [DataMiner web apps Feature Release 10.6.10](xref:Web_apps_Feature_Release_10.6.10).
+
+## Highlights
+
+*No highlights have been selected yet.*
+
+## New features
+
+*This release does not contain any new features yet.*
+
+## Changes
+
+*This release does not contain any enhancements yet.*
+
+### Fixes
+
+*This release does not contain any fixes yet.*

--- a/release-notes/Cube/Cube_Main_Release_10.5/Cube_10.5.0_CU19.md
+++ b/release-notes/Cube/Cube_Main_Release_10.5/Cube_10.5.0_CU19.md
@@ -1,0 +1,15 @@
+---
+uid: Cube_Main_Release_10.5.0_CU19
+---
+
+# DataMiner Cube Main Release 10.5.0 CU19 - Preview
+
+> [!IMPORTANT]
+> We are still working on this release. Some release notes may still be modified or moved to a later release. Check back soon for updates!
+
+This Main Release of the DataMiner Cube client application contains all new features, enhancements and fixes that were added to [DataMiner Cube Feature Release 10.6.10](xref:Cube_Feature_Release_10.6.10).
+
+> [!TIP]
+>
+> - For release notes related to the general DataMiner release, see [General Main Release 10.5.0 CU19](xref:General_Main_Release_10.5.0_CU19).
+> - For release notes related to the DataMiner web applications, see [DataMiner web apps Main Release 10.5.0 CU19](xref:Web_apps_Main_Release_10.5.0_CU19).

--- a/release-notes/Cube/Cube_Main_Release_10.6/Cube_10.6.0_CU7.md
+++ b/release-notes/Cube/Cube_Main_Release_10.6/Cube_10.6.0_CU7.md
@@ -1,0 +1,15 @@
+---
+uid: Cube_Main_Release_10.6.0_CU7
+---
+
+# DataMiner Cube Main Release 10.6.0 CU7 - Preview
+
+> [!IMPORTANT]
+> We are still working on this release. Some release notes may still be modified or moved to a later release. Check back soon for updates!
+
+This Main Release of the DataMiner Cube client application contains all new features, enhancements and fixes that were added to [DataMiner Cube Feature Release 10.6.10](xref:Cube_Feature_Release_10.6.10).
+
+> [!TIP]
+>
+> - For release notes related to the general DataMiner release, see [General Main Release 10.6.0 CU7](xref:General_Main_Release_10.6.0_CU7).
+> - For release notes related to the DataMiner web applications, see [DataMiner web apps Main Release 10.6.0 CU7](xref:Web_apps_Main_Release_10.6.0_CU7).

--- a/release-notes/Cube/toc.yml
+++ b/release-notes/Cube/toc.yml
@@ -23,8 +23,12 @@ items:
             topicUid: Cube_Main_Release_10.6.0_CU5
           - name: DataMiner Cube Main Release 10.6.0 CU6 - Preview
             topicUid: Cube_Main_Release_10.6.0_CU6
+          - name: DataMiner Cube Main Release 10.6.0 CU7 - Preview
+            topicUid: Cube_Main_Release_10.6.0_CU7
       - name: Feature Release
         items:
+          - name: DataMiner Cube Feature Release 10.6.10 - Preview
+            topicUid: Cube_Feature_Release_10.6.10
           - name: DataMiner Cube Feature Release 10.6.9 - Preview
             topicUid: Cube_Feature_Release_10.6.9
           - name: DataMiner Cube Feature Release 10.6.8
@@ -93,6 +97,8 @@ items:
             topicUid: Cube_Main_Release_10.5.0_CU17
           - name: DataMiner Cube Main Release 10.5.0 CU18 - Preview
             topicUid: Cube_Main_Release_10.5.0_CU18
+          - name: DataMiner Cube Main Release 10.5.0 CU19 - Preview
+            topicUid: Cube_Main_Release_10.5.0_CU19
       - name: Feature Release
         items:
           - name: DataMiner Cube Feature Release 10.5.12

--- a/release-notes/General/General_Feature_Release_10.6/General_Feature_Release_10.6.10.md
+++ b/release-notes/General/General_Feature_Release_10.6/General_Feature_Release_10.6.10.md
@@ -1,0 +1,47 @@
+---
+uid: General_Feature_Release_10.6.10
+---
+
+# General Feature Release 10.6.10 – Preview
+
+> [!IMPORTANT]
+> We are still working on this release. Some release notes may still be modified or moved to a later release. Check back soon for updates!
+
+> [!TIP]
+>
+> - For release notes related to DataMiner Cube, see [DataMiner Cube Feature Release 10.6.10](xref:Cube_Feature_Release_10.6.10).
+> - For release notes related to the DataMiner web applications, see [DataMiner web apps Feature Release 10.6.10](xref:Web_apps_Feature_Release_10.6.10).
+> - For information on how to upgrade DataMiner, see [Upgrading a DataMiner Agent](xref:Upgrading_a_DataMiner_Agent).
+
+## Prerequisites
+
+Before you upgrade to this DataMiner version:
+
+- Make sure **version 14.44.35211.0** or higher of the **Microsoft Visual C++ x86/x64 redistributables** is installed. Otherwise, the upgrade will trigger an **automatic reboot** of the DMA in order to complete the installation.
+
+  The latest version of the redistributables can be downloaded from the [Microsoft website](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version):
+
+  - [vc_redist.x86.exe](https://aka.ms/vs/17/release/vc_redist.x86.exe)
+  - [vc_redist.x64.exe](https://aka.ms/vs/17/release/vc_redist.x64.exe)
+
+- Make sure all DataMiner Agents in the cluster have been migrated to the BrokerGateway-managed NATS solution.
+
+  For detailed information, see [Migrating to BrokerGateway](xref:BrokerGateway_Migration).
+
+  See also: [DataMiner Systems will now use the BrokerGateway-managed NATS solution by default [ID 43856] [ID 43861] [ID 44035] [ID 44050] [ID 44062]](xref:General_Feature_Release_10.6.1#dataminer-systems-will-now-use-the-brokergateway-managed-nats-solution-by-default-id-43856-id-43861-id-44035-id-44050-id-44062)
+
+## Highlights
+
+*No highlights have been selected yet.*
+
+## New features
+
+*This release does not contain any new features yet.*
+
+## Changes
+
+*This release does not contain any enhancements yet.*
+
+### Fixes
+
+*This release does not contain any fixes yet.*

--- a/release-notes/General/General_Main_Release_10.5/General_Main_Release_10.5.0_CU19.md
+++ b/release-notes/General/General_Main_Release_10.5/General_Main_Release_10.5.0_CU19.md
@@ -1,0 +1,33 @@
+---
+uid: General_Main_Release_10.5.0_CU19
+---
+
+# General Main Release 10.5.0 CU19 - Preview
+
+> [!IMPORTANT]
+> We are still working on this release. Some release notes may still be modified or moved to a later release. Check back soon for updates!
+
+> [!IMPORTANT]
+> Before you upgrade to this DataMiner version:
+>
+> - Make sure the Microsoft **.NET 10** hosting bundle is installed (download the latest Hosting Bundle under ASP.NET Core Runtime from [dotnet.microsoft.com](https://dotnet.microsoft.com/en-us/download/dotnet/10.0)). See also: [DataMiner upgrade: New prerequisite will check whether .NET 10 is installed](xref:General_Main_Release_10.5.0_CU10#dataminer-upgrade-new-prerequisite-will-check-whether-net-10-is-installed-id-44121).
+> - Make sure **version 14.44.35211.0** or higher of the **Microsoft Visual C++ x86/x64 redistributables** is installed. Otherwise, the upgrade will trigger an **automatic reboot** of the DMA in order to complete the installation. The latest version of the redistributables can be downloaded from the [Microsoft website](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version):
+>
+>   - [vc_redist.x86.exe](https://aka.ms/vs/17/release/vc_redist.x86.exe)
+>   - [vc_redist.x64.exe](https://aka.ms/vs/17/release/vc_redist.x64.exe)
+
+> [!TIP]
+>
+> - For release notes related to DataMiner Cube, see [DataMiner Cube 10.5.0 CU19](xref:Cube_Main_Release_10.5.0_CU19).
+> - For release notes related to the DataMiner web applications, see [DataMiner web apps Main Release 10.5.0 CU19](xref:Web_apps_Main_Release_10.5.0_CU19).
+> - For information on how to upgrade DataMiner, see [Upgrading a DataMiner Agent](xref:Upgrading_a_DataMiner_Agent).
+
+## Changes
+
+### Enhancements
+
+*This release does not contain any enhancements yet.*
+
+### Fixes
+
+*This release does not contain any fixes yet.*

--- a/release-notes/General/General_Main_Release_10.6/General_Main_Release_10.6.0_CU7.md
+++ b/release-notes/General/General_Main_Release_10.6/General_Main_Release_10.6.0_CU7.md
@@ -1,0 +1,41 @@
+---
+uid: General_Main_Release_10.6.0_CU7
+---
+
+# General Main Release 10.6.0 CU7 - Preview
+
+> [!IMPORTANT]
+> We are still working on this release. Some release notes may still be modified or moved to a later release. Check back soon for updates!
+
+> [!TIP]
+>
+> - For release notes related to DataMiner Cube, see [DataMiner Cube 10.6.0 CU7](xref:Cube_Main_Release_10.6.0_CU7).
+> - For release notes related to the DataMiner web applications, see [DataMiner web apps Main Release 10.6.0 CU7](xref:Web_apps_Main_Release_10.6.0_CU7).
+> - For information on how to upgrade DataMiner, see [Upgrading a DataMiner Agent](xref:Upgrading_a_DataMiner_Agent).
+
+## Prerequisites
+
+Before you upgrade to this DataMiner version:
+
+- Make sure **version 14.44.35211.0** or higher of the **Microsoft Visual C++ x86/x64 redistributables** is installed. Otherwise, the upgrade will trigger an **automatic reboot** of the DMA in order to complete the installation.
+
+  The latest version of the redistributables can be downloaded from the [Microsoft website](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version):
+
+  - [vc_redist.x86.exe](https://aka.ms/vs/17/release/vc_redist.x86.exe)
+  - [vc_redist.x64.exe](https://aka.ms/vs/17/release/vc_redist.x64.exe)
+
+- Make sure all DataMiner Agents in the cluster have been migrated to the BrokerGateway-managed NATS solution.
+
+  For detailed information, see [Migrating to BrokerGateway](xref:BrokerGateway_Migration).
+
+  See also: [DataMiner Systems will now use the BrokerGateway-managed NATS solution by default [ID 43526] [ID 43856] [ID 43861] [ID 44035] [ID 44050] [ID 44062]](xref:General_Main_Release_10.6.0_changes#dataminer-systems-will-now-use-the-brokergateway-managed-nats-solution-by-default-id-43526-id-43856-id-43861-id-44035-id-44050-id-44062)
+
+## Changes
+
+### Enhancements
+
+*This release does not contain any enhancements yet.*
+
+### Fixes
+
+*This release does not contain any fixes yet.*

--- a/release-notes/General/toc.yml
+++ b/release-notes/General/toc.yml
@@ -33,8 +33,12 @@ items:
             topicUid: General_Main_Release_10.6.0_CU5
           - name: General Main Release 10.6.0 CU6 - Preview
             topicUid: General_Main_Release_10.6.0_CU6
+          - name: General Main Release 10.6.0 CU7 - Preview
+            topicUid: General_Main_Release_10.6.0_CU7
       - name: Feature Release
         items:
+          - name: General Feature Release 10.6.10 - Preview
+            topicUid: General_Feature_Release_10.6.10
           - name: General Feature Release 10.6.9 - Preview
             topicUid: General_Feature_Release_10.6.9
           - name: General Feature Release 10.6.8
@@ -112,6 +116,8 @@ items:
             topicUid: General_Main_Release_10.5.0_CU17
           - name: General Main Release 10.5.0 CU18 - Preview
             topicUid: General_Main_Release_10.5.0_CU18
+          - name: General Main Release 10.5.0 CU19 - Preview
+            topicUid: General_Main_Release_10.5.0_CU19
       - name: Feature Release
         items:
           - name: General Feature Release 10.5.12

--- a/release-notes/Web_apps/Web_apps_Feature_Release_10.6/Web_apps_Feature_Release_10.6.10.md
+++ b/release-notes/Web_apps/Web_apps_Feature_Release_10.6/Web_apps_Feature_Release_10.6.10.md
@@ -1,0 +1,33 @@
+---
+uid: Web_apps_Feature_Release_10.6.10
+---
+
+# DataMiner web apps Feature Release 10.6.10 – Preview
+
+> [!IMPORTANT]
+> We are still working on this release. Some release notes may still be modified or moved to a later release. Check back soon for updates!
+
+This Feature Release of the DataMiner web applications contains the same new features, enhancements, and fixes as DataMiner web apps Main Release 10.6.0 [CU7].
+
+> [!TIP]
+>
+> - For release notes related to the general DataMiner release, see [General Feature Release 10.6.10](xref:General_Feature_Release_10.6.10).
+> - For release notes related to DataMiner Cube, see [DataMiner Cube Feature Release 10.6.10](xref:Cube_Feature_Release_10.6.10).
+
+## Highlights
+
+*No highlights have been selected yet.*
+
+## New features
+
+*This release does not contain any new features yet.*
+
+## Changes
+
+### Enhancements
+
+*This release does not contain any enhancements yet.*
+
+### Fixes
+
+*This release does not contain any fixes yet.*

--- a/release-notes/Web_apps/Web_apps_Main_Release_10.5/Web_apps_Main_Release_10.5.0_CU19.md
+++ b/release-notes/Web_apps/Web_apps_Main_Release_10.5/Web_apps_Main_Release_10.5.0_CU19.md
@@ -1,0 +1,15 @@
+---
+uid: Web_apps_Main_Release_10.5.0_CU19
+---
+
+# DataMiner web apps Main Release 10.5.0 CU19 - Preview
+
+> [!IMPORTANT]
+> We are still working on this release. Some release notes may still be modified or moved to a later release. Check back soon for updates!
+
+This Main Release of the DataMiner web applications contains all new features, enhancements and fixes that were added to [DataMiner web apps Feature Release 10.6.10](xref:Web_apps_Feature_Release_10.6.10).
+
+> [!TIP]
+>
+> - For release notes related to the general DataMiner release, see [General Main Release 10.5.0 CU19](xref:General_Main_Release_10.5.0_CU19).
+> - For release notes related to DataMiner Cube, see [DataMiner Cube Main Release 10.5.0 CU19](xref:Cube_Main_Release_10.5.0_CU19).

--- a/release-notes/Web_apps/Web_apps_Main_Release_10.6/Web_apps_Main_Release_10.6.0_CU7.md
+++ b/release-notes/Web_apps/Web_apps_Main_Release_10.6/Web_apps_Main_Release_10.6.0_CU7.md
@@ -1,0 +1,15 @@
+---
+uid: Web_apps_Main_Release_10.6.0_CU7
+---
+
+# DataMiner web apps Main Release 10.6.0 CU7 – Preview
+
+> [!IMPORTANT]
+> We are still working on this release. Some release notes may still be modified or moved to a later release. Check back soon for updates!
+
+This Main Release of the DataMiner web applications contains all new features, enhancements and fixes that were added to [DataMiner web apps Feature Release 10.6.10](xref:Web_apps_Feature_Release_10.6.10).
+
+> [!TIP]
+>
+> - For release notes related to the general DataMiner release, see [General Main Release 10.6.0 CU7](xref:General_Main_Release_10.6.0_CU7).
+> - For release notes related to DataMiner Cube, see [DataMiner Cube Main Release 10.6.0 CU7](xref:Cube_Main_Release_10.6.0_CU7).

--- a/release-notes/Web_apps/toc.yml
+++ b/release-notes/Web_apps/toc.yml
@@ -23,8 +23,12 @@ items:
             topicUid: Web_apps_Main_Release_10.6.0_CU5
           - name: DataMiner web apps Main Release 10.6.0 CU6 - Preview
             topicUid: Web_apps_Main_Release_10.6.0_CU6
+          - name: DataMiner web apps Main Release 10.6.0 CU7 - Preview
+            topicUid: Web_apps_Main_Release_10.6.0_CU7
       - name: Feature Release
         items:
+          - name: DataMiner web apps Feature Release 10.6.10 - Preview
+            topicUid: Web_apps_Feature_Release_10.6.10
           - name: DataMiner web apps Feature Release 10.6.9 - Preview
             topicUid: Web_apps_Feature_Release_10.6.9
           - name: DataMiner web apps Feature Release 10.6.8
@@ -89,6 +93,8 @@ items:
             topicUid: Web_apps_Main_Release_10.5.0_CU17
           - name: DataMiner web apps Main Release 10.5.0 CU18 - Preview
             topicUid: Web_apps_Main_Release_10.5.0_CU18
+          - name: DataMiner web apps Main Release 10.5.0 CU19 - Preview
+            topicUid: Web_apps_Main_Release_10.5.0_CU19
       - name: Feature Release
         items:
           - name: DataMiner web apps Feature Release 10.5.12


### PR DESCRIPTION
Adds preview release note pages for Cube, General, and Web apps for 10.6.10, plus matching 10.5.0 CU19 and 10.6.0 CU7 main release pages. Updates the release note TOCs to surface the new entries.