### PR TITLE
"Read all" option (Alarm Console)

### DIFF
--- a/dataminer/Operator_guide/Alarms/Working_with_alarms/Changing_the_read_status_of_an_alarm.md
+++ b/dataminer/Operator_guide/Alarms/Working_with_alarms/Changing_the_read_status_of_an_alarm.md
@@ -1,14 +1,19 @@
 ---
 uid: Changing_the_read_status_of_an_alarm
+description: "Learn how to mark alarm records as read or unread in the Alarm Console and understand how the read status is stored for each user."
 ---
 
 # Changing the read status of an alarm
 
 In DataMiner Cube, a new "unread" alarm record shows up in the Alarm Console in bold typeface. As soon as you select it for more than two seconds, it is considered "read" and subsequently loses its bold typeface.
 
+To quickly mark all alarms in an alarm tab as "read", select an alarm and press Ctrl + A.
+
 The number of "unread" alarm records shown in a particular alarm tab is indicated in the label of that alarm tab, e.g., "Active alarms (55 new)".
 
 To set a read alarm record back to "unread", right-click the alarm record and click *Set alarm as unread*.
+
+To set all alarm records in an alarm tab back to "unread", select an alarm, press Ctrl + A, right-click one of the selected alarms, and click *Set alarm as unread*.
 
 > [!NOTE]
 > The read/unread status of an alarm record is a user setting, which means that it is linked to your user account. As a result, read/unread statuses shown on your screen will differ from those shown on another user’s screen.


### PR DESCRIPTION
Added information on using Ctrl + A to mark all alarms in an alarm tab as read or unread, based on a [question on Dojo](https://community.dataminer.services/question/shortcut-for-read-all-in-alarmtable/).