### PR TITLE
Align docs guidance and style rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,10 +43,9 @@ For most key directories (with the exception of `src`), all images are placed in
 3. Do not use spaces in file and folder names.
 4. Use DocFX-flavored Markdown syntax as defined in `/contributing/CTB_Markdown_Syntax.md`.
 5. Follow the instructions defined in `/contributing/CTB_Tips.md`.
-6. Use US English.
-7. Avoid em dashes when possible.
-8. One `.md` file must never contain more than 64000 characters.
-9. If changes are implemented that remove all references to a specific image, that image must be removed, with the exception of any images included in the `connectors` directory.
-10. Avoid adding pages that only contain links to underlying pages but no actual content of their own.
-11. When referring to changes introduced by a specific release note, make sure the Main Release version and Feature Release version introducing the changes are mentioned on the page.
-12. Use sentence casing for titles.
+6. One `.md` file must never contain more than 64000 characters.
+7. If changes are implemented that remove all references to a specific image, that image must be removed, with the exception of any images included in the `connectors` directory.
+8. Avoid adding pages that only contain links to underlying pages but no actual content of their own.
+9. Ensure that all cross-references are accurate and up to date.
+10. Use sentence casing for titles.
+11. Follow the house style defined in `.github/instructions/dataminer-docs-house-style.instructions.md`.

--- a/.github/instructions/dataminer-docs-house-style.instructions.md
+++ b/.github/instructions/dataminer-docs-house-style.instructions.md
@@ -7,6 +7,8 @@ applyTo: "**/*.md"
 
 When creating or editing documentation pages, apply the following rules.
 
+## General
+
 - Use US English.
 - Follow Markdown conventions from `/contributing/CTB_Markdown_Syntax.md`.
 - Use sentence case in headers.
@@ -16,6 +18,7 @@ When creating or editing documentation pages, apply the following rules.
 - Only use backticks for references to code, file paths, or user input, not for emphasis.
 - Format direct UI references in italics, using bold only for intentional emphasis, such as an introductory UI label followed by a colon.
 - Use plain text in headers, avoiding italics, bold, or other formatting.
+- When referring to changes introduced by a specific release note, make sure both the Main Release version and Feature Release version introducing the changes are mentioned on the page.
 
 ## Procedure formatting
 


### PR DESCRIPTION
This commit removes duplicated guidance from the repo-wide Copilot instructions and centralizes the house-style requirements in the dedicated markdown instructions file.