### PR TITLE
Clarify Catalog item markdown formatting

### DIFF
--- a/develop/best_practices/Catalog_Items/Best_Practices_When_Documenting_Catalog_Items.md
+++ b/develop/best_practices/Catalog_Items/Best_Practices_When_Documenting_Catalog_Items.md
@@ -35,37 +35,7 @@ Depending on the size and complexity of your Catalog item, you can **combine or 
 > [!NOTE]
 > Avoid including a reference to support or contact details, because it is the rule of thumb for users to reach out to our [DataMiner Support team](xref:Contacting_tech_support). As an Owner or team, you can still add your email address in the [Manifest file](xref:Register_Catalog_Item#manifest-file).
 
-## Visuals
-
-**Purpose:** Enhance the *Overview*, *Key Features*, and *Use Cases* sections where appropriate by showcasing key features or advantages with visuals.
-
-**Format:** Add the images to the *Images* folder within the `manifest.zip` file. For a list of the supported image formats, see [Registering a Catalog item](xref:Register_Catalog_Item#body).
-
-**Do's:**
-
-- Include **up to 3 visuals** to support key points.
-- Ensure visuals are **clear, focused, and free from irrelevant elements**.
-  - When showing a table, make sure to hide irrelevant columns.
-  - Only show items that are relevant for and clearly show the Catalog item.
-- Use **high-quality** resolution.
-- Keep GIFs **concise** (at most 10 seconds) and **focused** on demonstrating a specific feature or action.
-- When creating GIFs, make sure to take sufficient **time between each click** or visual change so that the changes do not disturb the user too much.
-
-**Don'ts:**
-
-- Only show DataMiner **card tabs** if necessary to help understand a feature.
-- Avoid blurry or pixelated visuals — **quality is key**.
-- Avoid **unnecessary open panels**. Collapse panels like the Alarm Console if these do not add value.
-- Avoid **unnecessary blank space** by resizing the window when taking a screen capture.
-- Make sure not to show any **confidential data**. Blur any sensitive data, but keep the data that is not sensitive visible to still have a useful image.
-
-## Formatting
-
-Make sure to use DocFX-flavored markdown as detailed under [Markdown syntax](xref:CTB_Markdown_Syntax).
-
-However, avoid the use of HTML comments, as these will not be rendered correctly in the Catalog.
-
-## About section
+### About section
 
 **Purpose:** Summarize what makes the item valuable and why users should deploy it. Address the problems it solves and its primary benefits.
 
@@ -88,7 +58,7 @@ However, avoid the use of HTML comments, as these will not be rendered correctly
 - Do not refer to **generic DataMiner benefits** such as alarming and trending. Instead focus on the value this specific item brings.
 - Do not **duplicate** points mentioned in the **Key Features** and **Use Cases** sections.
 
-## Key Features section
+### Key Features section
 
 **Purpose:** **Product-centric**. Outline the main features that distinguish the item, focusing on functionality and unique benefits.
 
@@ -106,7 +76,7 @@ However, avoid the use of HTML comments, as these will not be rendered correctly
 - Avoid **excessive detail** or vague descriptors like "high-performance" without specific context.
 - Avoid adding key features that **do not specifically relate to the item**, but that are general to DataMiner (for example, the benefits of having alarms for your equipment, which is already a key feature of DataMiner itself).
 
-## Use Cases section
+### Use Cases section
 
 **Purpose:** **User-centric**. Demonstrate practical, real-world scenarios where the solution provides value.
 
@@ -122,7 +92,7 @@ However, avoid the use of HTML comments, as these will not be rendered correctly
 - Avoid **hypothetical scenarios**. Make sure the examples are relevant to the typical user base, showing the value of the item.
 - Do not **duplicate** points covered in the **Key Features** section.
 
-## Prerequisites section
+### Prerequisites section
 
 **Purpose:** List essential technical requirements needed for deployment.
 
@@ -153,7 +123,7 @@ However, avoid the use of HTML comments, as these will not be rendered correctly
 - Avoid complex **installation or configuration steps**. Link to comprehensive documentation instead.
 - Avoid listing every **small technical dependency**. Focus only on the essentials.
 
-## Technical Reference section
+### Technical Reference section
 
 **Purpose:** Provide links to detailed technical documentation, as the Catalog should focus on high-level information only.
 
@@ -171,3 +141,33 @@ However, avoid the use of HTML comments, as these will not be rendered correctly
 - Do not add **redundant information** that is already available somewhere else. If relevant, link to that information instead.
 - Avoid documenting features that **change frequently** and are not that important to document (e.g., UI).
 - Avoid listing every **small technical dependency**. Focus only on the essentials.
+
+## Visuals
+
+**Purpose:** Enhance the *Overview*, *Key Features*, and *Use Cases* sections where appropriate by showcasing key features or advantages with visuals.
+
+**Format:** Add the images to the *Images* folder within the `manifest.zip` file. For a list of the supported image formats, see [Registering a Catalog item](xref:Register_Catalog_Item#body).
+
+**Do's:**
+
+- Include **up to 3 visuals** to support key points.
+- Ensure visuals are **clear, focused, and free from irrelevant elements**.
+  - When showing a table, make sure to hide irrelevant columns.
+  - Only show items that are relevant for and clearly show the Catalog item.
+- Use **high-quality** resolution.
+- Keep GIFs **concise** (at most 10 seconds) and **focused** on demonstrating a specific feature or action.
+- When creating GIFs, make sure to take sufficient **time between each click** or visual change so that the changes do not disturb the user too much.
+
+**Don'ts:**
+
+- Only show DataMiner **card tabs** if necessary to help understand a feature.
+- Avoid blurry or pixelated visuals — **quality is key**.
+- Avoid **unnecessary open panels**. Collapse panels like the Alarm Console if these do not add value.
+- Avoid **unnecessary blank space** by resizing the window when taking a screen capture.
+- Make sure not to show any **confidential data**. Blur any sensitive data, but keep the data that is not sensitive visible to still have a useful image.
+
+## Formatting
+
+Make sure to use DocFX-flavored markdown as detailed under [Markdown syntax](xref:CTB_Markdown_Syntax).
+
+However, avoid the use of HTML comments, as these will not be rendered correctly in the Catalog.

--- a/develop/best_practices/Catalog_Items/Best_Practices_When_Documenting_Catalog_Items.md
+++ b/develop/best_practices/Catalog_Items/Best_Practices_When_Documenting_Catalog_Items.md
@@ -59,6 +59,12 @@ Depending on the size and complexity of your Catalog item, you can **combine or 
 - Avoid **unnecessary blank space** by resizing the window when taking a screen capture.
 - Make sure not to show any **confidential data**. Blur any sensitive data, but keep the data that is not sensitive visible to still have a useful image.
 
+## Formatting
+
+Make sure to use DocFX-flavored markdown as detailed under [Markdown syntax](xref:CTB_Markdown_Syntax).
+
+However, avoid the use of HTML comments, as these will not be rendered correctly in the Catalog.
+
 ## About section
 
 **Purpose:** Summarize what makes the item valuable and why users should deploy it. Address the problems it solves and its primary benefits.


### PR DESCRIPTION
Add guidance to use DocFX-flavored markdown for Catalog item docs and note that HTML comments do not render correctly in the Catalog.