### PR TITLE
Updated UserDefinableApisEndpoint version table

### DIFF
--- a/dataminer/Functions/User-Defined_APIs/UD_APIs_UserDefinableApiEndpoint.md
+++ b/dataminer/Functions/User-Defined_APIs/UD_APIs_UserDefinableApiEndpoint.md
@@ -43,6 +43,10 @@ Below you can find a list of all the *UserDefinableApiEndpoint* DxM versions and
 | 3.3.1       | .NET 8                | 10.4.0+                            | 10.5.6                           |
 | 3.5.0       | .NET 8                | 10.4.0+                            | 10.5.12                          |
 | 3.6.0       | .NET 8                | 10.4.0+                            | 10.6.1                           |
+| 3.7.0       | .NET 8                | 10.4.0+                            | 10.6.7                           |
+| 3.8.0       | .NET 8                | 10.4.0+                            | 10.6.8                           |
+| 3.9.0       | .NET 10               | 10.4.0+                            | 10.6.10                          |
+
 
 > [!NOTE]
 >

--- a/dataminer/Functions/User-Defined_APIs/UD_APIs_UserDefinableApiEndpoint.md
+++ b/dataminer/Functions/User-Defined_APIs/UD_APIs_UserDefinableApiEndpoint.md
@@ -47,7 +47,6 @@ Below you can find a list of all the *UserDefinableApiEndpoint* DxM versions and
 | 3.8.0       | .NET 8                | 10.4.0+                            | 10.6.8                           |
 | 3.9.0       | .NET 10               | 10.4.0+                            | 10.6.10                          |
 
-
 > [!NOTE]
 >
 > - Versions not listed above were not released in official DataMiner upgrade packages.


### PR DESCRIPTION
Updated the version table for the UserDefinableEndpoint DxM with the latest two releases and the upcoming version which requires .NET 10. (RN46066)