### PR TITLE
Fix file offload size limit reference in About_storage.md

### DIFF
--- a/dataminer/Administrator_guide/Databases/About_storage.md
+++ b/dataminer/Administrator_guide/Databases/About_storage.md
@@ -32,5 +32,5 @@ Instead of a dedicated clustered storage setup, older systems often still use **
 
 > [!NOTE]
 >
-> - When the main database is offline, file offloads are used to store write/delete operations. You can configure a limit for the file size of these offloads in the file [DBConfiguration.xml](xref:DBConfiguration_xml).
+> - When the main database is offline, file offloads are used to store write/delete operations. You can configure a limit for the file size of these offloads in the file [DB.xml](xref:DB_xml#configuring-a-size-limit-for-file-offloads).
 > - You can also configure [data offloads to a separate database or to files](xref:Offload_database), for example in order to produce all kinds of reports without interfering with the live DataMiner System.


### PR DESCRIPTION
The note in *dataminer/Administrator_guide/Databases/About_storage.md* about configuring a size limit for file offloads pointed to **DBConfiguration.xml**. This is configured in **DB.xml** instead, so the link now points to [DB.xml - Configuring a size limit for file offloads](https://docs.dataminer.services/dataminer/Reference/Skyline_DataMiner_Folder/More_information_on_certain_files_and_folders/DB_xml.html#configuring-a-size-limit-for-file-offloads).