### PR TITLE
Update MediaOps.Plan version requirement in release notes

### DIFF
--- a/release-notes/Ticketing/Ticketing_2.0.0.md
+++ b/release-notes/Ticketing/Ticketing_2.0.0.md
@@ -20,7 +20,7 @@ uid: Ticketing_2.0.0
 
 - Installing the following apps alongside the Ticketing Solution will provide access to **additional functionality**:
 
-  - [MediaOps.Plan](https://catalog.dataminer.services/details/1b67a623-4ca6-4d25-8b3d-ed4e39496a75) 1.6.x or higher (Requiring DataMiner 10.6.4/10.7.0 or higher!): Required to be able to assign people to tickets.
+  - [MediaOps.Plan](https://catalog.dataminer.services/details/1b67a623-4ca6-4d25-8b3d-ed4e39496a75) 1.4.x or higher: Required to be able to assign people to tickets.
   - [InfraOps](https://catalog.dataminer.services/details/5a1edac2-45aa-4498-8ab7-ee322d07da27): Required to be able to link assets to tickets.
 
 ## New features

--- a/release-notes/Ticketing/Ticketing_2.0.0.md
+++ b/release-notes/Ticketing/Ticketing_2.0.0.md
@@ -20,7 +20,7 @@ uid: Ticketing_2.0.0
 
 - Installing the following apps alongside the Ticketing Solution will provide access to **additional functionality**:
 
-  - [MediaOps.Plan](https://catalog.dataminer.services/details/1b67a623-4ca6-4d25-8b3d-ed4e39496a75) 1.4.x or higher: Required to be able to assign people to tickets.
+  - [MediaOps.Plan](https://catalog.dataminer.services/details/1b67a623-4ca6-4d25-8b3d-ed4e39496a75) 1.6.x or higher (Requiring DataMiner 10.6.4/10.7.0 or higher!): Required to be able to assign people to tickets.
   - [InfraOps](https://catalog.dataminer.services/details/5a1edac2-45aa-4498-8ab7-ee322d07da27): Required to be able to link assets to tickets.
 
 ## New features

--- a/release-notes/Ticketing/Ticketing_2.1.0.md
+++ b/release-notes/Ticketing/Ticketing_2.1.0.md
@@ -6,7 +6,7 @@ uid: Ticketing_2.1.0
 
 ## Prerequisites
 
-- **DataMiner 10.5.9/10.6.0** or higher must be installed.
+- **DataMiner 10.6.4/10.7.0** or higher must be installed.
 
 - [**Standard Data Model Registration**](https://catalog.dataminer.services/details/52173e49-9185-4772-9b60-c186ee365a81) 2.0.x or higher must be installed.
 
@@ -22,7 +22,7 @@ uid: Ticketing_2.1.0
 
 - Installing the following apps alongside the Ticketing Solution will provide access to **additional functionality**:
 
-  - [MediaOps.Plan](https://catalog.dataminer.services/details/1b67a623-4ca6-4d25-8b3d-ed4e39496a75) 1.4.x or higher: Required to be able to assign people to tickets.
+  - [MediaOps.Plan](https://catalog.dataminer.services/details/1b67a623-4ca6-4d25-8b3d-ed4e39496a75) 1.6.x or higher: Required to be able to assign people to tickets.
   - [InfraOps](https://catalog.dataminer.services/details/5a1edac2-45aa-4498-8ab7-ee322d07da27): Required to be able to link assets to tickets.
 
 ## New features

--- a/release-notes/Ticketing/Ticketing_2.1.0.md
+++ b/release-notes/Ticketing/Ticketing_2.1.0.md
@@ -6,7 +6,7 @@ uid: Ticketing_2.1.0
 
 ## Prerequisites
 
-- **DataMiner 10.6.4/10.7.0** or higher must be installed.
+- **DataMiner 10.5.9/10.6.0** or higher must be installed. If you intend to use MediaOps Plan alongside Ticketing (see below), **DataMiner 10.6.4/10.7.0** or higher must be installed.
 
 - [**Standard Data Model Registration**](https://catalog.dataminer.services/details/52173e49-9185-4772-9b60-c186ee365a81) 2.0.x or higher must be installed.
 


### PR DESCRIPTION
Updated the required version for MediaOps.Plan to 1.6.x or higher for ticket assignment functionality.