### PR TITLE
Remove port 9142 TLS misconception

### DIFF
--- a/dataminer/Administrator_guide/DataMiner_Agents/Configuring_a_DMA/Configuring_the_IP_network_ports.md
+++ b/dataminer/Administrator_guide/DataMiner_Agents/Configuring_a_DMA/Configuring_the_IP_network_ports.md
@@ -23,8 +23,7 @@ A DataMiner System makes extensive use of TCP/IP communication. Below, you find 
 | N/A     | 7000/tcp | Cassandra: non-TLS setup (inter-node communication in Failover setups) |
 | N/A     | 7001/tcp | Cassandra: TLS setup (available from DataMiner 10.1.3 onwards) |
 | N/A     | 7199/tcp | Cassandra: cluster backups |
-| N/A     | 9042/tcp | Cassandra: non-TLS setup (server listening for client requests) |
-| N/A     | 9142/tcp | Cassandra: TLS setup (server listening for client requests) |
+| N/A     | 9042/tcp | Cassandra: non-TLS and TLS setup (server listening for client requests) |
 | N/A     | 9200/tcp | OpenSearch/Elasticsearch |
 | N/A     | 9300/tcp | OpenSearch/Elasticsearch (inter-node communication) |
 | Multiple protocols | 4222/tcp<br> 6222/tcp | NATS (required from DataMiner 10.1.1 onwards) |

--- a/dataminer/Administrator_guide/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
+++ b/dataminer/Administrator_guide/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
@@ -79,7 +79,7 @@ If you want to add the Failover pair to a DataMiner System that uses STaaS, firs
 
 ### Dedicated clustered storage
 
-1. Make sure that the Agents to be added can reach the Cassandra cluster through port 9042 (also port 9042 when using TLS).
+1. Make sure that the Agents to be added can reach the Cassandra cluster through port 9042 (also when using TLS).
 
 1. Make sure that the Agents to be added can reach the OpenSearch or Elasticsearch cluster through port 9200.
 

--- a/dataminer/Administrator_guide/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
+++ b/dataminer/Administrator_guide/Failover/Configuring_Failover/Preparing_the_two_DataMiner_Agents.md
@@ -79,7 +79,7 @@ If you want to add the Failover pair to a DataMiner System that uses STaaS, firs
 
 ### Dedicated clustered storage
 
-1. Make sure that the Agents to be added can reach the Cassandra cluster through ports 9042 or 9142 when using TLS.
+1. Make sure that the Agents to be added can reach the Cassandra cluster through port 9042 (also port 9042 when using TLS).
 
 1. Make sure that the Agents to be added can reach the OpenSearch or Elasticsearch cluster through port 9200.
 

--- a/dataminer/Administrator_guide/Security/DataMiner_hardening_guide.md
+++ b/dataminer/Administrator_guide/Security/DataMiner_hardening_guide.md
@@ -168,7 +168,7 @@ On DataMiner versions installed using the **DataMiner Installer v10.2**, the Dat
 - TCP 9042: Cassandra (client-server communication)
 
   > [!NOTE]
-  > This rule and the one above for TCP 7000 only apply when the DataMiner System uses a Cassandra database that is installed on the same machine as DataMiner. If Cassandra is configured to use TLS, port 7001 and 9142 are used instead. For detailed information on securing Cassandra, refer to [secure self-managed storage](#secure-self-managed-dataminer-storage).
+  > This rule and the one above for TCP 7000 only apply when the DataMiner System uses a Cassandra database that is installed on the same machine as DataMiner. If Cassandra is configured to use TLS, port 7001 is used instead. For detailed information on securing Cassandra, refer to [secure self-managed storage](#secure-self-managed-dataminer-storage).
 
 - TCP 9200: Elasticsearch (client-server communication)
 
@@ -215,7 +215,7 @@ On DataMiner versions installed using the **DataMiner Installer v10.0 (or older)
 - TCP 9042: Cassandra (client-server communication)
 
   > [!NOTE]
-  > This rule and the one above for TCP 7000 only apply when the DataMiner System uses a Cassandra database that is installed on the same machine as DataMiner. If Cassandra is configured to use TLS, port 7001 and 9142 are used instead. For detailed information on securing Cassandra, refer to [secure self-managed storage](#secure-self-managed-dataminer-storage).
+  > This rule and the one above for TCP 7000 only apply when the DataMiner System uses a Cassandra database that is installed on the same machine as DataMiner. If Cassandra is configured to use TLS, port 7001 is used instead. For detailed information on securing Cassandra, refer to [secure self-managed storage](#secure-self-managed-dataminer-storage).
 
 - TCP 9200: Elasticsearch (client-server communication)
 


### PR DESCRIPTION
In docs, there was a pervasive misconception that port 9142 is used for TLS communication with the remote Cassandra node. This was false. Default port 9042 is used and cannot be deviated from. If the user uncomments the "native_transport_port_ssl: 9142" option in Cassandra.yaml, or specifies a different custom port, DataMiner will have trouble connecting to the Cassandra database.