### PR TITLE
Fix deadlock issue in CloudGateway 3.3.2

### DIFF
--- a/release-notes/DxMs/cloudgateway_change_log.md
+++ b/release-notes/DxMs/cloudgateway_change_log.md
@@ -4,9 +4,9 @@ uid: cloudgateway_change_log
 
 # Cloud Gateway change log
 
-#### TBD - Fix - CloudGateway 3.3.2 - Resolved possible deadlock
+#### 10 August 2026 - Fix - CloudGateway 3.3.2 - Resolved possible unstable connection
 
-Resolved a deadlock that could keep a broken connection alive, causing for an unstable cloud connection.
+Fixed an issue where the cloud connection could become unstable, causing long request durations or timeouts.
 
 #### 31 Juli 2026 - Enhancement - CloudGateway 3.3.1 - Cloud connection stability improvements
 

--- a/release-notes/DxMs/cloudgateway_change_log.md
+++ b/release-notes/DxMs/cloudgateway_change_log.md
@@ -4,9 +4,9 @@ uid: cloudgateway_change_log
 
 # Cloud Gateway change log
 
-#### 10 August 2026 - Fix - CloudGateway 3.3.2 - Resolved possible unstable connection
+#### 10 August 2026 - Fix - CloudGateway 3.3.2 - Connection to dataminer.services could be unstable
 
-Fixed an issue where the cloud connection could become unstable, causing long request durations or timeouts.
+With CloudGateway 3.3.1, an issue could occur that made the connection to dataminer.services unstable, causing long request durations or timeouts. This has been resolved.
 
 #### 31 Juli 2026 - Enhancement - CloudGateway 3.3.1 - Cloud connection stability improvements
 

--- a/release-notes/DxMs/cloudgateway_change_log.md
+++ b/release-notes/DxMs/cloudgateway_change_log.md
@@ -4,6 +4,10 @@ uid: cloudgateway_change_log
 
 # Cloud Gateway change log
 
+#### TBD - Fix - CloudGateway 3.3.2 - Resolved possible deadlock
+
+Resolved a deadlock that could keep a broken connection alive, causing for an unstable cloud connection.
+
 #### 31 Juli 2026 - Enhancement - CloudGateway 3.3.1 - Cloud connection stability improvements
 
 Several changes were made to enhance the stability of the connection to dataminer.services.


### PR DESCRIPTION
Resolved a deadlock that could keep a broken connection alive, causing for an unstable cloud connection.