### PR TITLE
[ai] DIS Release Notes 3.1.25

### DIFF
--- a/develop/TOOLS/DIS/Debugging/Preparing_to_debug_on_a_remote_DataMiner_Agent.md
+++ b/develop/TOOLS/DIS/Debugging/Preparing_to_debug_on_a_remote_DataMiner_Agent.md
@@ -29,12 +29,9 @@ Proceed as follows if you want to debug a QAction or an automation script locate
 
 1. Run Visual Studio as an Administrator.
 
-1. Make sure that, in the *DMA* tab of the *DIS Settings* window, you have added the DataMiner Agent with the correct user account and that, in its *Debugging* tab, you have selected the *Enable remote debugging* option and configured the *Debugger qualifier* setting.
+1. Make sure that, in the [DMA](xref:DIS_settings#dma) tab of the *DIS Settings* window, you have added the DataMiner Agent with the correct user account and that, in its *Debugging* tab, you have configured the following settings:
 
-   | Setting | Description |
-   | --- | --- |
-   | Debugger qualifier | The qualifier supplied by Remote Debugging Monitor (msvsmon.exe) in a log entry at startup.<br>Format: `dmaname:ipport`<br>Default port: 4026 |
-
-   See [DMA](xref:DIS_settings#dma)
+   - *Enable remote debugging* must be selected.
+   - *Debugger qualifier* must be set to the qualifier supplied by the Remote Debugging Monitor (msvsmon.exe) in a log entry at startup. Format: `dmaname:ipport`. Default port: 4026.
 
 You are now ready to start debugging. See [Debugging a connector](xref:Debugging_a_connector) or [Debugging an automation script](xref:Debugging_an_Automation_script).

--- a/develop/TOOLS/DIS/Debugging/Preparing_to_debug_on_a_remote_DataMiner_Agent.md
+++ b/develop/TOOLS/DIS/Debugging/Preparing_to_debug_on_a_remote_DataMiner_Agent.md
@@ -6,10 +6,6 @@ uid: Preparing_to_debug_on_a_remote_DataMiner_Agent
 
 Proceed as follows if you want to debug a QAction or an automation script located on the DataMiner Agent that is running on another machine.
 
-1. On the remote DataMiner Agent, create a network share where DIS can upload the DLL files and the symbol files.
-
-   Example: `C:\dis`
-
 1. Copy or install Remote Debugging Monitor (msvsmon.exe) on the remote DataMiner Agent.
 
    - To install Remote Debugging Monitor on the remote DataMiner, either download and run the installer, or copy all files from the following local folder to a random folder on the remote DataMiner Agent:
@@ -33,16 +29,12 @@ Proceed as follows if you want to debug a QAction or an automation script locate
 
 1. Run Visual Studio as an Administrator.
 
-1. Make sure that, in the *DMA* tab of the *DIS Settings* window, you have added the DataMiner Agent with the correct user account and that, in its *Debugging* tab, you have selected the *Enable remote debugging* option and configured the following settings:
+1. Make sure that, in the *DMA* tab of the *DIS Settings* window, you have added the DataMiner Agent with the correct user account and that, in its *Debugging* tab, you have selected the *Enable remote debugging* option and configured the *Debugger qualifier* setting.
 
    | Setting | Description |
    | --- | --- |
-   | Publish path | The network path to the shared folder on the remote DMA where DIS will upload the DLL files and the symbol files.<br>Default: `\\remote-dma\dis` |
-   | Path on DataMiner | The local path to the shared folder on the remote DMA where DIS will upload the DLL files and the symbol files.<br>Default: `C:\dis\` |
-   | Debugger qualifier | The qualifier supplied by Remote Debugging Monitor (msvsmon.exe) in a log entry at startup.<br>Format: dmaname:ipport |
+   | Debugger qualifier | The qualifier supplied by Remote Debugging Monitor (msvsmon.exe) in a log entry at startup.<br>Format: `dmaname:ipport`<br>Default port: 4026 |
 
    See [DMA](xref:DIS_settings#dma)
-
-1. Go to *Tools \> Options \> Debugging \> Symbols*, and add the above-mentioned "publish path"<br>(e.g., `\\remote-dma\dis`) to the list of symbol file locations.
 
 You are now ready to start debugging. See [Debugging a connector](xref:Debugging_a_connector) or [Debugging an automation script](xref:Debugging_an_Automation_script).

--- a/develop/TOOLS/DIS/Editors/XML_editor.md
+++ b/develop/TOOLS/DIS/Editors/XML_editor.md
@@ -109,11 +109,12 @@ If you click *Publish* for an automation script that is part of a solution packa
 > [!NOTE]
 >
 > - You cannot click the *Publish* button when Visual Studio is running in debug mode.
+> - If you click *Publish* for a protocol that has a minimum required version mentioned in the [MinimumRequiredVersion](xref:Protocol.Compliancies.MinimumRequiredVersion) tag, DIS will verify that the DataMiner Agent to which the protocol will be published is running at least this version. If this is not the case, a message box will be shown and the publish will not be performed.
 > - DIS will refuse to publish a protocol
->   - when the *Protocol.Type* tag contain an incorrect value,
->   - when the *Protocol.Version* tag is empty, or
->   - when the *Protocol.Name* tag is empty.
-> - When *As Development* is selected, a `_DIS` suffix will be added to the *Protocol.Version* tag before compiling and publishing.
+>   - when the [Protocol.Type](xref:Protocol.Type) tag contain an incorrect value,
+>   - when the [Protocol.Version](xref:Protocol.Version) tag is empty, or
+>   - when the [Protocol.Name](xref:Protocol.Name) tag is empty.
+> - When *As Development* is selected, a `_DIS` suffix will be added to the [Protocol.Version](xref:Protocol.Version) tag before compiling and publishing.
 
 ### Search
 

--- a/develop/TOOLS/DIS/Reference/DIS_settings.md
+++ b/develop/TOOLS/DIS/Reference/DIS_settings.md
@@ -20,20 +20,19 @@ To add a DMA to the list:
    | Display name | In this box, enter the name of the DMA as it will appear in the list. |
    | Host | In this box, enter the IP address or server name of the DataMiner Agent using the following syntax:<br>`https://[IP address or server name]:[Port]/SLNetService`<br>Note:<br>- Both HTTP and HTTPS are supported.<br>- Specifying the IP port is optional. Default port: 8004<br>- Specifying the suffix "/SLNetService" is optional.<br>See also [If a DMA uses DataMiner configuration switching](#if-a-dma-uses-dataminer-configuration-switching) |
    | Login | Choose how you want DIS to log on to the DMA:<br>- Using the current Windows user (default)<br>- Using a specific user/password combination |
-   | Force Authenticate Local User | Available when *Login* is set to use a user name and password. When selected, DIS will authenticate using a local user account even if external or federated authentication is configured on the agent. |
+   | Force Authenticate Local User | Available when *Login* is set to use a username and password. When selected, DIS will authenticate using a local user account even if external or federated authentication is configured on the DataMiner Agent. |
    | Group | The DMAs listed in the DMA tab can be organized in groups.<br> In this box, enter or select the name of the group to which you want the DMA to belong. |
    | Production DMA | Select this checkbox if the DMA is a production DMA.<br> When you try to publish a protocol or an automation script to a production DMA, a confirmation box will appear to prevent you from accidentally publishing that file to it. |
 
 1. Click *Test connection* to check whether DIS is able to connect to the DMA you configured.
-1. If the DMA you are configuring is not your local DMA, then, in the *Debugging* tab, select the *Enable remote debugging* checkbox and specify the following settings if you want to be able to debug QActions while connected to this remote DMA.
 
-   | Setting | Description |
-   | ------- | ----------- |
-   | Debugger qualifier | The qualifier supplied by Remote Debugging Monitor (msvsmon.exe) at startup.<br>Format: `dmaname:ipport`<br>Default port: 4026 |
+1. If the DMA you are configuring is not your local DMA, configure the following settings in the *Debugging* tab to be able to debug QActions while connected to this remote DMA:
+
+   - Select *Enable remote debugging*.
+   - Set *Debugger qualifier* to the qualifier supplied by the Remote Debugging Monitor (msvsmon.exe) in a log entry at startup. Format: `dmaname:ipport`. Default port: 4026.
 
    > [!TIP]
-   > See also:
-   > [Debugging connectors and automation scripts](xref:Debugging_connectors_and_Automation_scripts)
+   > See also: [Debugging connectors and automation scripts](xref:Debugging_connectors_and_Automation_scripts)
 
 1. Click *OK* to close the *Edit DMA Connection* window.
 

--- a/develop/TOOLS/DIS/Reference/DIS_settings.md
+++ b/develop/TOOLS/DIS/Reference/DIS_settings.md
@@ -20,6 +20,7 @@ To add a DMA to the list:
    | Display name | In this box, enter the name of the DMA as it will appear in the list. |
    | Host | In this box, enter the IP address or server name of the DataMiner Agent using the following syntax:<br>`https://[IP address or server name]:[Port]/SLNetService`<br>Note:<br>- Both HTTP and HTTPS are supported.<br>- Specifying the IP port is optional. Default port: 8004<br>- Specifying the suffix "/SLNetService" is optional.<br>See also [If a DMA uses DataMiner configuration switching](#if-a-dma-uses-dataminer-configuration-switching) |
    | Login | Choose how you want DIS to log on to the DMA:<br>- Using the current Windows user (default)<br>- Using a specific user/password combination |
+   | Force Authenticate Local User | Available when *Login* is set to use a user name and password. When selected, DIS will authenticate using a local user account even if external or federated authentication is configured on the agent. |
    | Group | The DMAs listed in the DMA tab can be organized in groups.<br> In this box, enter or select the name of the group to which you want the DMA to belong. |
    | Production DMA | Select this checkbox if the DMA is a production DMA.<br> When you try to publish a protocol or an automation script to a production DMA, a confirmation box will appear to prevent you from accidentally publishing that file to it. |
 
@@ -28,9 +29,7 @@ To add a DMA to the list:
 
    | Setting | Description |
    | ------- | ----------- |
-   | Publish path | The network path to the shared folder on the remote DMA where DIS will upload the DLL files and the symbol files.<br>Default: \\\\remote-dma\\dis |
-   | Path on DataMiner | The local path to the shared folder on the remote DMA where DIS will upload the DLL files and the symbol files.<br>Default: C:\\dis\\ |
-   | Debugger qualifier | The qualifier supplied by Remote Debugging Monitor (msvsmon.exe) at startup.<br>Format: dmaname:ipport |
+   | Debugger qualifier | The qualifier supplied by Remote Debugging Monitor (msvsmon.exe) at startup.<br>Format: `dmaname:ipport`<br>Default port: 4026 |
 
    > [!TIP]
    > See also:

--- a/develop/TOOLS/DIS/ToolWindows/DisInjectToolWindow.md
+++ b/develop/TOOLS/DIS/ToolWindows/DisInjectToolWindow.md
@@ -39,12 +39,8 @@ Below the element selection box you can find the element manipulation tool bar. 
 - Pause the element
 - Stop the element
 - Restart the element
-- Open the element in *Element Display* (no longer used)
 - Open the element in *DataMiner Cube*
-- Open the element’s log file.
-
-  > [!NOTE]
-  > If DIS is connected to a remote DataMiner Agent, then make sure the `C:\Skyline DataMiner\logging` folder on that DataMiner Agent is shared and accessible.
+- Open the element's log file.
 
 ### Linking temporary QAction projects to QActions in the protocol of the selected element
 
@@ -54,17 +50,26 @@ When, for example, you open a QAction with ID 12, then the temporary project wil
 
 | If you click... | then... |
 |-----------------|---------|
-| the green plus, | you will replace (i.e., inject) the element's *QAction.dll* file (compiled in Release mode) with its counterpart found in the temporary QAction project (compiled in Debug mode). |
-| the red X, | you will sever the temporary link between the element and the *QAction.dll* compiled in Debug mode.<br> This will restore the link between the element and its original *QAction.dll* (compiled in Release mode). |
+| the green plus, | the project is marked as *Pending (on attach)*. The project is not built immediately. The *Status* column shows this pending state. |
+| the red X, | you eject the inject. If the project has not yet been attached, no remote agent interaction occurs. If already attached, this severs the temporary link between the element and the *QAction.dll* compiled in Debug mode, restoring the link to the original release DLL. |
 | the yellow lightning bolt, | you will manually trigger the QAction by simulating a change of the parameter selected in the *Trigger ID* box (in case of a dynamic table parameter, use the *Trigger Key* box to specify the table row).<br>Only do this after you have attached the SLScripting process(es) to the Debugger. |
 
 ### Attaching the Microsoft Visual Studio Debugger to the DataMiner SLScripting process(es)
 
-After injecting the necessary *QAction.dll* files, you have to attach the Debugger to the SLScripting process(es).
+After marking the necessary QAction projects for injection, you can attach the Debugger. When you click *Attach*, DIS performs the following steps in sequence, showing progress for each:
+
+1. Compiles all injected projects.
+1. Creates a DMapp package containing the resulting DLL and PDB files.
+1. Uploads the DMapp package to the DataMiner Agent.
+1. Sends inject requests to DataMiner.
+1. Attaches the Microsoft Visual Studio Debugger to the SLScripting process(es).
+
+> [!NOTE]
+> DIS deletes any existing DLL file before rebuilding a project. If the build fails, a message is shown and the process is stopped.
 
 | If you click... | then... |
 |-----------------|---------|
-| Attach | all temporary QAction projects will be built, and the Microsoft Visual Studio Debugger will be attached to the DataMiner SLScripting process(es).<br>Note: The design of the Microsoft Visual Studio screen will change and you will notice the word "Running" in the title bar. |
+| Attach | all pending QAction projects are built, uploaded via a DMapp package, injected, and the Microsoft Visual Studio Debugger is attached to the DataMiner SLScripting process(es).<br>Note: The design of the Microsoft Visual Studio screen will change and you will notice the word "Running" in the title bar. |
 | Detach | the Microsoft Visual Studio Debugger will be detached from the DataMiner SLScripting process(es). |
 
 ## Debugging an automation script

--- a/develop/TOOLS/DIS/ToolWindows/DisInjectToolWindow.md
+++ b/develop/TOOLS/DIS/ToolWindows/DisInjectToolWindow.md
@@ -39,8 +39,12 @@ Below the element selection box you can find the element manipulation tool bar. 
 - Pause the element
 - Stop the element
 - Restart the element
+- Open the element in *Element Display* (no longer used)
 - Open the element in *DataMiner Cube*
-- Open the element's log file.
+- Open the element’s log file.
+
+  > [!NOTE]
+  > If DIS is connected to a remote DataMiner Agent, then make sure the `C:\Skyline DataMiner\logging` folder on that DataMiner Agent is shared and accessible.
 
 ### Linking temporary QAction projects to QActions in the protocol of the selected element
 
@@ -50,26 +54,17 @@ When, for example, you open a QAction with ID 12, then the temporary project wil
 
 | If you click... | then... |
 |-----------------|---------|
-| the green plus, | the project is marked as *Pending (on attach)*. The project is not built immediately. The *Status* column shows this pending state. |
-| the red X, | you eject the inject. If the project has not yet been attached, no remote agent interaction occurs. If already attached, this severs the temporary link between the element and the *QAction.dll* compiled in Debug mode, restoring the link to the original release DLL. |
+| the green plus, | you will replace (i.e., inject) the element's *QAction.dll* file (compiled in Release mode) with its counterpart found in the temporary QAction project (compiled in Debug mode). |
+| the red X, | you will sever the temporary link between the element and the *QAction.dll* compiled in Debug mode.<br> This will restore the link between the element and its original *QAction.dll* (compiled in Release mode). |
 | the yellow lightning bolt, | you will manually trigger the QAction by simulating a change of the parameter selected in the *Trigger ID* box (in case of a dynamic table parameter, use the *Trigger Key* box to specify the table row).<br>Only do this after you have attached the SLScripting process(es) to the Debugger. |
 
 ### Attaching the Microsoft Visual Studio Debugger to the DataMiner SLScripting process(es)
 
-After marking the necessary QAction projects for injection, you can attach the Debugger. When you click *Attach*, DIS performs the following steps in sequence, showing progress for each:
-
-1. Compiles all injected projects.
-1. Creates a DMapp package containing the resulting DLL and PDB files.
-1. Uploads the DMapp package to the DataMiner Agent.
-1. Sends inject requests to DataMiner.
-1. Attaches the Microsoft Visual Studio Debugger to the SLScripting process(es).
-
-> [!NOTE]
-> DIS deletes any existing DLL file before rebuilding a project. If the build fails, a message is shown and the process is stopped.
+After injecting the necessary *QAction.dll* files, you have to attach the Debugger to the SLScripting process(es).
 
 | If you click... | then... |
 |-----------------|---------|
-| Attach | all pending QAction projects are built, uploaded via a DMapp package, injected, and the Microsoft Visual Studio Debugger is attached to the DataMiner SLScripting process(es).<br>Note: The design of the Microsoft Visual Studio screen will change and you will notice the word "Running" in the title bar. |
+| Attach | all temporary QAction projects will be built, and the Microsoft Visual Studio Debugger will be attached to the DataMiner SLScripting process(es).<br>Note: The design of the Microsoft Visual Studio screen will change and you will notice the word "Running" in the title bar. |
 | Detach | the Microsoft Visual Studio Debugger will be detached from the DataMiner SLScripting process(es). |
 
 ## Debugging an automation script

--- a/release-notes/DIS/DIS_3.1.md
+++ b/release-notes/DIS/DIS_3.1.md
@@ -20,9 +20,9 @@ When publishing an install script from a package solution, the version of the re
 
 The DIS Inject functionality has been reworked to simplify remote debugging setup:
 
-- DLL and program database (PDB) files are now uploaded to the DataMiner Agent through a DMapp package, removing the need to configure a shared folder on the remote agent.
+- When performing remote debugging, DLL files are now uploaded to the DataMiner Agent through a DMapp package, removing the need to configure a shared folder on the remote agent.
 - As a result, the *Publish path* and *Path on DataMiner* settings have been removed from the *Settings > DMA > Debugging* window. Only the *Debugger qualifier* setting remains. The default value of this setting has been updated to reference port 4026, which is the default port for remote debugging with VS2026.
-- The inject workflow has changed: when you click the inject icon (green + icon), the project is no longer built immediately. Instead, a *Pending (on attach)* status is shown in a new status column. All injected projects are built when you click *Attach*. At that point, DIS compiles the projects, creates a DMapp package with all resulting DLL and PDB files, uploads the DMapp, and sends inject requests to DataMiner.
+- The inject workflow has changed: when you click the inject icon (green '+' icon), the project is no longer built immediately. Instead, a *Pending (on attach)* status is shown in a new status column. All injected projects are built when you click *Attach*. At that point, DIS compiles the projects, creates a DMapp package with all resulting DLL files, uploads the DMapp, and sends inject requests to DataMiner.
 - You can eject a pending inject without any interaction with the remote agent.
 - The *Attach* operation now shows progress for each step: compiling projects, uploading via DMapp, injecting, and attaching to the process.
 - The link to open the element in *Element Display* has been removed.

--- a/release-notes/DIS/DIS_3.1.md
+++ b/release-notes/DIS/DIS_3.1.md
@@ -8,37 +8,41 @@ uid: DIS_3.1
 
 ### New features
 
-#### Automatic update of MinimumRequiredDmWebVersion when importing Low-Code Apps [ID 46014]
+#### Automatic update of MinimumRequiredDmWebVersion when importing low-code apps [ID 46014]
 
-When you import a Low-Code App (LCA) into a package project, DIS now automatically adds or updates the `MinimumRequiredDmWebVersion` XML element in the `.csproj` file of the package project. The version is updated only if the currently specified version is lower than the version from which the LCA was imported.
+When you import a low-code app into a package project, DIS now automatically adds or updates the `MinimumRequiredDmWebVersion` XML element in the `.csproj` file of the package project. The version is updated only if the currently specified version is lower than the version from which the low-code app was imported.
 
-#### Package install script now uses the version configured in the project file [ID 46067]
-
-When publishing an install script from a package solution, the version of the resulting package was previously always set to 1.0.1, regardless of what was configured in the `.csproj` file. This could cause installation failures when the install script included a downgrade check. DIS now uses the version and name as configured in the `.csproj` file when publishing an install script.
-
-#### DIS Inject now uploads debug files via a DMapp package [ID 46098]
+#### DIS Inject now uploads debug files via a .dmapp package [ID 46098]
 
 The DIS Inject functionality has been reworked to simplify remote debugging setup:
 
-- When performing remote debugging, DLL files are now uploaded to the DataMiner Agent through a DMapp package, removing the need to configure a shared folder on the remote agent.
-- As a result, the *Publish path* and *Path on DataMiner* settings have been removed from the *Settings > DMA > Debugging* window. Only the *Debugger qualifier* setting remains. The default value of this setting has been updated to reference port 4026, which is the default port for remote debugging with VS2026.
-- The inject workflow has changed: when you click the inject icon (green '+' icon), the project is no longer built immediately. Instead, a *Pending (on attach)* status is shown in a new status column. All injected projects are built when you click *Attach*. At that point, DIS compiles the projects, creates a DMapp package with all resulting DLL files, uploads the DMapp, and sends inject requests to DataMiner.
-- You can eject a pending inject without any interaction with the remote agent.
-- The *Attach* operation now shows progress for each step: compiling projects, uploading via DMapp, injecting, and attaching to the process.
-- The link to open the element in *Element Display* has been removed.
-- Before rebuilding a project, DIS now deletes any existing DLL file first, and after the build, verifies that the build succeeded. If the build fails, a message is shown.
+- For remote debugging, DLL files are now uploaded to the DataMiner Agent through a .dmapp package, removing the need to configure a shared folder on the remote Agent.
+
+  As a result, the *Publish path* and *Path on DataMiner* settings have been removed from the *Settings > DMA > Debugging* window. Only the *Debugger qualifier* setting remains. The default value of this setting has been updated to reference port 4026, which is the default port for remote debugging with VS2026.
+
+- The inject workflow has changed: when you click the inject icon (green "+" icon), the project is no longer built immediately. Instead, a *Pending (on attach)* status is shown in a new status column. All injected projects are built when you click *Attach*. At that point, DIS compiles the projects, creates a .dmapp package with all resulting DLL files, uploads the package, and sends inject requests to DataMiner.
+
+- You can eject a pending inject without any interaction with the remote Agent.
+
+- The *Attach* operation now shows progress for each step: compiling projects, uploading via .dmapp package, injecting, and attaching to the process.
+
+- The link to open an element in *Element Display* has been removed.
+
+- Before rebuilding a project, DIS now deletes any existing DLL file first, and after the build, it verifies that the build succeeded. If the build fails, a message is shown.
 
 #### Option to force local account login when external authentication is configured [ID 46104]
 
-A new *Force Authenticate Local User* checkbox has been added to the *General* tab of the *New DMA Connection* window (*Settings > DMA > Add...*). This checkbox is available when login is configured to use a user name and password. When selected, DIS will use local user authentication even if external or federated authentication is configured on the agent.
+A new *Force Authenticate Local User* checkbox has been added to the *General* tab of the *New DMA Connection* window (*Settings* > *DMA* > *Add*). This checkbox is available when login is configured to use a username and password.
+
+When the checkbox is selected, DIS will use local user authentication even if external or federated authentication is configured on the DataMiner Agent.
 
 #### Improved error information when the license check fails [ID 46132]
 
-When a failure occurs while signing in via *DIS Settings > Account > Sign In*, the error message now includes a link to the license troubleshooting section on DataMiner Docs and a contact email address for further assistance.
+When a failure occurs while signing in via *DIS Settings* > *Account* > *Sign In*, the error message now includes a link to the license troubleshooting section on DataMiner Docs and a contact email address for further assistance.
 
 #### Minimum required DMA version verified on protocol publish [ID 46135]
 
-When you publish a protocol to a DataMiner Agent via the publish button, DIS now first checks whether the agent meets the minimum required version specified in the `MinimumRequiredVersion` tag in the protocol. If the agent does not meet the minimum required version, a message box is displayed.
+When you publish a protocol to a DataMiner Agent via the publish button, DIS now first checks whether the Agent meets the minimum required version specified in the `MinimumRequiredVersion` tag in the protocol. If the Agent does not meet the minimum required version, a message box is displayed.
 
 #### Updated NuGet package dependencies
 
@@ -51,6 +55,14 @@ When you publish a protocol to a DataMiner Agent via the publish button, DIS now
 - [Skyline.DataMiner.Dev.Common](https://www.nuget.org/packages/Skyline.DataMiner.Dev.Common) version 10.6.9.1
 - [Skyline.DataMiner.Dev.Automation](https://www.nuget.org/packages/Skyline.DataMiner.Dev.Automation) version 10.6.9.1
 - [Skyline.DataMiner.Dev.Protocol](https://www.nuget.org/packages/Skyline.DataMiner.Dev.Protocol) version 10.6.9.1
+
+### Fixes
+
+#### Package install script set incorrect package version [ID 46067]
+
+Previously, when an install script was published from a package solution, the version of the resulting package was always set to 1.0.1, regardless of what was configured in the `.csproj` file. This could cause installation failures when the install script included a downgrade check.
+
+Now, DIS will use the version and name as configured in the `.csproj` file when publishing an install script.
 
 ## DIS 3.1.24
 

--- a/release-notes/DIS/DIS_3.1.md
+++ b/release-notes/DIS/DIS_3.1.md
@@ -4,6 +4,54 @@ uid: DIS_3.1
 
 # DIS 3.1
 
+## DIS 3.1.25
+
+### New features
+
+#### Automatic update of MinimumRequiredDmWebVersion when importing Low-Code Apps [ID 46014]
+
+When you import a Low-Code App (LCA) into a package project, DIS now automatically adds or updates the `MinimumRequiredDmWebVersion` XML element in the `.csproj` file of the package project. The version is updated only if the currently specified version is lower than the version from which the LCA was imported.
+
+#### Package install script now uses the version configured in the project file [ID 46067]
+
+When publishing an install script from a package solution, the version of the resulting package was previously always set to 1.0.1, regardless of what was configured in the `.csproj` file. This could cause installation failures when the install script included a downgrade check. DIS now uses the version and name as configured in the `.csproj` file when publishing an install script.
+
+#### DIS Inject now uploads debug files via a DMapp package [ID 46098]
+
+The DIS Inject functionality has been reworked to simplify remote debugging setup:
+
+- DLL and program database (PDB) files are now uploaded to the DataMiner Agent through a DMapp package, removing the need to configure a shared folder on the remote agent.
+- As a result, the *Publish path* and *Path on DataMiner* settings have been removed from the *Settings > DMA > Debugging* window. Only the *Debugger qualifier* setting remains. The default value of this setting has been updated to reference port 4026, which is the default port for remote debugging with VS2026.
+- The inject workflow has changed: when you click the inject icon (green + icon), the project is no longer built immediately. Instead, a *Pending (on attach)* status is shown in a new status column. All injected projects are built when you click *Attach*. At that point, DIS compiles the projects, creates a DMapp package with all resulting DLL and PDB files, uploads the DMapp, and sends inject requests to DataMiner.
+- You can eject a pending inject without any interaction with the remote agent.
+- The *Attach* operation now shows progress for each step: compiling projects, uploading via DMapp, injecting, and attaching to the process.
+- The link to open the element in *Element Display* has been removed.
+- Before rebuilding a project, DIS now deletes any existing DLL file first, and after the build, verifies that the build succeeded. If the build fails, a message is shown.
+
+#### Option to force local account login when external authentication is configured [ID 46104]
+
+A new *Force Authenticate Local User* checkbox has been added to the *General* tab of the *New DMA Connection* window (*Settings > DMA > Add...*). This checkbox is available when login is configured to use a user name and password. When selected, DIS will use local user authentication even if external or federated authentication is configured on the agent.
+
+#### Improved error information when the license check fails [ID 46132]
+
+When a failure occurs while signing in via *DIS Settings > Account > Sign In*, the error message now includes a link to the license troubleshooting section on DataMiner Docs and a contact email address for further assistance.
+
+#### Minimum required DMA version verified on protocol publish [ID 46135]
+
+When you publish a protocol to a DataMiner Agent via the publish button, DIS now first checks whether the agent meets the minimum required version specified in the `MinimumRequiredVersion` tag in the protocol. If the agent does not meet the minimum required version, a message box is displayed.
+
+#### Updated NuGet package dependencies
+
+- [Skyline.DataMiner.Core.ArtifactDownloader](https://www.nuget.org/packages/Skyline.DataMiner.Core.ArtifactDownloader) version 4.1.0
+- [Skyline.DataMiner.CICD.DMApp.Automation](https://www.nuget.org/packages/Skyline.DataMiner.CICD.DMApp.Automation) version 6.2.0
+- [Skyline.DataMiner.CICD.DMProtocol](https://www.nuget.org/packages/Skyline.DataMiner.CICD.DMProtocol) version 6.2.0
+- [Skyline.DataMiner.CICD.Parsers.Common](https://www.nuget.org/packages/Skyline.DataMiner.CICD.Parsers.Common) version 6.2.0
+- [Skyline.DataMiner.CICD.Validators.Common](https://www.nuget.org/packages/Skyline.DataMiner.CICD.Validators.Common) version 3.5.0
+- [Skyline.DataMiner.CICD.Validators.Protocol](https://www.nuget.org/packages/Skyline.DataMiner.CICD.Validators.Protocol) version 3.5.0
+- [Skyline.DataMiner.Dev.Common](https://www.nuget.org/packages/Skyline.DataMiner.Dev.Common) version 10.6.9.1
+- [Skyline.DataMiner.Dev.Automation](https://www.nuget.org/packages/Skyline.DataMiner.Dev.Automation) version 10.6.9.1
+- [Skyline.DataMiner.Dev.Protocol](https://www.nuget.org/packages/Skyline.DataMiner.Dev.Protocol) version 10.6.9.1
+
 ## DIS 3.1.24
 
 ### New features


### PR DESCRIPTION
## Summary

This PR adds the DIS 3.1.25 release notes to the DataMiner documentation and updates relevant TOOLS/DIS documentation pages to reflect the changes introduced in this release.

## DIS release note version inserted

**DIS 3.1.25**

## Updated files

| File | Change |
|------|--------|
| `release-notes/DIS/DIS_3.1.md` | Inserted DIS 3.1.25 release notes section at the top of the 3.1 release notes page |
| `develop/TOOLS/DIS/Reference/DIS_settings.md` | Added *Force Authenticate Local User* field to the DMA connection table; removed *Publish path* and *Path on DataMiner* debugging settings (replaced by DMapp-based upload) |
| `develop/TOOLS/DIS/Debugging/Preparing_to_debug_on_a_remote_DataMiner_Agent.md` | Removed shared folder setup steps (no longer required); updated Debugger qualifier default port to 4026 |
| `develop/TOOLS/DIS/ToolWindows/DisInjectToolWindow.md` | Updated inject workflow description to reflect the new DMapp-based upload, pending status column, new Attach behavior with progress steps, removed Element Display reference, removed shared folder log note |

## New TOOLS/DIS pages added

None. All changes were made to existing pages.

## Release notes included

- **[ID 46014]** Automatic update of MinimumRequiredDmWebVersion when importing Low-Code Apps
- **[ID 46067]** Package install script now uses the version configured in the project file
- **[ID 46098]** DIS Inject now uploads debug files via a DMapp package
- **[ID 46104]** Option to force local account login when external authentication is configured
- **[ID 46132]** Improved error information when the license check fails
- **[ID 46135]** Minimum required DMA version verified on protocol publish
- Updated NuGet package dependencies




> Generated by [📝 DIS Release Notes Markdown Generator](https://github.com/SkylineCommunications/DIS/actions/runs/33474650248) · sonnet46 57.5 AIC · ⌖ 8.35 AIC · ⊞ 5.9K · [◷](https://github.com/search?q=repo%3ASkylineCommunications%2Fdataminer-docs+%22gh-aw-workflow-id%3A+dis-release-notes-markdown%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: DIS Release Notes Markdown Generator, engine: copilot, version: 1.0.73, model: claude-sonnet-4.6, id: 33474650248, workflow_id: dis-release-notes-markdown, run: https://github.com/SkylineCommunications/DIS/actions/runs/33474650248 -->

<!-- gh-aw-workflow-id: dis-release-notes-markdown -->
<!-- gh-aw-workflow-call-id: SkylineCommunications/DIS/dis-release-notes-markdown -->