### PR TITLE
Update MediaOps Live connection handler script docs

### DIFF
--- a/solutions/standard_solutions/MediaOps/MediaOps.Live/Mediation_layer/MO_ConnectionHandlerScript.md
+++ b/solutions/standard_solutions/MediaOps/MediaOps.Live/Mediation_layer/MO_ConnectionHandlerScript.md
@@ -24,6 +24,11 @@ public class Script
 
 public class EVS_Cerebrum_ConnectionHandler : ConnectionHandler
 {
+    public override ConnectionHandlerConfiguration GetConfiguration()
+    {
+        // ...
+    }
+
     public override IEnumerable<ElementInfo> GetSupportedElements(IEngine engine, IEnumerable<ElementInfo> elements)
     {
         // ...
@@ -51,6 +56,23 @@ public class EVS_Cerebrum_ConnectionHandler : ConnectionHandler
 }
 ```
 
+## GetConfiguration() method
+
+The `GetConfiguration` method is an optional override that allows the connection handler script to customize its configuration. When it is not overridden, the default configuration is used.
+
+Currently, the configuration lets you customize the timeout for connect and disconnect operations. Both timeouts default to 10 seconds.
+
+```csharp
+    public override ConnectionHandlerConfiguration GetConfiguration()
+    {
+        return new ConnectionHandlerConfiguration
+        {
+            ConnectTimeout = TimeSpan.FromSeconds(30),
+            DisconnectTimeout = TimeSpan.FromSeconds(30),
+        };
+    }
+```
+
 ## GetSupportedElements() method
 
 The `GetSupportedElements` method allows the connection handler script to indicate which elements it is designed to work with.
@@ -60,7 +82,7 @@ The method receives the list of available elements from the mediation layer and 
 ```csharp
     public override IEnumerable<ElementInfo> GetSupportedElements(IEngine engine, IEnumerable<ElementInfo> elements)
     {
-        return elements.Where(e => e.ProtocolN == "My Device Protocol");
+        return elements.Where(e => e.Protocol == "My Device Protocol");
     }
 ```
 
@@ -81,19 +103,61 @@ The purpose of this method is to let the mediation layer know which parameters (
     }
 ```
 
+Instead of using the constructor, you can also create the `SubscriptionInfo` objects with the `StandaloneParameter` and `Table` factory methods:
+
+```csharp
+    public override IEnumerable<SubscriptionInfo> GetSubscriptionInfo(IEngine engine)
+    {
+        return new[]
+        {
+            SubscriptionInfo.StandaloneParameter(1000),
+            SubscriptionInfo.Table(12100), // Routes
+            SubscriptionInfo.Table(14100), // Sources
+            SubscriptionInfo.Table(15100), // Destinations
+        };
+    }
+```
+
+### Filtering on columns and row keys
+
+For table parameters, you can narrow down the subscription so that only changes to specific columns and/or a specific row are reported. This reduces the number of updates the connection handler script has to process. You can apply these filters with the following methods, which can be chained onto a `SubscriptionInfo` object:
+
+- `FilterColumn(int column)`: Only report changes to the specified column parameter ID.
+- `FilterColumns(params ICollection<int> columns)`: Only report changes to the specified column parameter IDs.
+- `FilterRowKey(string rowKey)`: Only report changes to the row with the specified row key. The provided key supports wildcards (`*` and `?`).
+
+> [!NOTE]
+> These filters are only applicable to table parameters. When you filter on columns, you must still provide the table parameter ID.
+
+```csharp
+    public override IEnumerable<SubscriptionInfo> GetSubscriptionInfo(IEngine engine)
+    {
+        return new[]
+        {
+            SubscriptionInfo.StandaloneParameter(1000),
+
+            // Only report changes to columns 12102 and 12103 of the Routes table.
+            SubscriptionInfo.Table(12100).FilterColumns(12102, 12103),
+
+            // Only report changes to column 14102 of a specific row in the Sources table.
+            SubscriptionInfo.Table(14100).FilterColumn(14102).FilterRowKey("Source 1"),
+        };
+    }
+```
+
 ## ProcessParameterUpdate() method
 
 The `ProcessParameterUpdate` method is triggered by the mediation layer whenever a parameter of a device element changes. Its purpose is to update the current connections (connect and disconnect) via the API.
 
-Based on the parameter changes, the method should try to find the corresponding source and destination endpoints that match the new data. Endpoints can be retrieved using the API object that can be found in the `connectionEngine` parameter.
+Based on the parameter changes, the method should try to find the corresponding source and destination endpoints that match the new data. Endpoints can be retrieved using the convenience methods on the `connectionEngine` parameter (e.g., `GetEndpointsWithTransportMetadata`, `GetEndpointsWithElement`, or `GetEndpointsWithIdentifier`) or directly via the API object (`connectionEngine.Api.Endpoints`).
 
 Example:
 
 ```csharp
-    var sourceEndpoints = connectionEngine.Api.Endpoints.GetByMulticasts(...);
+    var sourceEndpoints = connectionEngine.GetEndpointsWithTransportMetadata(EndpointRole.Source, ...);
 ```
 
-Once connections are detected, they should be registered using the `connectionEngine` provided as a parameter to the method. Disconnects also need to be registered. The endpoint objects retrieved using the code above should be used to create `ConnectionInfo` objects. New connections overwrite existing connections, based on the destination endpoint. In most cases, there is no need to first retrieve the existing connections from the API.
+Once connections are detected, they should be registered using the `connectionEngine` provided as a parameter to the method. Disconnects also need to be registered. The endpoint objects retrieved using the code above should be used to create `ConnectionUpdate` objects. New connections overwrite existing connections, based on the destination endpoint. In most cases, there is no need to first retrieve the existing connections from the API.
 
 > [!NOTE]
 > If a connection is detected but the corresponding source endpoint cannot be found, the connection still has to be registered.
@@ -101,7 +165,7 @@ Once connections are detected, they should be registered using the `connectionEn
 ```csharp
     public override void ProcessParameterUpdate(IEngine engine, IConnectionHandlerEngine connectionEngine, ParameterUpdate update)
     {
-        var updatedConnections = new List<ConnectionInfo>();
+        var updatedConnections = new List<ConnectionUpdate>();
 
         if (update.ParameterId != 12100)
         {

--- a/solutions/standard_solutions/MediaOps/MediaOps.Live/Tutorials/Generic_Matrix/Generic_Matrix_ConnectionHandlerScript.md
+++ b/solutions/standard_solutions/MediaOps/MediaOps.Live/Tutorials/Generic_Matrix/Generic_Matrix_ConnectionHandlerScript.md
@@ -152,7 +152,7 @@ public override void ProcessParameterUpdate(IEngine engine, IConnectionHandlerEn
             var outputIdentifier = Convert.ToString(row[0]);
             var inputIdentifier = Convert.ToString(row[5]);
 
-            var output = connectionEngine.Api.Endpoints.GetByRoleElementAndIdentifier(Role.Destination, elementId, outputIdentifier)
+            var output = connectionEngine.Api.Endpoints.GetByRoleElementAndIdentifier(EndpointRole.Destination, elementId, outputIdentifier)
                 ?? throw new InvalidOperationException($"Destination endpoint '{outputIdentifier}' not found for element '{elementId}'.");
 
             if (String.IsNullOrWhiteSpace(inputIdentifier))
@@ -162,7 +162,7 @@ public override void ProcessParameterUpdate(IEngine engine, IConnectionHandlerEn
                 continue;
             }
 
-            var input = connectionEngine.Api.Endpoints.GetByRoleElementAndIdentifier(Role.Source, elementId, inputIdentifier);
+            var input = connectionEngine.Api.Endpoints.GetByRoleElementAndIdentifier(EndpointRole.Source, elementId, inputIdentifier);
 
             if (input != null)
             {
@@ -182,7 +182,7 @@ public override void ProcessParameterUpdate(IEngine engine, IConnectionHandlerEn
         {
             var outputIdentifier = Convert.ToString(row[0]);
 
-            var output = connectionEngine.Api.Endpoints.GetByRoleElementAndIdentifier(Role.Destination, elementId, outputIdentifier)
+            var output = connectionEngine.Api.Endpoints.GetByRoleElementAndIdentifier(EndpointRole.Destination, elementId, outputIdentifier)
                 ?? throw new InvalidOperationException($"Destination endpoint '{outputIdentifier}' not found for element '{elementId}'.");
 
             updatedConnections.Add(new ConnectionUpdate(output, isConnected: false));

--- a/solutions/standard_solutions/MediaOps/MediaOps.Live/Tutorials/Generic_Matrix/Generic_Matrix_Provisioning_Code.md
+++ b/solutions/standard_solutions/MediaOps/MediaOps.Live/Tutorials/Generic_Matrix/Generic_Matrix_Provisioning_Code.md
@@ -111,7 +111,7 @@ private void ProvisionSources(IEngine engine, Element element, IEngineMediaOpsLi
 
     // Get existing endpoints and virtual signal groups for the element.
     var existingEndpoints = api.Endpoints.Query()
-        .Where(x => x.Role == Role.Source && x.Element == elementId)
+        .Where(x => x.Role == EndpointRole.Source && x.Element == elementId)
         .SafeToDictionary(x => (x.Element, x.Identifier));
 
     var existingVirtualSignalGroups = api.VirtualSignalGroups
@@ -135,7 +135,7 @@ private void ProvisionSources(IEngine engine, Element element, IEngineMediaOpsLi
         }
 
         endpoint.Name = name;
-        endpoint.Role = Role.Source;
+        endpoint.Role = EndpointRole.Source;
         endpoint.Element = elementId;
         endpoint.Identifier = key;
         endpoint.TransportType = sdiTransportType;
@@ -149,7 +149,7 @@ private void ProvisionSources(IEngine engine, Element element, IEngineMediaOpsLi
         }
 
         vsg.Name = name;
-        vsg.Role = Role.Source;
+        vsg.Role = EndpointRole.Source;
         vsg.AssignEndpointToLevel(videoLevel, endpoint);
 
         newVirtualSignalGroups.Add(vsg);
@@ -176,7 +176,7 @@ private void ProvisionDestinations(IEngine engine, Element element, IEngineMedia
     var sdiTransportType = api.TransportTypes.ReadSingle("SDI");
 
     var existingEndpoints = api.Endpoints.Query()
-        .Where(x => x.Role == Role.Destination && x.Element == elementId)
+        .Where(x => x.Role == EndpointRole.Destination && x.Element == elementId)
         .SafeToDictionary(x => (x.Element, x.Identifier));
 
     var existingVirtualSignalGroups = api.VirtualSignalGroups
@@ -199,7 +199,7 @@ private void ProvisionDestinations(IEngine engine, Element element, IEngineMedia
         }
 
         endpoint.Name = name;
-        endpoint.Role = Role.Destination;
+        endpoint.Role = EndpointRole.Destination;
         endpoint.Element = elementId;
         endpoint.Identifier = key;
         endpoint.TransportType = sdiTransportType;
@@ -213,7 +213,7 @@ private void ProvisionDestinations(IEngine engine, Element element, IEngineMedia
         }
 
         vsg.Name = name;
-        vsg.Role = Role.Destination;
+        vsg.Role = EndpointRole.Destination;
         vsg.AssignEndpointToLevel(videoLevel, endpoint);
 
         newVirtualSignalGroups.Add(vsg);

--- a/solutions/standard_solutions/MediaOps/MediaOps.Live/Tutorials/IP Matrix/IP_Matrix_ConnectionHandlerScript.md
+++ b/solutions/standard_solutions/MediaOps/MediaOps.Live/Tutorials/IP Matrix/IP_Matrix_ConnectionHandlerScript.md
@@ -79,12 +79,12 @@ public class Script
 {
     public void Run(IEngine engine)
     {
-        var handler = new Generic_Matrix_ConnectionHandler();
+        var handler = new IPMatrix_ConnectionHandler();
         handler.Execute(engine);
     }
 }
 
-public class Generic_Matrix_ConnectionHandler : ConnectionHandler
+public class IPMatrix_ConnectionHandler : ConnectionHandler
 {
 
 }
@@ -149,7 +149,7 @@ public override void ProcessParameterUpdate(IEngine engine, IConnectionHandlerEn
 
     var elementId = update.DmsElementId;
     var destinationEndpoint = connectionEngine.Api.Endpoints.GetByElement(elementId)
-        .SingleOrDefault(e => e.Role == Role.Destination);
+        .SingleOrDefault(e => e.Role == EndpointRole.Destination);
 
     if (destinationEndpoint == null)
     {
@@ -170,8 +170,7 @@ public override void ProcessParameterUpdate(IEngine engine, IConnectionHandlerEn
 
         if (isConnected)
         {
-            var multicast = new Multicast(multicastIp);
-            var sourceEndpoint = connectionEngine.Api.Endpoints.GetByMulticasts(new[] { multicast })
+            var sourceEndpoint = connectionEngine.Api.Endpoints.GetByTransportMetadata(TsoipTransportType.FieldNames.MulticastIp, multicastIp)
                 .SingleOrDefault();
 
             if (sourceEndpoint != null)


### PR DESCRIPTION
Extends and updates the MediaOps Live connection handler script documentation.

## Changes

- Document new subscription filtering in `GetSubscriptionInfo()`: `FilterColumn`, `FilterColumns`, and `FilterRowKey` (row keys support wildcards `*` and `?`), plus the `StandaloneParameter` and `Table` factory methods.
- Add a `GetConfiguration()` section documenting the optional `ConnectTimeout` and `DisconnectTimeout` settings.
- Correct outdated content verified against the source:
  - `ElementInfo.Protocol` (was `ProtocolN`).
  - `RegisterConnections` uses `ConnectionUpdate` (was `ConnectionInfo`).
  - Endpoint retrieval convenience methods (was `Api.Endpoints.GetByMulticasts`).