### PR TITLE
Expand and centralize docs house style rules

### DIFF
--- a/.github/agents/dataminer-docs-house-style-reviewer.agent.md
+++ b/.github/agents/dataminer-docs-house-style-reviewer.agent.md
@@ -9,21 +9,9 @@ You are a documentation quality reviewer for the DataMiner Docs repository.
 Your job is to review a documentation page or section and report whether it follows the house style.
 
 ## Scope and standards
-- Review against US English usage.
+- Enforce all rules defined in `/.github/instructions/dataminer-docs-house-style.instructions.md`. Read that file before reviewing, and treat it as the single source of truth for house style rules.
 - Review Markdown and structure against `/contributing/CTB_Markdown_Syntax.md`.
-- Enforce these house rules:
-  - Use `e.g.,` instead of `e.g.`
-  - Use `i.e.,` instead of `i.e.`
-  - Use sentence case in headers
-  - Use descriptive alt text for images
-  - Require a `description` value in page metadata/front matter, and ensure it is between 100 and 155 characters
-  - Keep tone formal, simple, and focused on quickly informing technical users
-  - Ensure a logical structure with meaningful headers
-  - Format procedures as numbered lists with one logical step per item
-  - Keep instructions concise, and place the result of each step on an indented line below that step
-  - Ensure images inside procedures are indented correctly so numbering does not restart
-  - Format direct UI references in italics, with optional bold for emphasis in specific cases (e.g., introductory elements followed by a colon)
-  - Use plain text in headers, avoiding italics, bold, or other formatting
+- Review against US English usage.
 
 ## Approach
 1. Ask the user whether they want you to apply the changes directly or list the issues in chat.
@@ -35,7 +23,7 @@ Your job is to review a documentation page or section and report whether it foll
    - Otherwise, list each issue with line number and correction suggestion.
 
 ## Constraints
-- Do not invent repository conventions beyond the listed standards and referenced CTB syntax guidance.
+- Do not invent repository conventions beyond the house style instructions and referenced CTB syntax guidance.
 - Do not rewrite the whole page unless the user explicitly asks for a full rewrite.
 - Keep feedback concise, actionable, and specific.
 - If no line number can be determined, explicitly state that the location is approximate and reference the nearest heading.

--- a/.github/instructions/dataminer-docs-house-style.instructions.md
+++ b/.github/instructions/dataminer-docs-house-style.instructions.md
@@ -9,19 +9,13 @@ When creating or editing documentation pages, apply the following rules.
 
 - Use US English.
 - Follow Markdown conventions from `/contributing/CTB_Markdown_Syntax.md`.
-- Use `e.g.,` instead of `e.g.`.
-- Use `i.e.,` instead of `i.e.`.
 - Use sentence case in headers.
-- Use descriptive alt text for images.
-- Ensure each page has a `description` value in its metadata/front matter, and ensure it is between 100 and 155 characters.
 - Use a formal but simple technical style that helps users find information quickly.
 - Address the reader directly with `you` and avoid third-person references to the user.
-- Keep a logical structure with meaningful headers.
 - For cross-references to pages within this repository, use DocFX `xref` links instead of hard links to local Markdown files.
-- Use backticks for references to code, file paths, and user input, but not for emphasis.
-- Use plain text in headers, avoiding italics, bold, or other formatting
-- Do not place two note blocks immediately after one another. When that would occur, combine the content into a single note block that uses a bulleted list.
-- Only use the following alert types: `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!CAUTION]`, and `> [!WARNING]`. No other alert type (e.g., `[!ALERT]`) is supported. Before adding or editing an alert, verify the type against `/contributing/CTB_Markdown_Syntax.md`.
+- Only use backticks for references to code, file paths, or user input, not for emphasis.
+- Format direct UI references in italics, using bold only for intentional emphasis, such as an introductory UI label followed by a colon.
+- Use plain text in headers, avoiding italics, bold, or other formatting.
 
 ## Procedure formatting
 
@@ -31,7 +25,30 @@ When creating or editing documentation pages, apply the following rules.
 - Put the result of a step on an indented line below that step.
 - If a step contains an image, indent it correctly so list numbering does not restart.
 
-## UI references
+## Alert blocks
 
-- Format direct UI references in italics.
-- Use bold only when intentional emphasis is needed, for example an introductory UI label followed by a colon.
+- Only use the following alert types: `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!CAUTION]`, and `> [!WARNING]`. No other alert type (e.g., `> [!ALERT]`) is supported. Before adding or editing an alert, verify the type against `/contributing/CTB_Markdown_Syntax.md`.
+- Never place two or more alert blocks of the same type directly after one another. Combine their content into a single alert block using a bulleted list instead.
+- Avoid long alert blocks. If an alert block would be long, move its content to a regular text section instead.
+- Avoid using several alert blocks in a row. If a more readable alternative exists, weave the content of some or all of the alerts into the regular text instead.
+- Use `> [!CAUTION]` only for information about the possible negative consequences of an action.
+- Use `> [!WARNING]` only for information about actions that could have far-reaching, dangerous consequences, such as breaking the DataMiner software.
+- Use `> [!IMPORTANT]` for information a user must notice that has no direct negative or dangerous consequence.
+
+## AI-friendly writing
+
+- Use descriptive alt text for images.
+- Ensure each page has a `description` value in its metadata/front matter, and ensure it is between 100 and 155 characters.
+- Always make sure the text is structured logically, with meaningful headers that clearly indicate what each subsection is about.
+- Make content as future-proof as possible, for instance by adding DataMiner version info where relevant, or by rephrasing text about new features to make sure it doesn't become outdated almost immediately.
+- Give preference to a bulleted list or regular text over a table when either would be equally clear, since tables can be harder to interpret correctly.
+- Only use a table when it is clearly the most user-friendly option for the content.
+
+## Punctuation
+
+- Use single quotation marks in headers.
+- Use single quotation marks to indicate quoted material within a quotation (i.e., a nested quote); otherwise, use double quotation marks.
+- Use `e.g.,` instead of `e.g.`.
+- Use `i.e.,` instead of `i.e.`.
+- Avoid em dashes.
+- When referring to a menu option in the UI that contains an ellipsis (`...`) at the end, leave out the ellipsis.


### PR DESCRIPTION
House style enforcement is now centralized in `dataminer-docs-house-style.instructions.md`, and the reviewer agent was updated to treat that file as the single source of truth. The instruction set was reorganized and expanded with clearer guidance for alerts, UI references, AI-friendly writing, and punctuation, while tightening wording to reduce ambiguity.